### PR TITLE
fix: update gputypes to v0.2.0 for webgpu.h spec compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-01-29
+
+### Changed
+
+- **Update gputypes to v0.2.0** for webgpu.h spec-compliant enum values
+  - All enum values now match official WebGPU C header specification
+  - Binary compatibility with wgpu-native and other WebGPU implementations
+
+### Fixed
+
+- **CompositeAlphaMode naming** — Fixed `PreMultiplied` → `Premultiplied` in all HAL adapters
+  - Matches webgpu.h spec naming convention
+  - Affected: Vulkan, DX12, GLES, Metal, Noop, Software adapters
+
 ## [0.11.1] - 2026-01-29
 
 ### Breaking Changes
@@ -578,7 +592,8 @@ The following features are not yet fully implemented in the Vulkan backend:
 - **Noop backend** (`hal/noop/`) - Reference implementation for testing
 - **OpenGL ES backend** (`hal/gles/`) - Pure Go via goffi (~3.5K LOC)
 
-[Unreleased]: https://github.com/gogpu/wgpu/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/gogpu/wgpu/compare/v0.11.2...HEAD
+[0.11.2]: https://github.com/gogpu/wgpu/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/gogpu/wgpu/compare/v0.10.3...v0.11.1
 [0.10.3]: https://github.com/gogpu/wgpu/compare/v0.10.2...v0.10.3
 [0.10.2]: https://github.com/gogpu/wgpu/compare/v0.10.1...v0.10.2

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@
 
 ---
 
-## Current Status: v0.11.0
+## Current Status: v0.11.2
 
 | Component | Status | LOC | Coverage |
 |-----------|--------|-----|----------|
@@ -171,10 +171,14 @@
 - [x] **Ebiten-style Architecture** — Main thread for Win32, render thread for GPU
 - [x] **Responsive Windows** — No "Not Responding" during resize/drag
 
-### v0.11.0 — gputypes Migration (Current)
+### v0.11.0 — gputypes Migration
 - [x] **Unified WebGPU Types** — Import from `github.com/gogpu/gputypes`
 - [x] **Removed `types/` package** — 1,745 lines removed
 - [x] **Ecosystem Compatibility** — Single source of truth for types
+
+### v0.11.2 — gputypes v0.2.0 (Current)
+- [x] **webgpu.h Compliance** — Update gputypes to v0.2.0 with spec-compliant enum values
+- [x] **CompositeAlphaMode Fix** — `PreMultiplied` → `Premultiplied` in all HAL adapters
 
 ---
 
@@ -250,6 +254,7 @@ Priority areas:
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| v0.11.2 | 2026-01 | gputypes v0.2.0, webgpu.h spec compliance |
 | v0.11.0 | 2026-01 | gputypes migration, types/ removed |
 | v0.10.3 | 2026-01 | Multi-thread architecture |
 | v0.10.2 | 2026-01 | goffi v0.3.8, CGO build tag fix |

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25
 
 require (
 	github.com/go-webgpu/goffi v0.3.8
-	github.com/gogpu/gputypes v0.1.0
+	github.com/gogpu/gputypes v0.2.0
 	github.com/gogpu/naga v0.8.4
 	golang.org/x/sys v0.39.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/go-webgpu/goffi v0.3.8 h1:Kzw7oP1XEjkv+6QvOIWwuNMfW3iOTPq0hQjr14YwVBM=
 github.com/go-webgpu/goffi v0.3.8/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/gogpu/gputypes v0.1.0 h1:n8tAmV9qPZA5E7JBBbRfmT0k7NFfNHxUUPi5vqy3I2I=
-github.com/gogpu/gputypes v0.1.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
+github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
+github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.8.4 h1:Ge+bOVriIqozna1sStcEqvcP5sygZdxs8DjM8cLt2d8=
 github.com/gogpu/naga v0.8.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=

--- a/hal/descriptor.go
+++ b/hal/descriptor.go
@@ -130,11 +130,11 @@ type CompositeAlphaMode = gputypes.CompositeAlphaMode
 
 // CompositeAlphaMode constants for backward compatibility.
 const (
-	CompositeAlphaModeAuto           = gputypes.CompositeAlphaModeAuto
-	CompositeAlphaModeOpaque         = gputypes.CompositeAlphaModeOpaque
-	CompositeAlphaModePreMultiplied  = gputypes.CompositeAlphaModePreMultiplied
-	CompositeAlphaModePostMultiplied = gputypes.CompositeAlphaModePostMultiplied
-	CompositeAlphaModeInherit        = gputypes.CompositeAlphaModeInherit
+	CompositeAlphaModeAuto            = gputypes.CompositeAlphaModeAuto
+	CompositeAlphaModeOpaque          = gputypes.CompositeAlphaModeOpaque
+	CompositeAlphaModePremultiplied   = gputypes.CompositeAlphaModePremultiplied
+	CompositeAlphaModeUnpremultiplied = gputypes.CompositeAlphaModeUnpremultiplied
+	CompositeAlphaModeInherit         = gputypes.CompositeAlphaModeInherit
 )
 
 // SurfaceConfiguration describes surface settings.

--- a/hal/dx12/adapter.go
+++ b/hal/dx12/adapter.go
@@ -366,7 +366,7 @@ func (a *Adapter) SurfaceCapabilities(surface hal.Surface) *hal.SurfaceCapabilit
 		PresentModes: a.presentModes(),
 		AlphaModes: []hal.CompositeAlphaMode{
 			hal.CompositeAlphaModeOpaque,
-			hal.CompositeAlphaModePreMultiplied,
+			hal.CompositeAlphaModePremultiplied,
 		},
 	}
 }

