### PR TITLE
fix(vulkan): per-encoder command pools (v0.16.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.5] - 2026-02-18
+
+### Fixed
+
+- **Vulkan per-encoder command pools** (VK-POOL-001) — Each `CreateCommandEncoder` now gets
+  its own dedicated `VkCommandPool` + `VkCommandBuffer` pair, matching Rust wgpu-hal architecture.
+  Eliminates race condition between per-frame bulk pool reset (`vkResetCommandPool`) and individual
+  command buffer freeing (`vkFreeCommandBuffers`) that caused `vkBeginCommandBuffer(): Couldn't find
+  VkCommandBuffer Object` access violation crashes. Pools are recycled via a thread-safe free list
+  with lazy reset on next acquire. No API changes — `hal.Device` interface unchanged.
+
 ## [0.16.4] - 2026-02-18
 
 Vulkan timeline semaphore fences, binary fence pool, hot-path allocation optimization,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,9 +19,12 @@
 
 ---
 
-## Current State: v0.16.4
+## Current State: v0.16.5
 
 ✅ **All 5 HAL backends complete** (~80K LOC, ~100K total):
+
+**New in v0.16.5:**
+- Vulkan per-encoder command pools — dedicated VkCommandPool per encoder, eliminates VkCommandBuffer crash
 
 **New in v0.16.4:**
 - Vulkan timeline semaphore fence — single VkSemaphore replaces binary fence ring buffer (Vulkan 1.2+)


### PR DESCRIPTION
## Summary

- Replace per-frame command pool ring buffer with per-encoder dedicated pools (VK-POOL-001)
- Each `CreateCommandEncoder` gets its own `VkCommandPool` + `VkCommandBuffer` pair, matching Rust wgpu-hal architecture
- Pools recycled via thread-safe free list with lazy `vkResetCommandPool` on next acquire
- Fixes race between `advanceFrame` bulk pool reset and `FreeCommandBuffer` that caused `vkBeginCommandBuffer(): Couldn't find VkCommandBuffer Object` access violation crash

## Changes

| File | Change |
|------|--------|
| `hal/vulkan/device.go` | Remove `frameState` ring buffer, add `commandAllocator` free list |
| `hal/vulkan/queue.go` | Simplify `Present()` — remove frame management |
| `hal/vulkan/command.go` | `DiscardEncoding()` recycles pool+buffer pair |
| `hal/vulkan/bundle.go` | Dedicated pool per render bundle (unchanged) |
| `CHANGELOG.md` | Add v0.16.5 entry |
| `ROADMAP.md` | Update current state to v0.16.5 |

**+156 / −305 lines** (net −149 — simpler code)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run` — 0 issues
- [x] `ui/examples/hello` — no crash, renders correctly
- [ ] CI green