### PR TITLE
feat(metal): debug logging across rendering path, goffi v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.6] - 2026-02-18
+
+### Added
+
+- **Metal backend debug logging** — 23 new `hal.Logger()` calls across the critical
+  rendering path: `AcquireTexture`, `Submit`, `Present`, `BeginEncoding`/`EndEncoding`,
+  `CreateCommandEncoder`, `Wait`/`WaitIdle`, `Destroy`, and all three ObjC block callback
+  invocations (shared event, completion handler, frame completion). Enables diagnosis of
+  blank window issues on macOS (gogpu/gogpu#89) and validates goffi callback delivery
+  (go-webgpu/goffi#16). Metal backend now has ~38 log points, matching Vulkan/DX12 coverage.
+
+### Changed
+
+- **goffi** v0.3.8 → v0.3.9
+
 ## [0.16.5] - 2026-02-18
 
 ### Fixed
@@ -942,7 +957,9 @@ The following features are not yet fully implemented in the Vulkan backend:
 - **OpenGL ES backend** (`hal/gles/`) - Pure Go via goffi (~3.5K LOC)
 
 [#55]: https://github.com/gogpu/wgpu/issues/55
-[Unreleased]: https://github.com/gogpu/wgpu/compare/v0.16.4...HEAD
+[Unreleased]: https://github.com/gogpu/wgpu/compare/v0.16.6...HEAD
+[0.16.6]: https://github.com/gogpu/wgpu/compare/v0.16.5...v0.16.6
+[0.16.5]: https://github.com/gogpu/wgpu/compare/v0.16.4...v0.16.5
 [0.16.4]: https://github.com/gogpu/wgpu/compare/v0.16.3...v0.16.4
 [0.16.3]: https://github.com/gogpu/wgpu/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/gogpu/wgpu/compare/v0.16.1...v0.16.2

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,9 +19,13 @@
 
 ---
 
-## Current State: v0.16.5
+## Current State: v0.16.6
 
 ✅ **All 5 HAL backends complete** (~80K LOC, ~100K total):
+
+**New in v0.16.6:**
+- Metal backend debug logging — 23 new log points across rendering path, callbacks, and lifecycle (gogpu/gogpu#89, go-webgpu/goffi#16)
+- goffi v0.3.9
 
 **New in v0.16.5:**
 - Vulkan per-encoder command pools — dedicated VkCommandPool per encoder, eliminates VkCommandBuffer crash
@@ -105,7 +109,9 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| **v0.16.4** | 2026-02 | Timeline semaphore, FencePool, batch alloc, hot-path benchmarks |
+| **v0.16.6** | 2026-02 | Metal debug logging (23 log points), goffi v0.3.9 |
+| v0.16.5 | 2026-02 | Vulkan per-encoder command pools |
+| v0.16.4 | 2026-02 | Timeline semaphore, FencePool, batch alloc, hot-path benchmarks |
 | v0.16.3 | 2026-02 | Per-frame fence tracking, GLES VSync, WaitIdle interface |
 | v0.16.2 | 2026-02 | Metal autorelease pool LIFO fix (macOS Tahoe crash) |
 | v0.16.1 | 2026-02 | Vulkan framebuffer cache invalidation fix |

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/wgpu
 go 1.25
 
 require (
-	github.com/go-webgpu/goffi v0.3.8
+	github.com/go-webgpu/goffi v0.3.9
 	github.com/gogpu/gputypes v0.2.0
 	github.com/gogpu/naga v0.13.1
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.3.8 h1:Kzw7oP1XEjkv+6QvOIWwuNMfW3iOTPq0hQjr14YwVBM=
-github.com/go-webgpu/goffi v0.3.8/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc=
+github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.13.1 h1:lqv0uIp9dseio6Jzd/a8XvQH0/LWrCimlbVWWD+utEg=

--- a/hal/metal/adapter.go
+++ b/hal/metal/adapter.go
@@ -42,6 +42,11 @@ func (a *Adapter) Open(features gputypes.Features, limits gputypes.Limits) (hal.
 	// Back-reference so Device.WaitIdle can drain the frame semaphore.
 	device.queue = queue
 
+	hal.Logger().Debug("metal: adapter opened",
+		"maxFramesInFlight", maxFramesInFlight,
+		"blockSupport", symNSConcreteStackBlock != 0,
+	)
+
 	return hal.OpenDevice{
 		Device: device,
 		Queue:  queue,

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -720,6 +720,7 @@ func (d *Device) CreateCommandEncoder(desc *hal.CommandEncoderDescriptor) (hal.C
 	if desc != nil {
 		label = desc.Label
 	}
+	hal.Logger().Debug("metal: command encoder created", "label", label)
 	return &CommandEncoder{device: d, label: label}, nil
 }
 
@@ -804,6 +805,7 @@ func (d *Device) Wait(fence hal.Fence, value uint64, timeout time.Duration) (boo
 // Returns (result, error, true) if the event-driven path was used.
 // Returns (false, nil, false) if the path is unavailable and caller should fall back.
 func (d *Device) waitEventDriven(mtlFence *Fence, value uint64, timeout time.Duration) (bool, error, bool) {
+	hal.Logger().Debug("metal: Wait", "value", value, "timeout", timeout, "path", "event-driven")
 	listener := d.getOrCreateEventListener()
 	if listener == 0 {
 		return false, nil, false
@@ -847,6 +849,7 @@ func (d *Device) waitEventDriven(mtlFence *Fence, value uint64, timeout time.Dur
 // waitPolling waits for a fence using progressive backoff polling.
 // This is the fallback path when event-driven notification is unavailable.
 func (d *Device) waitPolling(mtlFence *Fence, value uint64, timeout time.Duration) (bool, error) {
+	hal.Logger().Debug("metal: Wait (polling)", "value", value, "timeout", timeout)
 	deadline := time.Now().Add(timeout)
 	spins := 0
 	for {
@@ -926,6 +929,7 @@ func (d *Device) DestroyRenderBundle(bundle hal.RenderBundle) {}
 // all in-flight slots are reclaimed. This prevents deadlocks when the caller
 // wants to submit new work after WaitIdle returns.
 func (d *Device) WaitIdle() error {
+	hal.Logger().Debug("metal: WaitIdle starting")
 	pool := NewAutoreleasePool()
 	defer pool.Drain()
 
@@ -960,11 +964,13 @@ func (d *Device) WaitIdle() error {
 		}
 	}
 
+	hal.Logger().Debug("metal: WaitIdle complete")
 	return nil
 }
 
 // Destroy releases the device and associated resources.
 func (d *Device) Destroy() {
+	hal.Logger().Debug("metal: device destroyed")
 	if d.eventListener != 0 {
 		Release(d.eventListener)
 		d.eventListener = 0

--- a/hal/metal/encoder.go
+++ b/hal/metal/encoder.go
@@ -54,6 +54,7 @@ func (e *CommandEncoder) BeginEncoding(label string) error {
 		Release(nsLabel)
 	}
 	pool.Drain()
+	hal.Logger().Debug("metal: encoding started", "label", label)
 	return nil
 }
 
@@ -65,6 +66,7 @@ func (e *CommandEncoder) EndEncoding() (hal.CommandBuffer, error) {
 	}
 	cb := &CommandBuffer{raw: e.cmdBuffer, device: e.device}
 	e.cmdBuffer = 0 // Recording state becomes false
+	hal.Logger().Debug("metal: encoding ended")
 	return cb, nil
 }
 
@@ -72,6 +74,7 @@ func (e *CommandEncoder) EndEncoding() (hal.CommandBuffer, error) {
 // After call, IsRecording() returns false.
 func (e *CommandEncoder) DiscardEncoding() {
 	if e.cmdBuffer != 0 {
+		hal.Logger().Debug("metal: encoding discarded")
 		Release(e.cmdBuffer)
 		e.cmdBuffer = 0 // Recording state becomes false
 	}

--- a/hal/metal/objc.go
+++ b/hal/metal/objc.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/go-webgpu/goffi/ffi"
 	"github.com/go-webgpu/goffi/types"
+	"github.com/gogpu/wgpu/hal"
 )
 
 // Objective-C runtime library handle and function symbols.
@@ -561,6 +562,8 @@ func getSharedEventBlockInvoke() uintptr {
 			// Offset: isa(8) + flags(4) + reserved(4) + invoke(8) + descriptor(8) = 32 bytes
 			blockID := *(*uint64)(unsafe.Pointer(blockPtr + 32)) //nolint:govet // Required for ObjC block ABI access
 
+			hal.Logger().Debug("metal: shared event notification fired", "blockID", blockID)
+
 			if entry, ok := blockRegistry.Load(blockID); ok {
 				e := entry.(*blockRegistryEntry)
 				select {
@@ -657,6 +660,8 @@ func getCompletedHandlerBlockInvoke() uintptr {
 			// Read blockID from the block literal at the fixed offset.
 			// Offset: isa(8) + flags(4) + reserved(4) + invoke(8) + descriptor(8) = 32 bytes
 			blockID := *(*uint64)(unsafe.Pointer(blockPtr + 32)) //nolint:govet // Required for ObjC block ABI access
+
+			hal.Logger().Debug("metal: completion handler fired", "blockID", blockID)
 
 			if val, ok := completedHandlerRegistry.LoadAndDelete(blockID); ok {
 				stagingBuf := val.(ID)
@@ -761,6 +766,8 @@ func getFrameCompletionBlockInvoke() uintptr {
 			// Read blockID from the block literal at the fixed offset.
 			// Offset: isa(8) + flags(4) + reserved(4) + invoke(8) + descriptor(8) = 32 bytes
 			blockID := *(*uint64)(unsafe.Pointer(blockPtr + 32)) //nolint:govet // Required for ObjC block ABI access
+
+			hal.Logger().Debug("metal: frame completion fired", "blockID", blockID)
 
 			if val, ok := frameCompletionRegistry.LoadAndDelete(blockID); ok {
 				ch := val.(chan<- struct{})


### PR DESCRIPTION
## Summary

- **23 new `hal.Logger()` calls** across 6 Metal backend files covering the critical rendering path
- **goffi** v0.3.8 → v0.3.9

### Logging coverage added

| File | Calls | Key points |
|------|-------|------------|
| `surface.go` | +5 | AcquireTexture success/fail, Unconfigure, Destroy |
| `queue.go` | +5 | Submit, presentDrawable, frame completion, Present |
| `objc.go` | +3 | All 3 ObjC block callback invocations (goffi#16 diagnosis) |
| `device.go` | +6 | CreateCommandEncoder, Wait, WaitIdle, Destroy |
| `encoder.go` | +3 | BeginEncoding, EndEncoding, DiscardEncoding |
| `adapter.go` | +1 | Open (maxFramesInFlight, blockSupport) |

Metal backend now has ~38 log points, matching Vulkan/DX12 coverage.

### Motivation

- **gogpu/gogpu#89** — blank window on macOS Tahoe M2 Max, no way to diagnose without logging
- **go-webgpu/goffi#16** — Metal callbacks via `ffi.NewCallback` may silently fail on C-threads; logging inside callback invocations will confirm/deny

No logic changes, no API changes.
