### PR TITLE
docs: update ecosystem versions (gg v0.9.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ surface.GetFramebuffer() // Returns []byte (RGBA8)
 | Project | Description | Status |
 |---------|-------------|--------|
 | [gogpu/gogpu](https://github.com/gogpu/gogpu) | Graphics framework | v0.3.0 |
-| [gogpu/naga](https://github.com/gogpu/naga) | Pure Go shader compiler (WGSL → SPIR-V) | **v0.4.0** |
-| [gogpu/gg](https://github.com/gogpu/gg) | 2D graphics with GPU backend, scene graph, SIMD | **v0.9.0** |
-| [go-webgpu/webgpu](https://github.com/go-webgpu/webgpu) | FFI bindings (current solution) | Stable |
+| [gogpu/naga](https://github.com/gogpu/naga) | Shader compiler (WGSL → SPIR-V) | v0.4.0 |
+| [gogpu/gg](https://github.com/gogpu/gg) | 2D graphics library | **v0.9.1** |
+| [go-webgpu/webgpu](https://github.com/go-webgpu/webgpu) | FFI bindings | Stable |
 
 ## Contributing
 


### PR DESCRIPTION
Update gg version to v0.9.1 in ecosystem table