### PR TITLE
fix: update goffi v0.3.8 for CGO build tag consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2] - 2026-01-24
+
+### Changed
+
+- **goffi v0.3.8** — Fixed CGO build tag consistency ([#43](https://github.com/gogpu/wgpu/issues/43))
+  - Clear error message when building with CGO enabled: `undefined: GOFFI_REQUIRES_CGO_ENABLED_0`
+  - Consistent `!cgo` build tags across all FFI files
+  - See [goffi v0.3.8 release notes](https://github.com/go-webgpu/goffi/releases/tag/v0.3.8)
+
 ## [0.10.1] - 2026-01-16
 
 Window responsiveness fix for Vulkan swapchain.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ go get github.com/gogpu/wgpu
 
 **Requirements:** Go 1.25+
 
+**Build:**
+```bash
+CGO_ENABLED=0 go build
+```
+
+> **Note:** wgpu uses Pure Go FFI via `cgo_import_dynamic`, which requires `CGO_ENABLED=0`. This enables zero C compiler dependency and easy cross-compilation.
+
 ---
 
 ## Quick Start

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 
 ---
 
-## Current Status: v0.10.0
+## Current Status: v0.10.2
 
 | Component | Status | LOC | Coverage |
 |-----------|--------|-----|----------|
@@ -149,13 +149,22 @@
 - [x] **VkRenderPass Fix** — Fixed rendering on Intel GPUs
   - Proper VkRenderPass creation with wgpu-style synchronization
 
-### v0.10.0 — HAL Backend Integration (Current)
+### v0.10.0 — HAL Backend Integration
 - [x] **Backend Interface** — New abstraction for HAL backend management
 - [x] **HAL Backend Integration** — Seamless backend auto-registration
 - [x] **Enhanced Instance** — HAL backend support in core.Instance
 - [x] **Device Extensions** — HAL device in core.Device
 - [x] **Buffer Extensions** — HAL buffer in core.Buffer
 - [x] **CommandEncoder Extensions** — HAL command encoding
+
+### v0.10.1 — Vulkan Swapchain Fix
+- [x] **Non-blocking swapchain acquire** — Window responsiveness fix
+- [x] **ErrNotReady Error** — New error for timeout signaling
+
+### v0.10.2 — FFI Build Tag Fix (Current)
+- [x] **goffi v0.3.8** — Fixed CGO build tag consistency
+- [x] **Clear error message** — `undefined: GOFFI_REQUIRES_CGO_ENABLED_0`
+- [x] **Documentation** — Added `CGO_ENABLED=0` requirement to README
 
 ---
 
@@ -231,6 +240,8 @@ Priority areas:
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| v0.10.2 | 2026-01 | goffi v0.3.8, CGO build tag fix |
+| v0.10.1 | 2026-01 | Vulkan swapchain responsiveness fix |
 | v0.10.0 | 2026-01 | HAL Backend Integration layer |
 | v0.9.3 | 2026-01 | Intel Vulkan fix: VkRenderPass, wgpu-style sync |
 | v0.9.2 | 2026-01 | Metal NSString double-free fix |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/wgpu
 go 1.25
 
 require (
-	github.com/go-webgpu/goffi v0.3.7
+	github.com/go-webgpu/goffi v0.3.8
 	github.com/gogpu/naga v0.8.4
 	golang.org/x/sys v0.39.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.3.7 h1:JqzV4l7PUhJRSsmeyP2vJaIK5ZtSWITwG78iA1E4/AQ=
-github.com/go-webgpu/goffi v0.3.7/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.3.8 h1:Kzw7oP1XEjkv+6QvOIWwuNMfW3iOTPq0hQjr14YwVBM=
+github.com/go-webgpu/goffi v0.3.8/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/naga v0.8.4 h1:Ge+bOVriIqozna1sStcEqvcP5sygZdxs8DjM8cLt2d8=
 github.com/gogpu/naga v0.8.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=


### PR DESCRIPTION
## Summary

- Updates goffi v0.3.7 → v0.3.8
- Fixes #43 — undefined dl.Dlopen/Dlsym errors on Linux with CGO enabled

## Changes

- **go.mod** — goffi v0.3.8
- **README.md** — Added `CGO_ENABLED=0` build requirement
- **CHANGELOG.md** — v0.10.2 entry
- **ROADMAP.md** — v0.10.2 milestone

## goffi v0.3.8 Improvements

- Consistent `!cgo` build tags across all FFI files
- Clear compile-time error: `undefined: GOFFI_REQUIRES_CGO_ENABLED_0`
- See [goffi v0.3.8 release](https://github.com/go-webgpu/goffi/releases/tag/v0.3.8)

## Test Plan

- [ ] CI passes
- [ ] `CGO_ENABLED=0 go build ./...` works
- [ ] `go build` (CGO enabled) shows clear error message