### PR TITLE
chore: update naga v0.14.0 → v0.14.1 (v0.16.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.9] - 2026-02-21
+
+### Dependencies
+
+- naga v0.14.0 → v0.14.1 (HLSL row_major matrices for DX12, GLSL namedExpressions leak fix for GLES)
+
 ## [0.16.8] - 2026-02-21
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25
 require (
 	github.com/go-webgpu/goffi v0.3.9
 	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/naga v0.14.0
+	github.com/gogpu/naga v0.14.1
 	golang.org/x/sys v0.41.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,7 @@ github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.14.0 h1:JfUd608ULl7ey6t/xBt0p41/HXgYLkKESYv2YnbezZY=
 github.com/gogpu/naga v0.14.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.14.1 h1:V4zwc2NPUrsllnwD5hqzgZYbjWZO4OOR3NYkpbQPNx0=
+github.com/gogpu/naga v0.14.1/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

- Update naga v0.14.0 → v0.14.1 (HLSL row_major matrices for DX12, GLSL namedExpressions leak fix for GLES)

## Test plan

- [x] All wgpu tests pass (`go test ./...`)
- [x] golangci-lint clean (0 issues)
- [x] DX12, GLES, Vulkan rendering verified with gg gogpu_integration example