--- a/hal/dx12/surface.go
+++ b/hal/dx12/surface.go
@@ -353,9 +353,9 @@ func textureFormatToDXGI(format gputypes.TextureFormat) dxgi.DXGI_FORMAT {
 // compositeAlphaModeToDXGI converts HAL CompositeAlphaMode to DXGI_ALPHA_MODE.
 func compositeAlphaModeToDXGI(mode hal.CompositeAlphaMode) dxgi.DXGI_ALPHA_MODE {
 	switch mode {
-	case hal.CompositeAlphaModePreMultiplied:
+	case hal.CompositeAlphaModePremultiplied:
 		return dxgi.DXGI_ALPHA_MODE_PREMULTIPLIED
-	case hal.CompositeAlphaModePostMultiplied:
+	case hal.CompositeAlphaModeUnpremultiplied:
 		return dxgi.DXGI_ALPHA_MODE_STRAIGHT
 	case hal.CompositeAlphaModeInherit:
 		return dxgi.DXGI_ALPHA_MODE_UNSPECIFIED

--- a/hal/gles/adapter.go
+++ b/hal/gles/adapter.go
@@ -103,7 +103,7 @@ func (a *Adapter) SurfaceCapabilities(_ hal.Surface) *hal.SurfaceCapabilities {
 		},
 		AlphaModes: []hal.CompositeAlphaMode{
 			hal.CompositeAlphaModeOpaque,
-			hal.CompositeAlphaModePreMultiplied,
+			hal.CompositeAlphaModePremultiplied,
 		},
 	}
 }

--- a/hal/gles/adapter_linux.go
+++ b/hal/gles/adapter_linux.go
@@ -105,7 +105,7 @@ func (a *Adapter) SurfaceCapabilities(_ hal.Surface) *hal.SurfaceCapabilities {
 		},
 		AlphaModes: []hal.CompositeAlphaMode{
 			hal.CompositeAlphaModeOpaque,
-			hal.CompositeAlphaModePreMultiplied,
+			hal.CompositeAlphaModePremultiplied,
 		},
 	}
 }

--- a/hal/metal/adapter.go
+++ b/hal/metal/adapter.go
@@ -88,7 +88,7 @@ func (a *Adapter) SurfaceCapabilities(surface hal.Surface) *hal.SurfaceCapabilit
 		},
 		AlphaModes: []hal.CompositeAlphaMode{
 			hal.CompositeAlphaModeOpaque,
-			hal.CompositeAlphaModePreMultiplied,
+			hal.CompositeAlphaModePremultiplied,
 		},
 	}
 }

--- a/hal/noop/adapter.go
+++ b/hal/noop/adapter.go
@@ -45,8 +45,8 @@ func (a *Adapter) SurfaceCapabilities(_ hal.Surface) *hal.SurfaceCapabilities {
 		},
 		AlphaModes: []hal.CompositeAlphaMode{
 			hal.CompositeAlphaModeOpaque,
-			hal.CompositeAlphaModePreMultiplied,
-			hal.CompositeAlphaModePostMultiplied,
+			hal.CompositeAlphaModePremultiplied,
+			hal.CompositeAlphaModeUnpremultiplied,
 			hal.CompositeAlphaModeInherit,
 		},
 	}

--- a/hal/software/adapter.go
+++ b/hal/software/adapter.go
@@ -47,8 +47,8 @@ func (a *Adapter) SurfaceCapabilities(_ hal.Surface) *hal.SurfaceCapabilities {
 		},
 		AlphaModes: []hal.CompositeAlphaMode{
 			hal.CompositeAlphaModeOpaque,
-			hal.CompositeAlphaModePreMultiplied,
-			hal.CompositeAlphaModePostMultiplied,
+			hal.CompositeAlphaModePremultiplied,
+			hal.CompositeAlphaModeUnpremultiplied,
 			hal.CompositeAlphaModeInherit,
 		},
 	}

--- a/hal/vulkan/adapter.go
+++ b/hal/vulkan/adapter.go
@@ -169,7 +169,7 @@ func (a *Adapter) SurfaceCapabilities(surface hal.Surface) *hal.SurfaceCapabilit
 		},
 		AlphaModes: []hal.CompositeAlphaMode{
 			hal.CompositeAlphaModeOpaque,
-			hal.CompositeAlphaModePreMultiplied,
+			hal.CompositeAlphaModePremultiplied,
 		},
 	}
 }


### PR DESCRIPTION
## Summary

- Update gputypes dependency to v0.2.0 with webgpu.h spec-compliant enum values
- Fix CompositeAlphaMode naming: `PreMultiplied` → `Premultiplied` in all HAL adapters
- Binary compatibility with wgpu-native and other WebGPU implementations

## Changed Files

- `go.mod`, `go.sum` — gputypes v0.1.0 → v0.2.0
- `hal/descriptor.go` — Type alias update
- `hal/vulkan/adapter.go`
- `hal/dx12/adapter.go`, `hal/dx12/surface.go`
- `hal/gles/adapter.go`, `hal/gles/adapter_linux.go`
- `hal/metal/adapter.go`
- `hal/noop/adapter.go`
- `hal/software/adapter.go`

## Test Plan

- [ ] Build passes: `go build ./...`
- [ ] Tests pass: `go test ./...`
- [ ] Lint passes: `golangci-lint run`

## Release

This is a patch release: **v0.11.2**