### PR TITLE
chore: update naga v0.10.0 → v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.2] - 2026-02-07
+
+### Changed
+
+- **naga** dependency updated v0.10.0 → v0.11.0 — fixes SPIR-V `if/else` GPU hang, adds 55 new WGSL built-in functions
+
 ## [0.13.1] - 2026-02-06
 
 ### Fixed
@@ -660,7 +666,11 @@ The following features are not yet fully implemented in the Vulkan backend:
 - **Noop backend** (`hal/noop/`) - Reference implementation for testing
 - **OpenGL ES backend** (`hal/gles/`) - Pure Go via goffi (~3.5K LOC)
 
-[Unreleased]: https://github.com/gogpu/wgpu/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/gogpu/wgpu/compare/v0.13.2...HEAD
+[0.13.2]: https://github.com/gogpu/wgpu/compare/v0.13.1...v0.13.2
+[0.13.1]: https://github.com/gogpu/wgpu/compare/v0.13.0...v0.13.1
+[0.13.0]: https://github.com/gogpu/wgpu/compare/v0.12.0...v0.13.0
+[0.12.0]: https://github.com/gogpu/wgpu/compare/v0.11.2...v0.12.0
 [0.11.2]: https://github.com/gogpu/wgpu/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/gogpu/wgpu/compare/v0.10.3...v0.11.1
 [0.10.3]: https://github.com/gogpu/wgpu/compare/v0.10.2...v0.10.3

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25
 require (
 	github.com/go-webgpu/goffi v0.3.8
 	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/naga v0.10.0
+	github.com/gogpu/naga v0.11.0
 	golang.org/x/sys v0.39.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,7 @@ github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.10.0 h1:TmCTTkgjZyFppyCEUtcz5E6yl9x3E76ZhpYkoGTt1HI=
 github.com/gogpu/naga v0.10.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.11.0 h1:rNTcG/06kSyTFcyhQ1p37zh+SIYtudq22NQhYOHOv/g=
+github.com/gogpu/naga v0.11.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.39.0 h1:CvCKL8MeisomCi6qNZ+wbb0DN9E5AATixKsvNtMoMFk=
 golang.org/x/sys v0.39.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

- Update naga dependency v0.10.0 → v0.11.0
- Picks up critical SPIR-V if/else control flow fix (GPU hang) and 55 new WGSL built-in functions
- Update CHANGELOG for v0.13.2, fix missing comparison links