### PR TITLE
fix(metal): scoped autorelease pools to prevent LIFO violation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-02-16
+
+### Fixed
+
+- **Metal autorelease pool LIFO violation** — Replaced stored autorelease pools with
+  scoped pools that drain immediately within the same function. Previously, pools were
+  stored in `CommandBuffer` structs and drained asynchronously via `FencePool`, causing
+  LIFO violations when frame N+1 overlapped with frame N on the ObjC pool stack.
+  macOS Tahoe (26.2) upgraded this from a warning to fatal SIGABRT. Fix matches the
+  Rust wgpu-hal Metal backend pattern. Fixes gogpu/gogpu#83.
+
 ## [0.16.1] - 2026-02-15
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,9 +19,12 @@
 
 ---
 
-## Current State: v0.16.1
+## Current State: v0.16.2
 
 ✅ **All 5 HAL backends complete** (~80K LOC, ~100K total):
+
+**New in v0.16.2:**
+- Metal autorelease pool LIFO fix — scoped pools instead of stored pools (fixes macOS Tahoe crash, gogpu/gogpu#83)
 
 **New in v0.16.0:**
 - Full GLES rendering pipeline — WGSL→GLSL shaders, VAO, FBO, MSAA, blend, stencil
@@ -82,7 +85,8 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| **v0.16.1** | 2026-02 | Vulkan framebuffer cache invalidation fix |
+| **v0.16.2** | 2026-02 | Metal autorelease pool LIFO fix (macOS Tahoe crash) |
+| v0.16.1 | 2026-02 | Vulkan framebuffer cache invalidation fix |
 | v0.16.0 | 2026-02 | Full GLES pipeline, structured logging, MSAA, Metal/DX12 features |
 | v0.15.1 | 2026-02 | DX12 WriteBuffer/WriteTexture fix, shader pipeline fix |
 | v0.15.0 | 2026-02 | ReadBuffer for compute shader readback |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,161 @@
+# Architecture
+
+This document describes the architecture of `wgpu` — a Pure Go WebGPU implementation.
+
+## Overview
+
+```
+┌─────────────────────────────────────────────────┐
+│                   User Code                     │
+│        (gogpu, gg, or direct HAL usage)         │
+└──────────────────────┬──────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────┐
+│                  core/                          │
+│      WebGPU-compliant API with validation       │
+│   (Instance, Adapter, Device, Queue, Pipeline)  │
+└──────────────────────┬──────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────┐
+│                  hal/                           │
+│     Hardware Abstraction Layer (interfaces)     │
+│  Backend · Instance · Adapter · Device · Queue  │
+│  CommandEncoder · RenderPass · ComputePass      │
+└──────┬────────┬────────┬────────┬────────┬──────┘
+       │        │        │        │        │
+┌──────▼──┐┌───▼────┐┌──▼───┐┌────▼───┐┌───▼──────┐
+│ vulkan/ ││ metal/ ││ dx12/││ gles/  ││software/ │
+│ Vulkan  ││ Metal  ││ DX12 ││OpenGLES││  CPU     │
+│1.0+ API ││ macOS  ││ Win  ││ 3.0+   ││rasterizer│
+└─────────┘└────────┘└──────┘└────────┘└──────────┘
+```
+
+## Layers
+
+### `core/` — WebGPU API
+
+The public API layer that users interact with. Follows the W3C WebGPU specification.
+
+- **Validation** — Validates descriptors, usage flags, and state before forwarding to HAL
+- **Error scopes** — WebGPU error handling model (`PushErrorScope` / `PopErrorScope`)
+- **Resource tracking** — Leak detection in debug builds
+- **Structured logging** — `log/slog` integration, silent by default
+
+Key types: `Instance`, `Adapter`, `Device`, `Queue`, `Buffer`, `Texture`, `RenderPipeline`, `ComputePipeline`, `CommandEncoder`.
+
+### `hal/` — Hardware Abstraction Layer
+
+Backend-agnostic interfaces that each graphics API implements. The HAL prioritizes portability over safety — validation is handled by the `core/` layer above.
+
+Key interfaces (defined in `hal/api.go`):
+
+| Interface | Responsibility |
+|-----------|---------------|
+| `Backend` | Factory for creating instances |
+| `Instance` | Surface creation, adapter enumeration |
+| `Adapter` | Physical GPU, capability queries |
+| `Device` | Resource creation (buffers, textures, pipelines) |
+| `Queue` | Command submission, presentation |
+| `CommandEncoder` | Command recording |
+| `RenderPassEncoder` | Render pass commands |
+| `ComputePassEncoder` | Compute dispatch commands |
+
+### `hal/vulkan/` — Vulkan Backend
+
+Pure Go Vulkan 1.0+ implementation using `cgo_import_dynamic` for function loading.
+
+- `vk/` — Low-level Vulkan bindings (generated types, function signatures, loader)
+- `memory/` — GPU memory allocator (buddy allocation)
+- Platform surface: VkWin32, VkXlib, VkMetal
+
+### `hal/metal/` — Metal Backend
+
+Pure Go Metal implementation via Objective-C runtime message sending.
+
+- `objc.go` — Objective-C runtime (`objc_msgSend`, `NSAutoreleasePool`, selectors)
+- `encoder.go` — Command encoder, render/compute pass encoders
+- `device.go` — Device, resource creation, fence management
+- `queue.go` — Command submission, texture writes
+- Uses scoped autorelease pools (create + drain in same function)
+
+### `hal/dx12/` — DirectX 12 Backend
+
+Pure Go DX12 implementation via COM interfaces.
+
+- `d3d12/` — D3D12 COM interfaces, GUID definitions, loader
+- `dxgi/` — DXGI factory, adapter enumeration
+- Windows-only (`//go:build windows`)
+
+### `hal/gles/` — OpenGL ES Backend
+
+Pure Go OpenGL ES 3.0+ implementation.
+
+- `gl/` — OpenGL function bindings
+- `egl/` — EGL context and display management
+- `wgl/` — WGL context for Windows
+- Shader compilation: WGSL → GLSL via naga
+
+### `hal/software/` — Software Backend
+
+CPU-based rasterizer for testing and fallback.
+
+- `raster/` — Triangle rasterization, blending, depth/stencil, tiling
+- `shader/` — Software shader execution (callback-based)
+
+### `hal/noop/` — No-op Backend
+
+Stub implementation for testing. All operations succeed without GPU interaction.
+
+## Backend Registration
+
+Backends register via `init()` functions. Import `hal/allbackends` to auto-register platform-appropriate backends:
+
+```go
+import _ "github.com/gogpu/wgpu/hal/allbackends"
+```
+
+Platform selection (`hal/allbackends/`):
+
+| Platform | Backends |
+|----------|----------|
+| Windows | Vulkan, DX12, GLES, Software, Noop |
+| macOS | Metal, Software, Noop |
+| Linux | Vulkan, GLES, Software, Noop |
+
+Backend priority for auto-selection: Vulkan > Metal > DX12 > GLES > Software > Noop.
+
+## Resource Lifecycle
+
+```
+Backend.CreateInstance()
+  → Instance.EnumerateAdapters()
+    → Adapter.Open()
+      → Device + Queue
+        → Device.Create*(desc)     // create resources
+        → CommandEncoder.Begin*()  // record commands
+        → Queue.Submit()           // execute
+        → Device.Destroy*(res)     // release
+```
+
+All resources must be explicitly destroyed. The `core/` layer provides leak detection.
+
+## Pure Go Approach
+
+All backends are implemented without CGO:
+
+- **Function loading** — `cgo_import_dynamic` + `go-webgpu/goffi` for symbol resolution
+- **Windows APIs** — `syscall.LazyDLL` for DX12/DXGI COM
+- **Objective-C** — `objc_msgSend` via FFI for Metal
+- **Build** — `CGO_ENABLED=0 go build` works everywhere
+
+## Dependencies
+
+```
+naga (shader compiler) — WGSL → SPIR-V / MSL / GLSL
+  ↑
+wgpu (this library)
+  ↑
+gogpu (app framework) / gg (2D graphics)
+```
+
+External dependency: `github.com/gogpu/naga` (shader compiler, also Pure Go).

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -797,7 +797,9 @@ func (d *Device) GetFenceStatus(fence hal.Fence) (bool, error) {
 	return signaled > 0, nil
 }
 
-// FreeCommandBuffer releases a submitted command buffer and its autorelease pool.
+// FreeCommandBuffer releases a submitted command buffer.
+// Autorelease pools are no longer stored in command buffers — they use scoped
+// pools that drain immediately in BeginEncoding (macOS Tahoe LIFO fix).
 func (d *Device) FreeCommandBuffer(cmdBuffer hal.CommandBuffer) {
 	cb, ok := cmdBuffer.(*CommandBuffer)
 	if !ok || cb == nil {
@@ -806,10 +808,6 @@ func (d *Device) FreeCommandBuffer(cmdBuffer hal.CommandBuffer) {
 	if cb.raw != 0 {
 		Release(cb.raw)
 		cb.raw = 0
-	}
-	if cb.pool != nil {
-		cb.pool.Drain()
-		cb.pool = nil
 	}
 }
 

--- a/hal/metal/queue.go
+++ b/hal/metal/queue.go
@@ -20,6 +20,9 @@ type Queue struct {
 
 // Submit submits command buffers to the GPU.
 func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenceValue uint64) error {
+	pool := NewAutoreleasePool()
+	defer pool.Drain()
+
 	for _, buf := range commandBuffers {
 		cb, ok := buf.(*CommandBuffer)
 		if !ok || cb == nil {


### PR DESCRIPTION
## Summary

- Replace stored autorelease pools with scoped pools in Metal HAL backend
- Pools now drain immediately within the same function (matching Rust wgpu-hal pattern)
- Metal objects that outlive the pool (command buffers, encoders) are Retained before drain

Fixes gogpu/gogpu#83 — macOS Tahoe (26.2) SIGABRT crash on M2 Max.

## Changed files

| File | Change |
|------|--------|
| `hal/metal/encoder.go` | Remove pool fields from 4 structs, scoped pools in Begin/End/blit methods |
| `hal/metal/device.go` | Remove pool drain from FreeCommandBuffer |
| `hal/metal/queue.go` | Add scoped pool to Submit |
| `CHANGELOG.md` | v0.16.2 entry |
| `ROADMAP.md` | Update to v0.16.2 |
| `docs/ARCHITECTURE.md` | New architecture documentation |

## Test plan

- [ ] CI passes (formatting, lint, build, tests)
- [ ] cyberbeast verifies on macOS Tahoe M2 Max (gogpu#83)