### PR TITLE
chore(deps): update naga v0.8.0 → v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.4] - 2025-12-29
+
+### Changed
+- Updated dependency: `github.com/gogpu/naga` v0.8.0 → v0.8.1
+  - Fixes missing `clamp()` built-in function in WGSL shader compilation
+  - Adds comprehensive math function tests
+
 ## [0.8.3] - 2025-12-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   <sub>Part of the <a href="https://github.com/gogpu">GoGPU</a> ecosystem</sub>
 </p>
 
-> **Status:** v0.9.0-dev — Compute shaders in development. All 5 HAL backends ready.
+> **Status:** Active development. All 5 HAL backends ready (Vulkan, Metal, DX12, GLES, Software).
 
 ---
 
@@ -117,45 +117,9 @@ wgpu/
 
 ## Roadmap
 
-**Phase 1: Types Package** ✓
-- [x] Backend types (Vulkan, Metal, DX12, GL)
-- [x] Adapter and device types
-- [x] Feature flags
-- [x] GPU limits with presets
-- [x] Texture formats (100+)
-- [x] Buffer, sampler, shader types
-- [x] Bind group and render state types
-- [x] Vertex formats with size calculations
+See [ROADMAP.md](ROADMAP.md) for detailed development milestones and version history.
 
-**Phase 2: Core Validation** ✓
-- [x] Type-safe ID system with generics
-- [x] Epoch-based use-after-free prevention
-- [x] Instance, Adapter, Device, Queue management
-- [x] Hub with 17 resource registries
-- [x] Comprehensive error handling
-- [x] 127 tests with 95% coverage
-
-**Phase 3: HAL Interface** ✓
-- [x] Backend abstraction layer (Backend, Instance, Adapter, Device, Queue)
-- [x] Resource interfaces (Buffer, Texture, Surface, Sampler, etc.)
-- [x] Command encoding (CommandEncoder, RenderPassEncoder, ComputePassEncoder)
-- [x] Backend registration system
-- [x] Noop backend for testing
-- [x] 54 tests with 94% coverage
-
-**Phase 4: Pure Go Backends** ✓
-- [x] OpenGL ES backend (`hal/gles/`) — Pure Go via goffi, Windows (WGL) + Linux (EGL), ~7.5K LOC
-- [x] Vulkan backend (`hal/vulkan/`) — Pure Go via goffi, cross-platform (Windows/Linux/macOS), ~27K LOC
-- [x] Software backend (`hal/software/`) — Full rasterization pipeline, ~10K LOC, 100+ tests
-- [x] Metal backend (`hal/metal/`) — Pure Go via goffi, macOS, ~3K LOC
-- [x] DX12 backend (`hal/dx12/`) — Pure Go via syscall, Windows, ~12K LOC
-
-**Phase 5: Compute Shaders** (In Progress)
-- [x] Core API: ComputePipelineDescriptor, ComputePassEncoder
-- [x] HAL infrastructure: glDispatchCompute, SetBindGroup, workgroup sizes
-- [ ] Backend tests: Vulkan, DX12, Metal, GLES
-- [ ] Examples: array sum, buffer copy, image filter
-- [ ] Documentation and tutorials
+**Current Focus:** Compute shader support across all backends.
 
 ## Pure Go Approach
 
@@ -230,22 +194,22 @@ surface.GetFramebuffer() // Returns []byte (RGBA8)
   - Resource structures
   - Memory allocator (buddy allocation)
 
-### Metal Backend Features (v0.6.0)
+### Metal Backend Features
 
 - **Pure Go Objective-C bridge** via goffi
 - **Metal API access** via Objective-C runtime
 - **Device and adapter enumeration**
 - **Command buffer and render encoder**
-- **Shader compilation** (MSL via naga v0.6.0)
+- **Shader compilation** (MSL via naga)
 - **Texture and buffer management**
 - **Surface presentation** (CAMetalLayer integration)
 - **~3K lines of code**
 
-### DirectX 12 Backend Features (v0.8.0+)
+### DirectX 12 Backend Features
 
 - **Pure Go COM bindings** via syscall (no CGO!)
 - **D3D12 API access** via COM interface vtables
