### PR TITLE
fix: pre-acquire semaphore wait for Vulkan swapchain (VK-IMPL-004)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.10] - 2026-02-22
+
+### Fixed
+
+- **Vulkan: pre-acquire semaphore wait** (VK-IMPL-004) — Acquire semaphores are rotated across
+  frames, but nothing guaranteed the GPU had consumed the previous wait before reuse, violating
+  `VUID-vkAcquireNextImageKHR-semaphore-01779` on some drivers. Now tracks the submission fence
+  value per acquire semaphore and waits before reuse, matching Rust wgpu's
+  `previously_used_submission_index` pattern. Also adds binary fence pool tracking to
+  `SubmitForPresent` which previously submitted with no fence at all.
+  ([gogpu#98](https://github.com/gogpu/gogpu/issues/98))
+
+### Dependencies
+
+- naga v0.14.1 → v0.14.2 (GLSL GL_ARB_separate_shader_objects fix, golden snapshot tests)
+
 ## [0.16.9] - 2026-02-21
 
 ### Dependencies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,9 +19,13 @@
 
 ---
 
-## Current State: v0.16.6
+## Current State: v0.16.10
 
 ✅ **All 5 HAL backends complete** (~80K LOC, ~100K total):
+
+**New in v0.16.10:**
+- Vulkan pre-acquire semaphore wait (VK-IMPL-004) — fixes `VUID-vkAcquireNextImageKHR-semaphore-01779` (gogpu#98)
+- naga v0.14.2 (GLSL GL_ARB_separate_shader_objects fix, golden snapshot tests)
 
 **New in v0.16.6:**
 - Metal backend debug logging — 23 new log points across rendering path, callbacks, and lifecycle (gogpu/gogpu#89, go-webgpu/goffi#16)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25
 require (
 	github.com/go-webgpu/goffi v0.3.9
 	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/naga v0.14.1
+	github.com/gogpu/naga v0.14.2
 	golang.org/x/sys v0.41.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,9 +2,7 @@ github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc
 github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.14.0 h1:JfUd608ULl7ey6t/xBt0p41/HXgYLkKESYv2YnbezZY=
-github.com/gogpu/naga v0.14.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
-github.com/gogpu/naga v0.14.1 h1:V4zwc2NPUrsllnwD5hqzgZYbjWZO4OOR3NYkpbQPNx0=
-github.com/gogpu/naga v0.14.1/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.14.2 h1:jja1gsYtJB+2gpcAXU5HYZ9OLA/sTrRMbM1dK+AIQL8=
+github.com/gogpu/naga v0.14.2/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

- **Vulkan: pre-acquire semaphore wait** (VK-IMPL-004) — acquire semaphores are rotated across frames, but nothing guaranteed the GPU had consumed the previous wait before reuse, violating `VUID-vkAcquireNextImageKHR-semaphore-01779`. Now tracks per-semaphore submission fence value and waits before reuse, matching Rust wgpu's `previously_used_submission_index` pattern.
- **SubmitForPresent binary fence tracking** — previously submitted with `vk.Fence(0)` (no tracking at all). Now uses fence pool in the non-timeline path.
- **naga** v0.14.1 → v0.14.2

Closes gogpu/gogpu#98

## Test plan

- [ ] CI passes (build + lint + tests)
- [ ] `go build ./...` / `go test ./...` pass locally
- [ ] No new lint issues (`golangci-lint run`)
- [ ] Manual test: `gg/examples/gogpu_integration` runs without validation errors
