### PR TITLE
fix(metal): correct goffi API usage for ARM64 compatibility

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.25
 
 require golang.org/x/sys v0.39.0
 
-require github.com/go-webgpu/goffi v0.3.1
+require github.com/go-webgpu/goffi v0.3.3

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/go-webgpu/goffi v0.3.1 h1:q1a7eG5gvMNbTOY8/YNGcBxyn5iVvtl9N8ifqJXiZRk=
-github.com/go-webgpu/goffi v0.3.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.3.3 h1:sK4nmMYZG6zLTMtSXD8rXlz0PnqZU4y4u0bqmZVEADk=
+github.com/go-webgpu/goffi v0.3.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/hal/metal/objc.go
+++ b/hal/metal/objc.go
@@ -74,8 +74,10 @@ func prepareObjCCallInterfaces() error {
 // GetClass returns the Class for a given name.
 func GetClass(name string) Class {
 	cname := append([]byte(name), 0)
+	// goffi API requires pointer TO pointer value (avalue is slice of pointers to argument values)
+	ptr := uintptr(unsafe.Pointer(&cname[0]))
 	var result Class
-	args := [1]unsafe.Pointer{unsafe.Pointer(&cname[0])}
+	args := [1]unsafe.Pointer{unsafe.Pointer(&ptr)}
 	_ = ffi.CallFunction(&cifGetClass, symObjcGetClass, unsafe.Pointer(&result), args[:])
 	return result
 }
@@ -87,8 +89,10 @@ func RegisterSelector(name string) SEL {
 	}
 
 	cname := append([]byte(name), 0)
+	// goffi API requires pointer TO pointer value (avalue is slice of pointers to argument values)
+	ptr := uintptr(unsafe.Pointer(&cname[0]))
 	var result SEL
-	args := [1]unsafe.Pointer{unsafe.Pointer(&cname[0])}
+	args := [1]unsafe.Pointer{unsafe.Pointer(&ptr)}
 	_ = ffi.CallFunction(&cifSelRegister, symSelRegisterName, unsafe.Pointer(&result), args[:])
 
 	selectorCache.Store(name, result)


### PR DESCRIPTION
## Summary

Fix SIGBUS crash on macOS ARM64 (M1/M4) when calling Objective-C runtime functions.

## Root Cause

`GetClass` and `RegisterSelector` passed string pointer directly instead of pointer-to-pointer as required by goffi API.

The previous code worked with goffi v0.3.1 due to a **compensating bug** in goffi's PointerType handling. After goffi v0.3.3 fixed that bug, the incorrect API usage caused SIGBUS.

**Fault address analysis:**
```
0x636f6c6c61 = ASCII bytes 'alloc\0' interpreted as memory address
```

The string contents were being read as a pointer value!

## Fix

```go
// Before (incorrect):
args := [1]unsafe.Pointer{unsafe.Pointer(&cname[0])}

// After (correct per goffi API):
ptr := uintptr(unsafe.Pointer(&cname[0]))
args := [1]unsafe.Pointer{unsafe.Pointer(&ptr)}
```

## Changes

- `hal/metal/objc.go`: Fix GetClass and RegisterSelector
- `go.mod`: Update goffi v0.3.1 → v0.3.3

## Testing

- Cross-compiled for darwin/arm64: builds successfully
- All existing tests pass
- **Needs verification on real macOS ARM64 hardware**

## Related

- Fixes gogpu/gogpu#10
- Related: go-webgpu/goffi#4