### PR TITLE
fix(vulkan): set correct InitialLayout for LoadOpLoad render passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-02-06
+
+### Fixed
+
+- **Render pass InitialLayout for LoadOpLoad** — Set correct `InitialLayout` when `LoadOp` is `Load` instead of unconditional `ImageLayoutUndefined`. Previously, Vulkan was allowed to discard image contents between render passes, causing ClearColor output to be lost (black background instead of the expected color). Affects both color and depth/stencil attachments.
+
 ## [0.13.0] - 2026-02-01
 
 Major HAL interface additions: format capabilities, array textures, and render bundles.


### PR DESCRIPTION
## Summary

- Fix `InitialLayout` in Vulkan render pass creation — was unconditionally `ImageLayoutUndefined`, which per Vulkan spec allows the driver to discard image contents even when `LoadOp` is `Load`
- This caused ClearColor output to be lost between consecutive render passes (black background instead of expected clear color)
- Set `InitialLayout` to match actual image layout when `LoadOp` is `Load`; keep `Undefined` for `Clear`/`DontCare`

## Test plan

- [x] Verified Pure Go backend now shows correct dark navy background (`0x1a1a2e`) matching Rust backend
- [x] Both backends produce identical visual output
- [x] Build passes for both native and rust tags
