### PR TITLE
chore: update naga v0.14.0 (v0.16.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.7] - 2026-02-21
+
+### Dependencies
+
+- naga v0.13.1 → v0.14.0 (Essential 15/15 reference shaders, 48 type aliases, 25 math ops, 20+ SPIR-V fixes)
+
 ## [0.16.6] - 2026-02-18
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25
 require (
 	github.com/go-webgpu/goffi v0.3.9
 	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/naga v0.13.1
+	github.com/gogpu/naga v0.14.0
 	golang.org/x/sys v0.41.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc
 github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.13.1 h1:lqv0uIp9dseio6Jzd/a8XvQH0/LWrCimlbVWWD+utEg=
-github.com/gogpu/naga v0.13.1/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.14.0 h1:JfUd608ULl7ey6t/xBt0p41/HXgYLkKESYv2YnbezZY=
+github.com/gogpu/naga v0.14.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

- Update naga v0.13.1 → v0.14.0 (Essential 15/15 reference shaders, 48 type aliases, 25 math ops, 20+ SPIR-V fixes)

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues
