### PR TITLE
feat(metal): implement WGSL→MSL compilation and CreateRenderPipeline

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/gogpu/wgpu
 
 go 1.25
 
-require golang.org/x/sys v0.39.0
-
-require github.com/go-webgpu/goffi v0.3.3
+require (
+	github.com/go-webgpu/goffi v0.3.3
+	github.com/gogpu/naga v0.5.0
+	golang.org/x/sys v0.39.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/go-webgpu/goffi v0.3.3 h1:sK4nmMYZG6zLTMtSXD8rXlz0PnqZU4y4u0bqmZVEADk=
 github.com/go-webgpu/goffi v0.3.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/gogpu/naga v0.5.0 h1:4ohXAubMXWERnp4f1Ta7Xv4ImvicKrjZUabEQzdzF0U=
+github.com/gogpu/naga v0.5.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/hal/metal/metal.go
+++ b/hal/metal/metal.go
@@ -104,12 +104,15 @@ func preRegisterSelectors() {
 		"alloc", "init", "new", "retain", "release", "autorelease",
 		"name", "setLabel:", "label",
 		"contents", "length", "count",
+		"localizedDescription", // NSError
 		// MTLDevice
 		"newBufferWithLength:options:",
 		"newTextureWithDescriptor:",
 		"newSamplerStateWithDescriptor:",
 		"newCommandQueue",
 		"newRenderPipelineStateWithDescriptor:error:",
+		"newLibraryWithSource:options:error:",
+		"newFunctionWithName:",
 		"supportsFamily:",
 		// MTLCommandQueue
 		"commandBuffer",
@@ -146,6 +149,12 @@ func preRegisterSelectors() {
 		"setWidth:", "setHeight:", "setDepth:",
 		"setPixelFormat:", "setTextureType:", "setUsage:",
 		"setStorageMode:", "setMipmapLevelCount:", "setSampleCount:",
+		// MTLRenderPipelineDescriptor
+		"setVertexFunction:", "setFragmentFunction:",
+		"colorAttachments", "objectAtIndexedSubscript:",
+		"setWriteMask:", "setBlendingEnabled:",
+		"setSourceRGBBlendFactor:", "setDestinationRGBBlendFactor:", "setRgbBlendOperation:",
+		"setSourceAlphaBlendFactor:", "setDestinationAlphaBlendFactor:", "setAlphaBlendOperation:",
 	}
 	for _, sel := range commonSelectors {
 		RegisterSelector(sel)


### PR DESCRIPTION
## Summary
- Add naga v0.5.0 dependency for WGSL shader compilation
- Implement WGSL → IR → MSL compilation in CreateShaderModule()
- Implement full CreateRenderPipeline() with vertex/fragment functions and color attachments
- Pre-register Metal selectors for library and pipeline creation

## Changes
- `go.mod` - Added `github.com/gogpu/naga v0.5.0`
- `hal/metal/device.go` - CreateShaderModule with naga MSL backend (~50 LOC)
- `hal/metal/device.go` - CreateRenderPipeline implementation (~120 LOC)
- `hal/metal/metal.go` - Added pipeline-related selectors

## Test plan
- [x] Build passes for darwin/arm64, linux/amd64, windows/amd64
- [x] All tests pass
- [ ] Verify triangle example renders correctly on macOS ARM64

Related to gogpu/gogpu#10