-- **Intel GPU support** (v0.8.1 — fixed COM calling convention)
+- **Intel GPU support** (fixed COM calling convention)
 - **DXGI integration** for swapchain and adapter enumeration
 - **Descriptor heap management** (CBV/SRV/UAV, Sampler, RTV, DSV)
 - **Flip model swapchain** with tearing support (VRR)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 
 ---
 
-## Current Status: v0.8.0
+## Current Status: v0.8.4
 
 | Component | Status | LOC | Coverage |
 |-----------|--------|-----|----------|
@@ -74,7 +74,7 @@
 - [x] Affected backends: Metal, Vulkan, GLES, Software
 - [x] Unit tests for zero-dimension handling
 
-### v0.8.0 — DirectX 12 Backend (Current)
+### v0.8.0 — DirectX 12 Backend
 - [x] DX12 bindings via syscall (Pure Go COM, no CGO!)
 - [x] Device and adapter enumeration via DXGI
 - [x] Command list and allocator management
@@ -82,6 +82,21 @@
 - [x] Descriptor heaps (CBV/SRV/UAV, Sampler, RTV, DSV)
 - [x] Flip model swapchain with tearing support
 - [x] Full format conversion (WebGPU → DXGI)
+
+### v0.8.1 — DX12 & Vulkan Fixes
+- [x] DX12 COM calling convention fix for Intel GPUs
+- [x] Vulkan goffi argument passing fix (Windows crash)
+- [x] Compute shader support (Phase 2 — Core API)
+
+### v0.8.2 — Naga Update
+- [x] Updated naga v0.6.0 → v0.8.0 (HLSL backend, SPIR-V fixes)
+
+### v0.8.3 — Metal macOS Fixes
+- [x] Metal present timing: schedule `presentDrawable:` before `commit`
+- [x] TextureView NSRange parameter fix
+
+### v0.8.4 — Naga Clamp Fix (Current)
+- [x] Updated naga v0.8.0 → v0.8.1 (clamp() built-in function fix)
 
 ---
 
@@ -157,6 +172,10 @@ Priority areas:
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| v0.8.4 | 2025-12 | Naga v0.8.1 (clamp() fix) |
+| v0.8.3 | 2025-12 | Metal macOS blank window fix |
+| v0.8.2 | 2025-12 | Naga v0.8.0 (HLSL backend) |
+| v0.8.1 | 2025-12 | DX12/Vulkan fixes, compute API |
 | v0.8.0 | 2025-12 | DirectX 12 backend, all 5 HAL backends complete |
 | v0.7.0 | 2025-12 | Metal shader pipeline (WGSL→MSL) |
 | v0.6.0 | 2025-12 | Metal backend for macOS |

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.25
 
 require (
 	github.com/go-webgpu/goffi v0.3.5
-	github.com/gogpu/naga v0.8.0
+	github.com/gogpu/naga v0.8.1
 	golang.org/x/sys v0.39.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/go-webgpu/goffi v0.3.5 h1:9QFC86mGERstCGEwMmpHJvKxtHofCsoxWpl27HZoXFw=
 github.com/go-webgpu/goffi v0.3.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/gogpu/naga v0.8.0 h1:swdhwuKBfovTqDSXhuKRNCGK+ZQtJ4zlAI7VrTomoMM=
-github.com/gogpu/naga v0.8.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.8.1 h1:0lp9rHoWlVVJTZ/F5mH5HKRaL8GqA2bNSbN1tCQxcHA=
+github.com/gogpu/naga v0.8.1/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

- Updated `github.com/gogpu/naga` v0.8.0 → v0.8.1
  - Fixes missing `clamp()` built-in function in WGSL shader compilation
  - This was causing gg GPU compute shader tests to fail

## Documentation Updates

- Updated CHANGELOG.md and ROADMAP.md for v0.8.4
- Made README.md version-agnostic (removed hardcoded version numbers)
- Simplified Roadmap section in README (link to ROADMAP.md)

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Pre-release script passes
- [x] Ecosystem dependency validation passes

**Full Changelog**: https://github.com/gogpu/wgpu/compare/v0.8.3...chore/update-naga-0.8.1