### PR TITLE
fix(metal): NSString double-free on autorelease pool drain

### DIFF
--- a/hal/metal/objc.go
+++ b/hal/metal/objc.go
@@ -404,14 +404,21 @@ func (p *AutoreleasePool) Drain() {
 }
 
 // NSString creates an NSString from a Go string.
+// Returns a +1 retained object that the caller must Release().
+// Uses alloc/initWithUTF8String: instead of stringWithUTF8String:
+// to return a retained object (not autoreleased) for explicit ownership.
 func NSString(s string) ID {
+	nsStringClass := ID(GetClass("NSString"))
 	if len(s) == 0 {
-		return MsgSend(ID(GetClass("NSString")), Sel("string"))
+		// Use alloc/init for empty string to get +1 retained object
+		obj := MsgSend(nsStringClass, Sel("alloc"))
+		return MsgSend(obj, Sel("init"))
 	}
 	cstr := append([]byte(s), 0)
+	obj := MsgSend(nsStringClass, Sel("alloc"))
 	return MsgSend(
-		ID(GetClass("NSString")),
-		Sel("stringWithUTF8String:"),
+		obj,
+		Sel("initWithUTF8String:"),
 		uintptr(unsafe.Pointer(&cstr[0])),
 	)
 }


### PR DESCRIPTION
## Problem

Intermittent panics in `CreateRenderPipeline` on macOS CI:

```
panic: ...
github.com/gogpu/wgpu/hal/metal.(*AutoreleasePool).Drain
    hal/metal/objc.go:401
github.com/gogpu/wgpu/hal/metal.(*Device).CreateRenderPipeline.deferwrap1
    hal/metal/device.go:468
```

## Root Cause

`NSString()` function used `stringWithUTF8String:` which returns an **autoreleased** object (+0 retain count, owned by autorelease pool).

Callers then called `Release()` on these objects:
1. `Release(label)` decrements retain count below 0 (invalid)
2. `pool.Drain()` tries to release already-freed object
3. **Crash** (double-free)

## Fix

Use `alloc/initWithUTF8String:` instead of `stringWithUTF8String:`:
- Returns **+1 retained** object owned by caller
- Caller's `Release()` correctly decrements to 0 and frees
- `pool.Drain()` has nothing extra to release

## Objective-C Memory Management Rules

| Method Pattern | Return | Ownership |
|----------------|--------|-----------|
| `alloc`, `new`, `copy`, `mutableCopy` | +1 retained | Caller owns, must release |
| `stringWith...`, convenience methods | +0 autoreleased | Pool owns, don't release |

## Test Plan

- [x] `go build ./hal/metal/...` — Pass
- [x] `golangci-lint run ./hal/metal/...` — 0 issues
- [ ] CI — Wait for all checks