### PR TITLE
feat(vulkan): multi-thread architecture for window responsiveness

### DIFF
--- a/cmd/vulkan-triangle/main.go
+++ b/cmd/vulkan-triangle/main.go
@@ -5,23 +5,39 @@
 
 // Command vulkan-triangle is a full integration test for the Pure Go Vulkan backend.
 // It renders a red triangle to validate the entire rendering pipeline.
+//
+// This demo uses enterprise-level multi-thread architecture (Ebiten pattern):
+// - Main thread: Window events (Win32 message pump)
+// - Render thread: All GPU operations (Vulkan calls)
+//
+// This separation ensures window responsiveness during heavy GPU operations
+// like swapchain recreation, which requires vkDeviceWaitIdle.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/gogpu/wgpu/hal"
 	"github.com/gogpu/wgpu/hal/vulkan"
+	"github.com/gogpu/wgpu/internal/thread"
 	"github.com/gogpu/wgpu/types"
 )
 
 const (
 	windowWidth  = 800
 	windowHeight = 600
-	windowTitle  = "Vulkan Triangle - Pure Go"
+	windowTitle  = "Vulkan Triangle - Pure Go (Multi-Thread)"
 )
+
+func init() {
+	// Lock the main goroutine to the OS main thread.
+	// Required for Win32 window operations.
+	runtime.LockOSThread()
+}
 
 func main() {
 	if err := run(); err != nil {
@@ -30,12 +46,26 @@ func main() {
 	}
 }
 
-//nolint:gocognit,gocyclo,cyclop,funlen,maintidx // Integration test needs sequential setup steps
+// GPU resources (created and used on render thread only).
+type gpuResources struct {
+	instance       hal.Instance
+	surface        hal.Surface
+	device         hal.Device
+	queue          hal.Queue
+	pipeline       hal.RenderPipeline
+	pipelineLayout hal.PipelineLayout
+	vertexShader   hal.ShaderModule
+	fragmentShader hal.ShaderModule
+	surfaceConfig  *hal.SurfaceConfiguration
+	currentWidth   uint32
+	currentHeight  uint32
+}
+
 func run() error {
-	fmt.Println("=== Vulkan Triangle Integration Test ===")
+	fmt.Println("=== Vulkan Triangle Integration Test (Multi-Thread) ===")
 	fmt.Println()
 
-	// Step 1: Create window
+	// Step 1: Create window (main thread)
 	fmt.Print("1. Creating window... ")
 	window, err := NewWindow(windowTitle, windowWidth, windowHeight)
 	if err != nil {
@@ -44,132 +74,255 @@ func run() error {
 	defer window.Destroy()
 	fmt.Println("OK")
 
-	// Step 2: Create Vulkan backend
-	fmt.Print("2. Creating Vulkan backend... ")
+	// Step 2: Create render loop with dedicated render thread
+	fmt.Print("2. Creating render thread... ")
+	renderLoop := thread.NewRenderLoop()
+	defer renderLoop.Stop()
+	fmt.Println("OK")
+
+	// Step 3-10: Initialize GPU resources on render thread
+	var gpu *gpuResources
+	var initErr error
+
+	renderLoop.RunOnRenderThreadVoid(func() {
+		gpu, initErr = initGPU(window)
+	})
+
+	if initErr != nil {
+		return initErr
+	}
+
+	// Cleanup GPU resources on render thread
+	defer func() {
+		renderLoop.RunOnRenderThreadVoid(func() {
+			cleanupGPU(gpu)
+		})
+	}()
+
+	fmt.Println()
+	fmt.Println("=== Starting Render Loop ===")
+	fmt.Println("Press ESC or close window to exit")
+	fmt.Println()
+
+	frameCount := 0
+	startTime := time.Now()
+
+	// Main render loop
+	for window.PollEvents() {
+		// Check for pending resize from UI thread
+		if window.NeedsResize() && !window.InSizeMove() {
+			width, height := window.Size()
+			newW, newH := safeUint32(width), safeUint32(height)
+			if newW > 0 && newH > 0 {
+				// Queue resize for render thread (non-blocking)
+				renderLoop.RequestResize(newW, newH)
+			}
+		}
+
+		// Render frame on render thread
+		var frameErr error
+		renderLoop.RunOnRenderThreadVoid(func() {
+			// Apply pending resize (deferred from UI thread)
+			applyPendingResize(renderLoop, gpu)
+
+			// Render frame
+			frameErr = renderFrame(gpu)
+
+			// Reset command pool periodically (every 3 seconds at 60 FPS)
+			resetCommandPoolIfNeeded(gpu, frameCount)
+		})
+
+		if frameErr != nil {
+			// Handle surface outdated
+			if errors.Is(frameErr, hal.ErrSurfaceOutdated) {
+				width, height := window.Size()
+				renderLoop.RequestResize(safeUint32(width), safeUint32(height))
+				continue
+			}
+			// Log other errors but continue
+			if !errors.Is(frameErr, hal.ErrNotReady) {
+				fmt.Printf("Frame error: %v\n", frameErr)
+			}
+			continue
+		}
+
+		frameCount++
+
+		// Print FPS every second
+		if frameCount%60 == 0 {
+			elapsed := time.Since(startTime).Seconds()
+			fps := float64(frameCount) / elapsed
+			fmt.Printf("Rendered %d frames (%.1f FPS)\n", frameCount, fps)
+		}
+	}
+
+	fmt.Println()
+	fmt.Println("=== Test Complete ===")
+	elapsed := time.Since(startTime).Seconds()
+	avgFPS := float64(frameCount) / elapsed
+	fmt.Printf("Total frames: %d\n", frameCount)
+	fmt.Printf("Average FPS: %.1f\n", avgFPS)
+
+	return nil
+}
+
+// applyPendingResize applies any pending resize from the UI thread.
+func applyPendingResize(renderLoop *thread.RenderLoop, gpu *gpuResources) {
+	w, h, ok := renderLoop.ConsumePendingResize()
+	if !ok {
+		return
+	}
+	if w == gpu.currentWidth && h == gpu.currentHeight {
+		return
+	}
+
+	gpu.surfaceConfig.Width = w
+	gpu.surfaceConfig.Height = h
+	if err := gpu.surface.Configure(gpu.device, gpu.surfaceConfig); err != nil {
+		fmt.Printf("Failed to reconfigure surface: %v\n", err)
+		return
+	}
+	gpu.currentWidth = w
+	gpu.currentHeight = h
+}
+
+// resetCommandPoolIfNeeded resets the command pool periodically.
+func resetCommandPoolIfNeeded(gpu *gpuResources, frameCount int) {
+	if frameCount == 0 || frameCount%180 != 0 {
+		return
+	}
+	vkDev, ok := gpu.device.(*vulkan.Device)
+	if !ok {
+		return
+	}
+	_ = vkDev.WaitIdle()
+	_ = vkDev.ResetCommandPool()
+}
+
+// initGPU initializes all GPU resources. Called on render thread.
+//
+//nolint:funlen // Sequential initialization steps
+func initGPU(window *Window) (*gpuResources, error) {
+	gpu := &gpuResources{}
+
+	// Create Vulkan backend
+	fmt.Print("3. Creating Vulkan backend... ")
 	backend := vulkan.Backend{}
 	fmt.Println("OK")
 
-	// Step 3: Create instance
-	fmt.Print("3. Creating Vulkan instance... ")
+	// Create instance
+	fmt.Print("4. Creating Vulkan instance... ")
 	instance, err := backend.CreateInstance(&hal.InstanceDescriptor{
 		Backends: types.BackendsVulkan,
 		Flags:    types.InstanceFlagsDebug,
 	})
 	if err != nil {
-		return fmt.Errorf("creating instance: %w", err)
+		return nil, fmt.Errorf("creating instance: %w", err)
 	}
-	defer instance.Destroy()
+	gpu.instance = instance
 	fmt.Println("OK")
 
-	// Step 4: Create surface
-	fmt.Print("4. Creating surface... ")
+	// Create surface
+	fmt.Print("5. Creating surface... ")
 	surface, err := instance.CreateSurface(0, window.Handle())
 	if err != nil {
-		return fmt.Errorf("creating surface: %w", err)
+		return nil, fmt.Errorf("creating surface: %w", err)
 	}
-	defer surface.Destroy()
+	gpu.surface = surface
 	fmt.Println("OK")
 
-	// Step 5: Enumerate adapters
-	fmt.Print("5. Enumerating adapters... ")
+	// Enumerate adapters
+	fmt.Print("6. Enumerating adapters... ")
 	adapters := instance.EnumerateAdapters(surface)
 	if len(adapters) == 0 {
-		return fmt.Errorf("no adapters found")
+		return nil, fmt.Errorf("no adapters found")
 	}
 	fmt.Printf("OK (found %d)\n", len(adapters))
 
-	// Print adapter info
 	for i := range adapters {
 		exposed := &adapters[i]
 		fmt.Printf("   - Adapter %d: %s (%s %s)\n",
 			i, exposed.Info.Name, exposed.Info.Vendor, exposed.Info.DriverInfo)
 	}
 
-	// Step 6: Open device
-	fmt.Print("6. Opening device... ")
+	// Open device
+	fmt.Print("7. Opening device... ")
 	openDev, err := adapters[0].Adapter.Open(0, adapters[0].Capabilities.Limits)
 	if err != nil {
-		return fmt.Errorf("opening device: %w", err)
+		return nil, fmt.Errorf("opening device: %w", err)
 	}
-	device := openDev.Device
-	queue := openDev.Queue
-	defer device.Destroy()
+	gpu.device = openDev.Device
+	gpu.queue = openDev.Queue
 	fmt.Println("OK")
 
-	// Step 7: Configure surface
-	fmt.Print("7. Configuring surface... ")
+	// Configure surface
+	fmt.Print("8. Configuring surface... ")
 	width, height := window.Size()
-	surfaceConfig := &hal.SurfaceConfiguration{
-		Width:       safeUint32(width),
-		Height:      safeUint32(height),
+	gpu.currentWidth = safeUint32(width)
+	gpu.currentHeight = safeUint32(height)
+	gpu.surfaceConfig = &hal.SurfaceConfiguration{
+		Width:       gpu.currentWidth,
+		Height:      gpu.currentHeight,
 		Format:      types.TextureFormatBGRA8Unorm,
 		Usage:       types.TextureUsageRenderAttachment,
-		PresentMode: hal.PresentModeFifo, // Vsync - correct for production
+		PresentMode: hal.PresentModeFifo,
 		AlphaMode:   hal.CompositeAlphaModeOpaque,
 	}
-	if err := surface.Configure(device, surfaceConfig); err != nil {
-		return fmt.Errorf("configuring surface: %w", err)
+	if err := surface.Configure(gpu.device, gpu.surfaceConfig); err != nil {
+		return nil, fmt.Errorf("configuring surface: %w", err)
 	}
-	defer surface.Unconfigure(device)
 	fmt.Println("OK")
 
-	// Step 8: Create shader modules
-	// Use WGSL shaders compiled to SPIR-V by naga at runtime.
-	// This works reliably across all drivers including Intel Iris Xe.
-	// The hardcoded SPIR-V fallback is kept for reference but not used.
-	fmt.Print("8. Creating shader modules... ")
-	vertexShader, err := device.CreateShaderModule(&hal.ShaderModuleDescriptor{
-		Label: "Vertex Shader",
-		Source: hal.ShaderSource{
-			WGSL: vertexShaderWGSL,
-		},
+	// Create shader modules
+	fmt.Print("9. Creating shader modules... ")
+	vertexShader, err := gpu.device.CreateShaderModule(&hal.ShaderModuleDescriptor{
+		Label:  "Vertex Shader",
+		Source: hal.ShaderSource{WGSL: vertexShaderWGSL},
 	})
 	if err != nil {
-		return fmt.Errorf("creating vertex shader: %w", err)
+		return nil, fmt.Errorf("creating vertex shader: %w", err)
 	}
-	defer device.DestroyShaderModule(vertexShader)
+	gpu.vertexShader = vertexShader
 
-	fragmentShader, err := device.CreateShaderModule(&hal.ShaderModuleDescriptor{
-		Label: "Fragment Shader",
-		Source: hal.ShaderSource{
-			WGSL: fragmentShaderWGSL,
-		},
+	fragmentShader, err := gpu.device.CreateShaderModule(&hal.ShaderModuleDescriptor{
+		Label:  "Fragment Shader",
+		Source: hal.ShaderSource{WGSL: fragmentShaderWGSL},
 	})
 	if err != nil {
-		return fmt.Errorf("creating fragment shader: %w", err)
+		return nil, fmt.Errorf("creating fragment shader: %w", err)
 	}
-	defer device.DestroyShaderModule(fragmentShader)
+	gpu.fragmentShader = fragmentShader
 	fmt.Println("OK")
 
-	// Step 9: Create pipeline layout (empty - no bindings)
-	fmt.Print("9. Creating pipeline layout... ")
-	pipelineLayout, err := device.CreatePipelineLayout(&hal.PipelineLayoutDescriptor{
+	// Create pipeline layout
+	fmt.Print("10. Creating pipeline layout... ")
+	pipelineLayout, err := gpu.device.CreatePipelineLayout(&hal.PipelineLayoutDescriptor{
 		Label:            "Triangle Pipeline Layout",
-		BindGroupLayouts: nil, // No bind groups
+		BindGroupLayouts: nil,
 	})
 	if err != nil {
-		return fmt.Errorf("creating pipeline layout: %w", err)
+		return nil, fmt.Errorf("creating pipeline layout: %w", err)
 	}
-	defer device.DestroyPipelineLayout(pipelineLayout)
+	gpu.pipelineLayout = pipelineLayout
 	fmt.Println("OK")
 
-	// Step 10: Create render pipeline
-	fmt.Print("10. Creating render pipeline... ")
-	pipeline, err := device.CreateRenderPipeline(&hal.RenderPipelineDescriptor{
+	// Create render pipeline
+	fmt.Print("11. Creating render pipeline... ")
+	pipeline, err := gpu.device.CreateRenderPipeline(&hal.RenderPipelineDescriptor{
 		Label:  "Triangle Pipeline",
 		Layout: pipelineLayout,
 		Vertex: hal.VertexState{
 			Module:     vertexShader,
 			EntryPoint: "main",
-			Buffers:    nil, // No vertex buffers - positions hardcoded in shader
+			Buffers:    nil,
 		},
 		Primitive: types.PrimitiveState{
 			Topology:         types.PrimitiveTopologyTriangleList,
-			StripIndexFormat: nil, // Not using strip topology
+			StripIndexFormat: nil,
 			FrontFace:        types.FrontFaceCCW,
 			CullMode:         types.CullModeNone,
 		},
-		DepthStencil: nil, // No depth testing
+		DepthStencil: nil,
 		Multisample: types.MultisampleState{
 			Count:                  1,
 			Mask:                   0xFFFFFFFF,
@@ -181,150 +334,144 @@ func run() error {
 			Targets: []types.ColorTargetState{
 				{
 					Format:    types.TextureFormatBGRA8Unorm,
-					Blend:     nil, // No blending
+					Blend:     nil,
 					WriteMask: types.ColorWriteMaskAll,
 				},
 			},
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("creating render pipeline: %w", err)
+		return nil, fmt.Errorf("creating render pipeline: %w", err)
 	}
-	defer device.DestroyRenderPipeline(pipeline)
+	gpu.pipeline = pipeline
 	fmt.Println("OK")
 
-	fmt.Println()
-	fmt.Println("=== Starting Render Loop ===")
-	fmt.Println("Press ESC or close window to exit")
-	fmt.Println()
+	return gpu, nil
+}
 
-	frameCount := 0
-	startTime := time.Now()
-
-	// Render loop
-	for window.PollEvents() {
-		// Acquire swapchain image
-		acquired, err := surface.AcquireTexture(nil)
-		if err != nil {
-			fmt.Printf("Failed to acquire texture: %v\n", err)
-			continue
-		}
-
-		// Create texture view for the acquired image
-		textureView, err := device.CreateTextureView(acquired.Texture, &hal.TextureViewDescriptor{
-			Label:           "Swapchain View",
-			Format:          types.TextureFormatBGRA8Unorm,
-			Dimension:       types.TextureViewDimension2D,
-			Aspect:          types.TextureAspectAll,
-			BaseMipLevel:    0,
-			MipLevelCount:   1,
-			BaseArrayLayer:  0,
-			ArrayLayerCount: 1,
-		})
-		if err != nil {
-			fmt.Printf("Failed to create texture view: %v\n", err)
-			surface.DiscardTexture(acquired.Texture)
-			continue
-		}
-
-		// Create command encoder
-		encoder, err := device.CreateCommandEncoder(&hal.CommandEncoderDescriptor{
-			Label: "Triangle Encoder",
-		})
-		if err != nil {
-			fmt.Printf("Failed to create command encoder: %v\n", err)
-			device.DestroyTextureView(textureView)
-			surface.DiscardTexture(acquired.Texture)
-			continue
-		}
-
-		// Begin encoding
-		if err := encoder.BeginEncoding("Triangle Rendering"); err != nil {
-			fmt.Printf("Failed to begin encoding: %v\n", err)
-			device.DestroyTextureView(textureView)
-			surface.DiscardTexture(acquired.Texture)
-			continue
-		}
-
-		// Begin render pass with blue clear color
-		renderPass := encoder.BeginRenderPass(&hal.RenderPassDescriptor{
-			Label: "Triangle Render Pass",
-			ColorAttachments: []hal.RenderPassColorAttachment{
-				{
-					View:    textureView,
-					LoadOp:  types.LoadOpClear,
-					StoreOp: types.StoreOpStore,
-					ClearValue: types.Color{
-						R: 0.0,
-						G: 0.0,
-						B: 0.5, // Blue background
-						A: 1.0,
-					},
-				},
-			},
-		})
-
-		// Set pipeline
-		renderPass.SetPipeline(pipeline)
-
-		// Draw triangle (3 vertices, 1 instance)
-		renderPass.Draw(3, 1, 0, 0)
-
-		// End render pass
-		renderPass.End()
-
-		// End encoding
-		cmdBuffer, err := encoder.EndEncoding()
-		if err != nil {
-			fmt.Printf("Failed to end encoding: %v\n", err)
-			device.DestroyTextureView(textureView)
-			surface.DiscardTexture(acquired.Texture)
-			continue
-		}
-
-		// Submit command buffer
-		if err := queue.Submit([]hal.CommandBuffer{cmdBuffer}, nil, 0); err != nil {
-			fmt.Printf("Failed to submit commands: %v\n", err)
-			device.DestroyTextureView(textureView)
-			surface.DiscardTexture(acquired.Texture)
-			continue
-		}
-
-		// Present
-		if err := queue.Present(surface, acquired.Texture); err != nil {
-			fmt.Printf("Failed to present: %v\n", err)
-		}
-
-		// Clean up
-		device.DestroyTextureView(textureView)
-
-		frameCount++
-
-		// Print FPS every second
-		if frameCount%60 == 0 {
-			elapsed := time.Since(startTime).Seconds()
-			fps := float64(frameCount) / elapsed
-			fmt.Printf("Rendered %d frames (%.1f FPS)\n", frameCount, fps)
-		}
-
-		// Reset command pool periodically to prevent memory exhaustion
-		if frameCount%180 == 0 { // Every 3 seconds at 60 FPS
-			if vkDev, ok := device.(*vulkan.Device); ok {
-				// Wait for all GPU work to complete before resetting
-				_ = vkDev.WaitIdle()
-				_ = vkDev.ResetCommandPool()
-			}
-		}
-
-		// Note: No sleep needed - present mode handles pacing
+// cleanupGPU cleans up all GPU resources. Called on render thread.
+func cleanupGPU(gpu *gpuResources) {
+	if gpu == nil {
+		return
 	}
 
-	fmt.Println()
-	fmt.Println("=== Test Complete ===")
-	elapsed := time.Since(startTime).Seconds()
-	avgFPS := float64(frameCount) / elapsed
-	fmt.Printf("Total frames: %d\n", frameCount)
-	fmt.Printf("Average FPS: %.1f\n", avgFPS)
+	if gpu.pipeline != nil {
+		gpu.device.DestroyRenderPipeline(gpu.pipeline)
+	}
+	if gpu.pipelineLayout != nil {
+		gpu.device.DestroyPipelineLayout(gpu.pipelineLayout)
+	}
+	if gpu.fragmentShader != nil {
+		gpu.device.DestroyShaderModule(gpu.fragmentShader)
+	}
+	if gpu.vertexShader != nil {
+		gpu.device.DestroyShaderModule(gpu.vertexShader)
+	}
+	if gpu.surface != nil {
+		gpu.surface.Unconfigure(gpu.device)
+		gpu.surface.Destroy()
+	}
+	if gpu.device != nil {
+		gpu.device.Destroy()
+	}
+	if gpu.instance != nil {
+		gpu.instance.Destroy()
+	}
+}
+
+// renderFrame renders a single frame. Called on render thread.
+func renderFrame(gpu *gpuResources) error {
+	// Acquire swapchain image with retry
+	var acquired *hal.AcquiredSurfaceTexture
+	for attempts := 0; attempts < 2; attempts++ {
+		var err error
+		acquired, err = gpu.surface.AcquireTexture(nil)
+		if err == nil {
+			break
+		}
+
+		if errors.Is(err, hal.ErrNotReady) {
+			continue
+		}
+
+		return err
+	}
+
+	if acquired == nil {
+		return hal.ErrNotReady
+	}
+
+	// Create texture view
+	textureView, err := gpu.device.CreateTextureView(acquired.Texture, &hal.TextureViewDescriptor{
+		Label:           "Swapchain View",
+		Format:          types.TextureFormatBGRA8Unorm,
+		Dimension:       types.TextureViewDimension2D,
+		Aspect:          types.TextureAspectAll,
+		BaseMipLevel:    0,
+		MipLevelCount:   1,
+		BaseArrayLayer:  0,
+		ArrayLayerCount: 1,
+	})
+	if err != nil {
+		gpu.surface.DiscardTexture(acquired.Texture)
+		return fmt.Errorf("create texture view: %w", err)
+	}
+	defer gpu.device.DestroyTextureView(textureView)
+
+	// Create command encoder
+	encoder, err := gpu.device.CreateCommandEncoder(&hal.CommandEncoderDescriptor{
+		Label: "Triangle Encoder",
+	})
+	if err != nil {
+		gpu.surface.DiscardTexture(acquired.Texture)
+		return fmt.Errorf("create command encoder: %w", err)
+	}
+
+	// Begin encoding
+	if err := encoder.BeginEncoding("Triangle Rendering"); err != nil {
+		gpu.surface.DiscardTexture(acquired.Texture)
+		return fmt.Errorf("begin encoding: %w", err)
+	}
+
+	// Begin render pass
+	renderPass := encoder.BeginRenderPass(&hal.RenderPassDescriptor{
+		Label: "Triangle Render Pass",
+		ColorAttachments: []hal.RenderPassColorAttachment{
+			{
+				View:    textureView,
+				LoadOp:  types.LoadOpClear,
+				StoreOp: types.StoreOpStore,
+				ClearValue: types.Color{
+					R: 0.0,
+					G: 0.0,
+					B: 0.5,
+					A: 1.0,
+				},
+			},
+		},
+	})
+
+	renderPass.SetPipeline(gpu.pipeline)
+	renderPass.Draw(3, 1, 0, 0)
+	renderPass.End()
+
+	// End encoding
+	cmdBuffer, err := encoder.EndEncoding()
+	if err != nil {
+		gpu.surface.DiscardTexture(acquired.Texture)
+		return fmt.Errorf("end encoding: %w", err)
+	}
+
+	// Submit
+	if err := gpu.queue.Submit([]hal.CommandBuffer{cmdBuffer}, nil, 0); err != nil {
+		gpu.surface.DiscardTexture(acquired.Texture)
+		return fmt.Errorf("submit: %w", err)
+	}
+
+	// Present
+	if err := gpu.queue.Present(gpu.surface, acquired.Texture); err != nil {
+		return fmt.Errorf("present: %w", err)
+	}
 
 	return nil
 }

--- a/cmd/vulkan-triangle/window_windows.go
+++ b/cmd/vulkan-triangle/window_windows.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	"sync/atomic"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -22,6 +23,7 @@ var (
 	procDestroyWindow      = user32.NewProc("DestroyWindow")
 	procShowWindow         = user32.NewProc("ShowWindow")
 	procUpdateWindow       = user32.NewProc("UpdateWindow")
+	procGetMessageW        = user32.NewProc("GetMessageW")
 	procPeekMessageW       = user32.NewProc("PeekMessageW")
 	procTranslateMessage   = user32.NewProc("TranslateMessage")
 	procDispatchMessageW   = user32.NewProc("DispatchMessageW")
@@ -29,25 +31,36 @@ var (
 	procPostQuitMessage    = user32.NewProc("PostQuitMessage")
 	procGetClientRect      = user32.NewProc("GetClientRect")
 	procAdjustWindowRectEx = user32.NewProc("AdjustWindowRectEx")
+	procSetWindowLongPtrW  = user32.NewProc("SetWindowLongPtrW")
+	procLoadCursorW        = user32.NewProc("LoadCursorW")
+	procSetCursor          = user32.NewProc("SetCursor")
 )
 
 const (
-	csOwnDC       = 0x0020
-	wsOverlapped  = 0x00000000
-	wsCaption     = 0x00C00000
-	wsSysMenu     = 0x00080000
-	wsMinimizeBox = 0x00020000
-	wsMaximizeBox = 0x00010000
-	wsThickFrame  = 0x00040000
-	wsVisible     = 0x10000000
+	csOwnDC = 0x0020
+
+	// Window styles
+	wsOverlappedWindow = 0x00CF0000 // Standard overlapped window with all buttons
+	wsVisible          = 0x10000000
 
 	swShow = 5
 
-	wmDestroy = 0x0002
-	wmClose   = 0x0010
-	wmQuit    = 0x0012
+	// Window messages
+	wmDestroy       = 0x0002
+	wmSize          = 0x0005
+	wmClose         = 0x0010
+	wmQuit          = 0x0012
+	wmSetCursor     = 0x0020
+	wmEnterSizeMove = 0x0231
+	wmExitSizeMove  = 0x0232
 
 	pmRemove = 0x0001
+
+	// Cursor constants
+	idcArrow = 32512
+
+	// WM_SETCURSOR hit test codes
+	htClient = 1
 )
 
 type wndClassExW struct {
@@ -86,14 +99,28 @@ type rect struct {
 	Bottom int32
 }
 
-// Window represents a platform window.
+// Window represents a platform window with professional event handling.
+// Uses hybrid GetMessage/PeekMessage pattern from Gio for responsiveness.
 type Window struct {
 	hwnd      uintptr
 	hInstance uintptr
+	cursor    uintptr // Default arrow cursor
 	width     int32
 	height    int32
 	running   bool
+
+	// Resize handling (professional pattern from Gio/wgpu)
+	inSizeMove  atomic.Bool // True during modal resize/move loop
+	needsResize atomic.Bool // Resize pending after size move ends
+	pendingW    atomic.Int32
+	pendingH    atomic.Int32
+
+	// Animation state for hybrid event loop
+	animating atomic.Bool
 }
+
+// Global window pointer for wndProc callback
+var globalWindow *Window
 
 // NewWindow creates a new window with the given title and size.
 func NewWindow(title string, width, height int32) (*Window, error) {
@@ -108,11 +135,15 @@ func NewWindow(title string, width, height int32) (*Window, error) {
 		return nil, fmt.Errorf("failed to create window title: %w", err)
 	}
 
+	// Load default arrow cursor
+	cursor, _, _ := procLoadCursorW.Call(0, uintptr(idcArrow))
+
 	wc := wndClassExW{
 		Size:      uint32(unsafe.Sizeof(wndClassExW{})),
 		Style:     csOwnDC,
 		WndProc:   windows.NewCallback(wndProc),
 		Instance:  hInstance,
+		Cursor:    cursor,
 		ClassName: className,
 	}
 
@@ -121,7 +152,7 @@ func NewWindow(title string, width, height int32) (*Window, error) {
 		return nil, fmt.Errorf("RegisterClassExW failed: %w", callErr)
 	}
 
-	style := uint32(wsOverlapped | wsCaption | wsSysMenu | wsMinimizeBox | wsMaximizeBox | wsThickFrame)
+	style := uint32(wsOverlappedWindow)
 
 	// Adjust window size to account for borders
 	var rc rect
@@ -151,10 +182,17 @@ func NewWindow(title string, width, height int32) (*Window, error) {
 	w := &Window{
 		hwnd:      hwnd,
 		hInstance: hInstance,
+		cursor:    cursor,
 		width:     width,
 		height:    height,
 		running:   true,
 	}
+	w.animating.Store(true) // Start in animating mode for games
+
+	// Store window pointer for wndProc
+	globalWindow = w
+	// Store window pointer for wndProc (gwlpUserData = -21)
+	procSetWindowLongPtrW.Call(hwnd, ^uintptr(20), uintptr(unsafe.Pointer(w))) //nolint:errcheck,gosec
 
 	// Show window
 	procShowWindow.Call(hwnd, uintptr(swShow)) //nolint:errcheck,gosec // Win32 API
@@ -168,6 +206,9 @@ func (w *Window) Destroy() {
 	if w.hwnd != 0 {
 		_, _, _ = procDestroyWindow.Call(w.hwnd)
 		w.hwnd = 0
+	}
+	if globalWindow == w {
+		globalWindow = nil
 	}
 }
 
@@ -183,23 +224,68 @@ func (w *Window) Size() (width, height int32) {
 	return rc.Right - rc.Left, rc.Bottom - rc.Top
 }
 
-// PollEvents processes pending window events.
+// SetAnimating sets whether the window should use continuous rendering mode.
+// When true, uses PeekMessage (non-blocking) for maximum FPS.
+// When false, uses GetMessage (blocking) for lower CPU usage.
+func (w *Window) SetAnimating(animating bool) {
+	w.animating.Store(animating)
+}
+
+// NeedsResize returns true if a resize event occurred and clears the flag.
+func (w *Window) NeedsResize() bool {
+	return w.needsResize.Swap(false)
+}
+
+// InSizeMove returns true if the window is currently being resized/moved.
+// During this time, rendering should continue but swapchain recreation should be deferred.
+func (w *Window) InSizeMove() bool {
+	return w.inSizeMove.Load()
+}
+
+// PollEvents processes pending window events using hybrid GetMessage/PeekMessage.
+// This is the professional pattern from Gio that prevents "Not Responding".
 // Returns false when the window should close.
+//
+//nolint:nestif // Hybrid event loop requires different paths for animating/idle modes
 func (w *Window) PollEvents() bool {
 	var m msg
-	for {
-		ret, _, _ := procPeekMessageW.Call(
+
+	// Hybrid event loop pattern from Gio:
+	// - When animating: use PeekMessage (non-blocking) for max FPS
+	// - When idle: would use GetMessage (blocking) for CPU efficiency
+	// For games/realtime apps, we always use PeekMessage
+
+	if w.animating.Load() {
+		// Non-blocking: process all pending messages, then return for rendering
+		for {
+			ret, _, _ := procPeekMessageW.Call(
+				uintptr(unsafe.Pointer(&m)), //nolint:gosec // G103: Win32 API
+				0,
+				0,
+				0,
+				uintptr(pmRemove),
+			)
+			if ret == 0 {
+				break // No more messages
+			}
+
+			if m.Message == wmQuit {
+				w.running = false
+				return false
+			}
+
+			_, _, _ = procTranslateMessage.Call(uintptr(unsafe.Pointer(&m))) //nolint:gosec // G103: Win32 API
+			_, _, _ = procDispatchMessageW.Call(uintptr(unsafe.Pointer(&m))) //nolint:gosec // G103: Win32 API
+		}
+	} else {
+		// Blocking: wait for message (for GUI apps that don't need continuous render)
+		ret, _, _ := procGetMessageW.Call(
 			uintptr(unsafe.Pointer(&m)), //nolint:gosec // G103: Win32 API
 			0,
 			0,
 			0,
-			uintptr(pmRemove),
 		)
-		if ret == 0 {
-			break
-		}
-
-		if m.Message == wmQuit {
+		if ret == 0 || m.Message == wmQuit {
 			w.running = false
 			return false
 		}
@@ -212,11 +298,65 @@ func (w *Window) PollEvents() bool {
 }
 
 // wndProc is the window procedure callback.
+// Handles resize events professionally like Gio/wgpu.
 func wndProc(hwnd, message, wParam, lParam uintptr) uintptr {
+	// Get window pointer
+	w := globalWindow
+	if w == nil || w.hwnd != hwnd {
+		ret, _, _ := procDefWindowProcW.Call(hwnd, message, wParam, lParam)
+		return ret
+	}
+
 	switch message {
 	case wmDestroy, wmClose:
 		_, _, _ = procPostQuitMessage.Call(0)
 		return 0
+
+	case wmEnterSizeMove:
+		// User started resizing/moving - enter modal loop
+		// Windows blocks the message pump during resize, so we track this
+		w.inSizeMove.Store(true)
+		return 0
+
+	case wmExitSizeMove:
+		// User finished resizing/moving - safe to recreate swapchain now
+		w.inSizeMove.Store(false)
+		// Signal that resize handling is needed
+		if w.pendingW.Load() > 0 && w.pendingH.Load() > 0 {
+			w.needsResize.Store(true)
+		}
+		return 0
+
+	case wmSize:
+		// Window size changed
+		width := int32(lParam & 0xFFFF)
+		height := int32((lParam >> 16) & 0xFFFF)
+
+		if width > 0 && height > 0 {
+			w.width = width
+			w.height = height
+			w.pendingW.Store(width)
+			w.pendingH.Store(height)
+
+			// If not in modal resize loop, signal resize immediately
+			if !w.inSizeMove.Load() {
+				w.needsResize.Store(true)
+			}
+		}
+		return 0
+
+	case wmSetCursor:
+		// Restore cursor to arrow when in client area
+		// This fixes the resize cursor staying after resize ends
+		hitTest := lParam & 0xFFFF
+		if hitTest == htClient {
+			_, _, _ = procSetCursor.Call(w.cursor)
+			return 1 // Cursor was set
+		}
+		// Let Windows handle non-client area cursors (resize handles, etc.)
+		ret, _, _ := procDefWindowProcW.Call(hwnd, message, wParam, lParam)
+		return ret
+
 	default:
 		ret, _, _ := procDefWindowProcW.Call(hwnd, message, wParam, lParam)
 		return ret

--- a/internal/thread/renderloop.go
+++ b/internal/thread/renderloop.go
@@ -1,0 +1,101 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+package thread
+
+import (
+	"sync/atomic"
+)
+
+// RenderLoop manages the separation between UI and render threads.
+// Based on Ebiten's architecture for professional responsiveness.
+//
+// Key pattern: All GPU operations (including vkDeviceWaitIdle) happen
+// on the render thread, never blocking the UI thread.
+type RenderLoop struct {
+	renderThread *Thread
+
+	// Pending resize (set from UI thread, applied on render thread)
+	pendingWidth  atomic.Uint32
+	pendingHeight atomic.Uint32
+	resizePending atomic.Bool
+
+	// Frame synchronization
+	frameReady   chan struct{}
+	frameDone    chan struct{}
+	renderPaused atomic.Bool
+}
+
+// NewRenderLoop creates a new render loop with a dedicated render thread.
+func NewRenderLoop() *RenderLoop {
+	return &RenderLoop{
+		renderThread: New(),
+		frameReady:   make(chan struct{}, 1),
+		frameDone:    make(chan struct{}, 1),
+	}
+}
+
+// Stop stops the render loop and its thread.
+func (rl *RenderLoop) Stop() {
+	rl.renderThread.Stop()
+}
+
+// RequestResize queues a resize to be applied on the render thread.
+// This is called from the UI thread (WM_SIZE handler).
+// The actual swapchain recreation happens in ApplyPendingResize.
+func (rl *RenderLoop) RequestResize(width, height uint32) {
+	if width == 0 || height == 0 {
+		return
+	}
+
+	rl.pendingWidth.Store(width)
+	rl.pendingHeight.Store(height)
+	rl.resizePending.Store(true)
+}
+
+// HasPendingResize returns true if a resize is pending.
+func (rl *RenderLoop) HasPendingResize() bool {
+	return rl.resizePending.Load()
+}
+
+// ConsumePendingResize returns the pending resize dimensions and clears the flag.
+// Returns (0, 0, false) if no resize is pending.
+func (rl *RenderLoop) ConsumePendingResize() (width, height uint32, ok bool) {
+	if !rl.resizePending.Swap(false) {
+		return 0, 0, false
+	}
+	return rl.pendingWidth.Load(), rl.pendingHeight.Load(), true
+}
+
+// RunOnRenderThread executes f on the render thread and waits for completion.
+// Use for GPU operations that need synchronous results.
+func (rl *RenderLoop) RunOnRenderThread(f func() any) any {
+	return rl.renderThread.Call(f)
+}
+
+// RunOnRenderThreadVoid executes f on the render thread and waits for completion.
+// Use for GPU operations without return values.
+func (rl *RenderLoop) RunOnRenderThreadVoid(f func()) {
+	rl.renderThread.CallVoid(f)
+}
+
+// RunOnRenderThreadAsync executes f on the render thread without waiting.
+// Use for fire-and-forget GPU operations.
+func (rl *RenderLoop) RunOnRenderThreadAsync(f func()) {
+	rl.renderThread.CallAsync(f)
+}
+
+// PauseRendering pauses render operations (during modal resize).
+func (rl *RenderLoop) PauseRendering() {
+	rl.renderPaused.Store(true)
+}
+
+// ResumeRendering resumes render operations.
+func (rl *RenderLoop) ResumeRendering() {
+	rl.renderPaused.Store(false)
+}
+
+// IsRenderingPaused returns true if rendering is paused.
+func (rl *RenderLoop) IsRenderingPaused() bool {
+	return rl.renderPaused.Load()
+}

--- a/internal/thread/thread.go
+++ b/internal/thread/thread.go
@@ -1,0 +1,119 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+// Package thread provides thread abstraction for GPU operations.
+// Based on Ebiten's thread architecture for professional responsiveness.
+//
+// Architecture:
+//   - Main thread: Window events, user input (must be OS main thread on Windows)
+//   - Render thread: All GPU operations (device, swapchain, commands)
+//
+// This separation ensures window responsiveness during heavy GPU operations
+// like swapchain recreation, which requires vkDeviceWaitIdle.
+package thread
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+)
+
+// Thread represents a dedicated OS thread for specific operations.
+// All function calls are serialized and executed on the same thread.
+type Thread struct {
+	funcs   chan func()
+	results chan any
+	done    chan struct{}
+	running atomic.Bool
+}
+
+// New creates a new thread and starts it.
+// The thread is locked to an OS thread (runtime.LockOSThread).
+func New() *Thread {
+	t := &Thread{
+		funcs:   make(chan func(), 16), // Buffered for async calls
+		results: make(chan any, 1),     // Unbuffered for sync calls
+		done:    make(chan struct{}),
+	}
+	t.running.Store(true)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	go func() {
+		// Lock this goroutine to an OS thread.
+		// Critical for Vulkan/OpenGL context operations.
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+
+		wg.Done() // Signal that thread is ready
+
+		for {
+			select {
+			case f := <-t.funcs:
+				f()
+			case <-t.done:
+				return
+			}
+		}
+	}()
+
+	wg.Wait() // Wait for thread to be ready
+	return t
+}
+
+// Call executes f on the thread and waits for completion.
+// Returns the result from f.
+func (t *Thread) Call(f func() any) any {
+	if !t.running.Load() {
+		return nil
+	}
+
+	done := make(chan any, 1)
+	t.funcs <- func() {
+		done <- f()
+	}
+	return <-done
+}
+
+// CallVoid executes f on the thread and waits for completion.
+// Use when no return value is needed.
+func (t *Thread) CallVoid(f func()) {
+	if !t.running.Load() {
+		return
+	}
+
+	done := make(chan struct{})
+	t.funcs <- func() {
+		f()
+		close(done)
+	}
+	<-done
+}
+
+// CallAsync executes f on the thread without waiting.
+// Use for fire-and-forget operations.
+func (t *Thread) CallAsync(f func()) {
+	if !t.running.Load() {
+		return
+	}
+
+	select {
+	case t.funcs <- f:
+	default:
+		// Channel full - execute synchronously to avoid deadlock
+		t.CallVoid(f)
+	}
+}
+
+// Stop stops the thread.
+func (t *Thread) Stop() {
+	if t.running.Swap(false) {
+		close(t.done)
+	}
+}
+
+// IsRunning returns true if the thread is running.
+func (t *Thread) IsRunning() bool {
+	return t.running.Load()
+}

--- a/internal/thread/thread_test.go
+++ b/internal/thread/thread_test.go
@@ -1,0 +1,136 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+package thread
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestThread_CallVoid(t *testing.T) {
+	th := New()
+	defer th.Stop()
+
+	var called atomic.Bool
+	th.CallVoid(func() {
+		called.Store(true)
+	})
+
+	if !called.Load() {
+		t.Error("CallVoid did not execute function")
+	}
+}
+
+func TestThread_Call(t *testing.T) {
+	th := New()
+	defer th.Stop()
+
+	result := th.Call(func() any {
+		return 42
+	})
+
+	if result != 42 {
+		t.Errorf("Call returned %v, want 42", result)
+	}
+}
+
+func TestThread_CallAsync(t *testing.T) {
+	th := New()
+	defer th.Stop()
+
+	var called atomic.Bool
+	th.CallAsync(func() {
+		called.Store(true)
+	})
+
+	// Wait for async call to complete
+	time.Sleep(10 * time.Millisecond)
+
+	if !called.Load() {
+		t.Error("CallAsync did not execute function")
+	}
+}
+
+func TestThread_Stop(t *testing.T) {
+	th := New()
+
+	if !th.IsRunning() {
+		t.Error("Thread should be running after New()")
+	}
+
+	th.Stop()
+
+	if th.IsRunning() {
+		t.Error("Thread should not be running after Stop()")
+	}
+
+	// Calling methods on stopped thread should not panic
+	th.CallVoid(func() {})
+	th.Call(func() any { return nil })
+	th.CallAsync(func() {})
+}
+
+func TestRenderLoop_RequestResize(t *testing.T) {
+	rl := NewRenderLoop()
+	defer rl.Stop()
+
+	// No pending resize initially
+	if rl.HasPendingResize() {
+		t.Error("Should not have pending resize initially")
+	}
+
+	// Request resize
+	rl.RequestResize(800, 600)
+
+	if !rl.HasPendingResize() {
+		t.Error("Should have pending resize after RequestResize")
+	}
+
+	// Consume resize
+	w, h, ok := rl.ConsumePendingResize()
+	if !ok {
+		t.Error("ConsumePendingResize should return true")
+	}
+	if w != 800 || h != 600 {
+		t.Errorf("ConsumePendingResize returned %dx%d, want 800x600", w, h)
+	}
+
+	// Resize should be consumed
+	if rl.HasPendingResize() {
+		t.Error("Should not have pending resize after consuming")
+	}
+}
+
+func TestRenderLoop_PauseRendering(t *testing.T) {
+	rl := NewRenderLoop()
+	defer rl.Stop()
+
+	if rl.IsRenderingPaused() {
+		t.Error("Rendering should not be paused initially")
+	}
+
+	rl.PauseRendering()
+	if !rl.IsRenderingPaused() {
+		t.Error("Rendering should be paused after PauseRendering")
+	}
+
+	rl.ResumeRendering()
+	if rl.IsRenderingPaused() {
+		t.Error("Rendering should not be paused after ResumeRendering")
+	}
+}
+
+func TestRenderLoop_RunOnRenderThread(t *testing.T) {
+	rl := NewRenderLoop()
+	defer rl.Stop()
+
+	result := rl.RunOnRenderThread(func() any {
+		return "hello"
+	})
+
+	if result != "hello" {
+		t.Errorf("RunOnRenderThread returned %v, want 'hello'", result)
+	}
+}


### PR DESCRIPTION
## Summary

Enterprise-level multi-thread architecture for window responsiveness based on Ebiten/Gio patterns.

- Add `internal/thread` package with Thread and RenderLoop abstractions
- Separate UI thread (Win32 messages) from render thread (GPU ops)
- Deferred swapchain resize using RequestResize/ConsumePendingResize
- Add WM_SETCURSOR handling for proper cursor restoration after resize
- Remove unused fence functions from swapchain.go

## Architecture

```
Main Thread (OS Thread 0)     Render Thread (Dedicated)
├─ runtime.LockOSThread()     ├─ runtime.LockOSThread()
├─ Win32 Message Pump         ├─ GPU Initialization
├─ WM_SIZE → RequestResize()  ├─ ConsumePendingResize()
├─ WM_SETCURSOR handling      ├─ Surface.Configure()
└─ window.PollEvents()        ├─ vkDeviceWaitIdle (non-blocking UI!)
                              └─ Acquire → Render → Present
```

## Test plan

- [x] Build passes: `go build ./...`
- [x] Linter passes: `golangci-lint run --timeout=5m ./...`
- [x] Thread tests pass: `go test ./internal/thread/...`
- [x] Manual testing: vulkan-triangle resize/drag responsive
- [x] Cursor restoration works after resize