### PR TITLE
fix(dx12): correct COM calling convention for struct-returning methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **DX12 COM Calling Convention Bug** — Fixes device operations on Intel GPUs
+  - Root cause: D3D12 methods returning structs require `this` pointer first, output pointer second
+  - Affected methods: `GetCPUDescriptorHandleForHeapStart`, `GetGPUDescriptorHandleForHeapStart`,
+    `GetDesc` (multiple types), `GetResourceAllocationInfo`
+  - Reference: [D3D12 Struct Return Convention](https://joshstaiger.org/notes/C-Language-Problems-in-Direct3D-12-GetCPUDescriptorHandleForHeapStart.html)
+
 - **Vulkan goffi Argument Passing Bug** — Fixes Windows crash (Exception 0xc0000005)
   - Root cause: vk-gen generated incorrect FFI calls after syscall→goffi migration
   - Before: `unsafe.Pointer(ptr)` passed pointer value directly
@@ -15,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Affected all Vulkan functions with pointer parameters
 
 ### Added
+- **DX12 Integration Test** (`cmd/dx12-test`) — Validates DX12 backend on Windows
+  - Tests: backend creation, instance, adapter enumeration, device, pipeline layout
+
 - **Compute Shader Support (Phase 2)** — Core API implementation
   - `ComputePipelineDescriptor` and `ProgrammableStage` types
   - `DeviceCreateComputePipeline()` and `DeviceDestroyComputePipeline()` functions

--- a/cmd/dx12-test/main.go
+++ b/cmd/dx12-test/main.go
@@ -1,0 +1,84 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+// Command dx12-test is an integration test for the DX12 backend.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gogpu/wgpu/hal"
+	"github.com/gogpu/wgpu/hal/dx12"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Printf("FAILED: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("SUCCESS: DX12 backend works!")
+}
+
+func run() error {
+	fmt.Println("=== DX12 Backend Integration Test ===")
+	fmt.Println()
+
+	// Step 1: Create backend
+	fmt.Print("1. Creating DX12 backend... ")
+	backend := dx12.Backend{}
+	fmt.Println("OK")
+
+	// Step 2: Create instance
+	fmt.Print("2. Creating DX12 instance... ")
+	instance, err := backend.CreateInstance(&hal.InstanceDescriptor{})
+	if err != nil {
+		return fmt.Errorf("create instance: %w", err)
+	}
+	defer instance.Destroy()
+	fmt.Println("OK")
+
+	// Step 3: Enumerate adapters
+	fmt.Print("3. Enumerating adapters... ")
+	adapters := instance.EnumerateAdapters(nil)
+	if len(adapters) == 0 {
+		return fmt.Errorf("no adapters found")
+	}
+	fmt.Printf("OK (found %d)\n", len(adapters))
+
+	// Print adapter info
+	for i := range adapters {
+		exposed := &adapters[i]
+		fmt.Printf("   - Adapter %d: %s (%s)\n",
+			i, exposed.Info.Name, exposed.Info.DriverInfo)
+	}
+
+	// Step 4: Open device
+	fmt.Print("4. Opening device... ")
+	openDev, err := adapters[0].Adapter.Open(0, adapters[0].Capabilities.Limits)
+	if err != nil {
+		return fmt.Errorf("open device: %w", err)
+	}
+	device := openDev.Device
+	defer device.Destroy()
+	fmt.Println("OK")
+
+	// Step 5: Create empty pipeline layout directly after device
+	fmt.Print("5. Creating empty pipeline layout... ")
+	pipelineLayout, err := device.CreatePipelineLayout(&hal.PipelineLayoutDescriptor{
+		Label:            "Empty Pipeline Layout",
+		BindGroupLayouts: nil,
+	})
+	if err != nil {
+		return fmt.Errorf("create pipeline layout: %w", err)
+	}
+	device.DestroyPipelineLayout(pipelineLayout)
+	fmt.Println("OK")
+
+	fmt.Println()
+	fmt.Println("=== DX12 Backend Test PASSED ===")
+
+	return nil
+}

--- a/hal/dx12/d3d12/device.go
+++ b/hal/dx12/d3d12/device.go
@@ -473,16 +473,16 @@ func (d *ID3D12Device) CreateCommandSignature(
 }
 
 // GetResourceAllocationInfo returns resource allocation info.
+// Note: Same calling convention issue as GetCPUDescriptorHandleForHeapStart.
+// See: https://joshstaiger.org/notes/C-Language-Problems-in-Direct3D-12-GetCPUDescriptorHandleForHeapStart.html
 func (d *ID3D12Device) GetResourceAllocationInfo(visibleMask uint32, numResourceDescs uint32, resourceDescs *D3D12_RESOURCE_DESC) D3D12_RESOURCE_ALLOCATION_INFO {
 	var info D3D12_RESOURCE_ALLOCATION_INFO
 
-	// Note: GetResourceAllocationInfo returns the struct by value, which on Windows x64
-	// means the caller must provide a pointer to receive the result as the first hidden parameter.
 	_, _, _ = syscall.Syscall6(
 		d.vtbl.GetResourceAllocationInfo,
 		5,
-		uintptr(unsafe.Pointer(&info)),
-		uintptr(unsafe.Pointer(d)),
+		uintptr(unsafe.Pointer(d)),     // this pointer first
+		uintptr(unsafe.Pointer(&info)), // output pointer second
 		uintptr(visibleMask),
 		uintptr(numResourceDescs),
 		uintptr(unsafe.Pointer(resourceDescs)),
@@ -569,14 +569,15 @@ func (q *ID3D12CommandQueue) GetTimestampFrequency() (uint64, error) {
 }
 
 // GetDesc returns the command queue description.
+// Note: Same calling convention issue as GetCPUDescriptorHandleForHeapStart.
 func (q *ID3D12CommandQueue) GetDesc() D3D12_COMMAND_QUEUE_DESC {
 	var desc D3D12_COMMAND_QUEUE_DESC
 
 	_, _, _ = syscall.Syscall(
 		q.vtbl.GetDesc,
 		2,
-		uintptr(unsafe.Pointer(&desc)),
-		uintptr(unsafe.Pointer(q)),
+		uintptr(unsafe.Pointer(q)),     // this pointer first
+		uintptr(unsafe.Pointer(&desc)), // output pointer second
 		0,
 	)
 
@@ -1100,14 +1101,15 @@ func (r *ID3D12Resource) GetGPUVirtualAddress() uint64 {
 }
 
 // GetDesc returns the resource description.
+// Note: Same calling convention issue as GetCPUDescriptorHandleForHeapStart.
 func (r *ID3D12Resource) GetDesc() D3D12_RESOURCE_DESC {
 	var desc D3D12_RESOURCE_DESC
 
 	_, _, _ = syscall.Syscall(
 		r.vtbl.GetDesc,
 		2,
-		uintptr(unsafe.Pointer(&desc)),
-		uintptr(unsafe.Pointer(r)),
+		uintptr(unsafe.Pointer(r)),     // this pointer first
+		uintptr(unsafe.Pointer(&desc)), // output pointer second
 		0,
 	)
 
@@ -1130,14 +1132,17 @@ func (h *ID3D12DescriptorHeap) Release() uint32 {
 }
 
 // GetCPUDescriptorHandleForHeapStart returns the CPU handle for the start of the heap.
+// Note: D3D12 C headers incorrectly declare this as returning the struct directly.
+// The actual calling convention requires passing an output pointer.
+// See: https://joshstaiger.org/notes/C-Language-Problems-in-Direct3D-12-GetCPUDescriptorHandleForHeapStart.html
 func (h *ID3D12DescriptorHeap) GetCPUDescriptorHandleForHeapStart() D3D12_CPU_DESCRIPTOR_HANDLE {
 	var handle D3D12_CPU_DESCRIPTOR_HANDLE
 
 	_, _, _ = syscall.Syscall(
 		h.vtbl.GetCPUDescriptorHandleForHeapStart,
 		2,
-		uintptr(unsafe.Pointer(&handle)),
-		uintptr(unsafe.Pointer(h)),
+		uintptr(unsafe.Pointer(h)),       // this pointer first
+		uintptr(unsafe.Pointer(&handle)), // output pointer second
 		0,
 	)
 
@@ -1145,14 +1150,16 @@ func (h *ID3D12DescriptorHeap) GetCPUDescriptorHandleForHeapStart() D3D12_CPU_DE
 }
 
 // GetGPUDescriptorHandleForHeapStart returns the GPU handle for the start of the heap.
+// Note: Same calling convention issue as GetCPUDescriptorHandleForHeapStart.
+// See: https://joshstaiger.org/notes/C-Language-Problems-in-Direct3D-12-GetCPUDescriptorHandleForHeapStart.html
 func (h *ID3D12DescriptorHeap) GetGPUDescriptorHandleForHeapStart() D3D12_GPU_DESCRIPTOR_HANDLE {
 	var handle D3D12_GPU_DESCRIPTOR_HANDLE
 
 	_, _, _ = syscall.Syscall(
 		h.vtbl.GetGPUDescriptorHandleForHeapStart,
 		2,
-		uintptr(unsafe.Pointer(&handle)),
-		uintptr(unsafe.Pointer(h)),
+		uintptr(unsafe.Pointer(h)),       // this pointer first
+		uintptr(unsafe.Pointer(&handle)), // output pointer second
 		0,
 	)
 
@@ -1160,14 +1167,15 @@ func (h *ID3D12DescriptorHeap) GetGPUDescriptorHandleForHeapStart() D3D12_GPU_DE
 }
 
 // GetDesc returns the descriptor heap description.
+// Note: Same calling convention issue as GetCPUDescriptorHandleForHeapStart.
 func (h *ID3D12DescriptorHeap) GetDesc() D3D12_DESCRIPTOR_HEAP_DESC {
 	var desc D3D12_DESCRIPTOR_HEAP_DESC
 
 	_, _, _ = syscall.Syscall(
 		h.vtbl.GetDesc,
 		2,
-		uintptr(unsafe.Pointer(&desc)),
-		uintptr(unsafe.Pointer(h)),
+		uintptr(unsafe.Pointer(h)),     // this pointer first
+		uintptr(unsafe.Pointer(&desc)), // output pointer second
 		0,
 	)
 


### PR DESCRIPTION
## Summary

Fixes D3D12 COM calling convention for methods that return structs. This enables the DX12 backend to work correctly on Intel GPUs.

## Problem

D3D12 methods like `GetCPUDescriptorHandleForHeapStart` that return structs require a specific calling convention:
- **Incorrect**: `(output_ptr, this)` 
- **Correct**: `(this, output_ptr)`

The Microsoft C headers incorrectly declare these as returning structs directly, but the actual COM implementation uses an output parameter with `this` first.

## Changes

- Fixed argument order in 6 COM method calls:
  - `GetCPUDescriptorHandleForHeapStart`
  - `GetGPUDescriptorHandleForHeapStart`
  - `ID3D12DescriptorHeap.GetDesc`
  - `ID3D12CommandQueue.GetDesc`
  - `ID3D12Resource.GetDesc`
  - `GetResourceAllocationInfo`
- Added `cmd/dx12-test` integration test
- Updated CHANGELOG.md

## Test Results

```
=== DX12 Backend Integration Test ===

1. Creating DX12 backend... OK
2. Creating DX12 instance... OK
3. Enumerating adapters... OK (found 1)
   - Adapter 0: Intel(R) Iris(R) Xe Graphics (Feature Level 12_1)
4. Opening device... OK
5. Creating empty pipeline layout... OK

=== DX12 Backend Test PASSED ===
```

## References

- https://joshstaiger.org/notes/C-Language-Problems-in-Direct3D-12-GetCPUDescriptorHandleForHeapStart.html
- Partially addresses #24 (DX12 as workaround for Intel Vulkan driver bug)

## Test plan

- [x] DX12 integration test passes on Intel Iris Xe
- [ ] Windows CI build passes