### PR TITLE
fix(ci): skip Metal tests on CI + update naga v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.8] - 2026-01-04
+
+### Fixed
+
+#### CI
+- **Metal Tests on CI** — Skip Metal tests on GitHub Actions (Metal unavailable in virtualized macOS)
+  - See: https://github.com/actions/runner-images/discussions/6138
+
+### Changed
+- Updated dependency: `github.com/gogpu/naga` v0.8.2 → v0.8.3
+  - Fixes MSL `[[position]]` attribute placement (now on struct member, not function)
+
 ## [0.8.7] - 2026-01-04
 
 ### Fixed
@@ -312,7 +324,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Noop backend** (`hal/noop/`) - Reference implementation for testing
 - **OpenGL ES backend** (`hal/gles/`) - Pure Go via goffi (~3.5K LOC)
 
-[Unreleased]: https://github.com/gogpu/wgpu/compare/v0.8.6...HEAD
+[Unreleased]: https://github.com/gogpu/wgpu/compare/v0.8.8...HEAD
+[0.8.8]: https://github.com/gogpu/wgpu/compare/v0.8.7...v0.8.8
+[0.8.7]: https://github.com/gogpu/wgpu/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/gogpu/wgpu/compare/v0.8.5...v0.8.6
 [0.8.5]: https://github.com/gogpu/wgpu/compare/v0.8.4...v0.8.5
 [0.8.4]: https://github.com/gogpu/wgpu/compare/v0.8.3...v0.8.4

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.25
 
 require (
 	github.com/go-webgpu/goffi v0.3.7
-	github.com/gogpu/naga v0.8.2
+	github.com/gogpu/naga v0.8.3
 	golang.org/x/sys v0.39.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/go-webgpu/goffi v0.3.7 h1:JqzV4l7PUhJRSsmeyP2vJaIK5ZtSWITwG78iA1E4/AQ=
 github.com/go-webgpu/goffi v0.3.7/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/gogpu/naga v0.8.2 h1:1HH2a2LlfTCSZcDQAVX7N6XrGKejWZLlUwpuzLA0NuM=
-github.com/gogpu/naga v0.8.2/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.8.3 h1:HcJ1dlIzANnqGSeowDNrOv9W/96KVExxPH4iXUWxtno=
+github.com/gogpu/naga v0.8.3/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/hal/metal/main_test.go
+++ b/hal/metal/main_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build darwin
+
+package metal
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Skip on CI - Metal is not available on GitHub Actions macOS runners
+	// due to Apple Virtualization Framework limitations.
+	// See: https://github.com/actions/runner-images/discussions/6138
+	if os.Getenv("CI") == "true" || os.Getenv("GITHUB_ACTIONS") == "true" {
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
## Summary
- Skip Metal tests on GitHub Actions (Metal unavailable in virtualized macOS)
- Update naga v0.8.2 → v0.8.3 (fixes MSL `[[position]]` attribute placement)

## Changes
- `hal/metal/main_test.go` — TestMain with CI skip
- `go.mod` / `go.sum` — naga dependency update
- `CHANGELOG.md` — v0.8.8 release notes

## References
- Metal unavailable on CI: https://github.com/actions/runner-images/discussions/6138
- naga v0.8.3: https://github.com/gogpu/naga/releases/tag/v0.8.3