### PR TITLE
update types import in quick start example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ import (
     "fmt"
 
     "github.com/gogpu/wgpu/core"
-    "github.com/gogpu/wgpu/types"
+    types "github.com/gogpu/gputypes"
     _ "github.com/gogpu/wgpu/hal/allbackends" // Auto-register platform backends
 )
 


### PR DESCRIPTION
noticed that the example in the main README no longer works, so just update to the types in another repo