### PR TITLE
fix: add Vulkan debug object naming (VK-VAL-002, v0.16.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.12] - 2026-02-23
+
+### Fixed
+
+- **Vulkan: debug object naming** (VK-VAL-002) — added `setObjectName` helper that calls
+  `vkSetDebugUtilsObjectNameEXT` after every Vulkan object creation. Labels buffers, textures,
+  pipelines, render passes, framebuffers, descriptor pools, swapchain images, semaphores, and
+  more with human-readable names. Eliminates false-positive `VUID-VkDebugUtilsObjectNameInfoEXT-objectType-02590`
+  validation errors on NVIDIA where the validation layer's handle tracking lost sync with packed
+  non-dispatchable handles. No-op when `VK_EXT_debug_utils` is unavailable. Resources display
+  named labels in RenderDoc/Nsight captures.
+  ([gogpu#98](https://github.com/gogpu/gogpu/issues/98))
+
 ## [0.16.11] - 2026-02-23
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,9 +19,12 @@
 
 ---
 
-## Current State: v0.16.11
+## Current State: v0.16.12
 
 ✅ **All 5 HAL backends complete** (~80K LOC, ~100K total):
+
+**New in v0.16.12:**
+- Vulkan debug object naming (VK-VAL-002) — labels every Vulkan object via `vkSetDebugUtilsObjectNameEXT`, eliminates false-positive validation errors on NVIDIA (gogpu#98)
 
 **New in v0.16.11:**
 - Vulkan zero-extent swapchain fix (VK-VAL-001) — config-primary extent, unconditional viewport/scissor (gogpu#98)
@@ -117,7 +120,10 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| **v0.16.6** | 2026-02 | Metal debug logging (23 log points), goffi v0.3.9 |
+| **v0.16.12** | 2026-02 | Vulkan debug object naming (VK-VAL-002, gogpu#98) |
+| v0.16.11 | 2026-02 | Vulkan zero-extent swapchain fix (VK-VAL-001, gogpu#98) |
+| v0.16.10 | 2026-02 | Vulkan pre-acquire semaphore wait (VK-IMPL-004) |
+| v0.16.6 | 2026-02 | Metal debug logging (23 log points), goffi v0.3.9 |
 | v0.16.5 | 2026-02 | Vulkan per-encoder command pools |
 | v0.16.4 | 2026-02 | Timeline semaphore, FencePool, batch alloc, hot-path benchmarks |
 | v0.16.3 | 2026-02 | Per-frame fence tracking, GLES VSync, WaitIdle interface |

--- a/hal/vulkan/bundle.go
+++ b/hal/vulkan/bundle.go
@@ -161,6 +161,8 @@ func (d *Device) CreateRenderBundleEncoder(_ *hal.RenderBundleEncoderDescriptor)
 		return nil, fmt.Errorf("vulkan: vkCreateCommandPool (bundle) failed: %d", result)
 	}
 
+	d.setObjectName(vk.ObjectTypeCommandPool, uint64(pool), "BundleCommandPool")
+
 	// Allocate a secondary command buffer from the dedicated pool.
 	allocInfo := vk.CommandBufferAllocateInfo{
 		SType:              vk.StructureTypeCommandBufferAllocateInfo,

--- a/hal/vulkan/pipeline.go
+++ b/hal/vulkan/pipeline.go
@@ -331,11 +331,17 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 		return nil, hal.ErrDriverBug
 	}
 
-	return &RenderPipeline{
+	rp := &RenderPipeline{
 		handle: pipeline,
 		layout: pipelineLayout,
 		device: d,
-	}, nil
+	}
+	if desc.Label != "" {
+		d.setObjectName(vk.ObjectTypePipeline, uint64(pipeline), desc.Label)
+	} else {
+		d.setObjectName(vk.ObjectTypePipeline, uint64(pipeline), "RenderPipeline")
+	}
+	return rp, nil
 }
 
 // DestroyRenderPipeline destroys a render pipeline.
@@ -410,11 +416,17 @@ func (d *Device) CreateComputePipeline(desc *hal.ComputePipelineDescriptor) (hal
 		return nil, hal.ErrDriverBug
 	}
 
-	return &ComputePipeline{
+	cp := &ComputePipeline{
 		handle: pipeline,
 		layout: pipelineLayout,
 		device: d,
-	}, nil
+	}
+	if desc.Label != "" {
+		d.setObjectName(vk.ObjectTypePipeline, uint64(pipeline), desc.Label)
+	} else {
+		d.setObjectName(vk.ObjectTypePipeline, uint64(pipeline), "ComputePipeline")
+	}
+	return cp, nil
 }
 
 // DestroyComputePipeline destroys a compute pipeline.

--- a/hal/vulkan/query.go
+++ b/hal/vulkan/query.go
@@ -58,12 +58,18 @@ func (d *Device) CreateQuerySet(desc *hal.QuerySetDescriptor) (hal.QuerySet, err
 	// Reset the query pool so it can be used immediately.
 	d.cmds.ResetQueryPool(d.handle, pool, 0, desc.Count)
 
-	return &QuerySet{
+	qs := &QuerySet{
 		pool:      pool,
 		device:    d,
 		queryType: desc.Type,
 		count:     desc.Count,
-	}, nil
+	}
+	if desc.Label != "" {
+		d.setObjectName(vk.ObjectTypeQueryPool, uint64(pool), desc.Label)
+	} else {
+		d.setObjectName(vk.ObjectTypeQueryPool, uint64(pool), "QueryPool")
+	}
+	return qs, nil
 }
 
 // DestroyQuerySet destroys a Vulkan query set.

--- a/hal/vulkan/vk/commands.go
+++ b/hal/vulkan/vk/commands.go
@@ -255,6 +255,9 @@ func (c *Commands) LoadDevice(device Device) error {
 	c.acquireNextImageKHR = GetDeviceProcAddr(device, "vkAcquireNextImageKHR")
 	c.queuePresentKHR = GetDeviceProcAddr(device, "vkQueuePresentKHR")
 
+	// VK_EXT_debug_utils (optional — loaded from device for object naming)
+	c.setDebugUtilsObjectNameEXT = GetDeviceProcAddr(device, "vkSetDebugUtilsObjectNameEXT")
+
 	// Verify critical functions loaded
 	if c.destroyDevice == nil || c.getDeviceQueue == nil || c.queueSubmit == nil {
 		return fmt.Errorf("failed to load critical device functions")
@@ -275,6 +278,13 @@ func (c *Commands) HasTimelineSemaphore() bool {
 // This is a Vulkan 1.1 core function used to query extended feature support via PNext chains.
 func (c *Commands) HasPhysicalDeviceFeatures2() bool {
 	return c.getPhysicalDeviceFeatures2 != nil
+}
+
+// HasDebugUtils returns true if vkSetDebugUtilsObjectNameEXT is available.
+// When true, Vulkan objects can be labeled with human-readable names for
+// validation layer messages and GPU debugging tools (RenderDoc, NSight).
+func (c *Commands) HasDebugUtils() bool {
+	return c.setDebugUtilsObjectNameEXT != nil
 }
 
 // DebugFunctionPointer returns the address of the specified Vulkan function.


### PR DESCRIPTION
## Summary

Label every Vulkan object via `vkSetDebugUtilsObjectNameEXT` after creation. Eliminates false-positive `VUID-VkDebugUtilsObjectNameInfoEXT-objectType-02590` validation errors on NVIDIA where the validation layer's handle tracking lost sync with packed non-dispatchable handles.

### Changes (9 files, +196/-26)

- **debug.go** — `setObjectName()` helper on Device (no-op when VK_EXT_debug_utils unavailable)
- **vk/commands.go** — Load `vkSetDebugUtilsObjectNameEXT` proc, `HasDebugUtils()` check
- **device.go** — Name Buffer, Texture, TextureView, Sampler, BindGroupLayout, PipelineLayout, ShaderModule, CommandPool, Fence
- **pipeline.go** — Name RenderPipeline, ComputePipeline
- **swapchain.go** — Name Swapchain, SwapchainImage, SwapchainView, AcquireSemaphore, PresentSemaphore
- **descriptor.go** — Name DescriptorPool
- **renderpass.go** — Name RenderPass, Framebuffer
- **bundle.go** — Name BundleCommandPool
- **query.go** — Name QueryPool

Uses `desc.Label` when available, falls back to type-based names. Indexed objects use `Type(N)` format.

Reference: Rust wgpu-hal `set_object_name()` (device.rs:36-74, 15+ call sites).

Reported by @qq1792569310 on NVIDIA RTX 3070 (driver 581.80) in gogpu#98.

## Test plan

- [x] `GOWORK=off go build ./...` clean
- [x] `GOWORK=off go test ./...` all pass
- [x] `golangci-lint run` 0 issues
- [ ] CI green