### PR TITLE
fix: load VK_EXT_debug_utils via GetInstanceProcAddr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.13] - 2026-02-24
+
+### Fixed
+
+- **Vulkan: load VK_EXT_debug_utils via GetInstanceProcAddr** — `vkSetDebugUtilsObjectNameEXT`
+  was loaded via `GetDeviceProcAddr`, which bypasses the validation layer's handle wrapping on
+  NVIDIA drivers, causing `VUID-VkDebugUtilsObjectNameInfoEXT-objectType-02590` ("Invalid
+  VkDescriptorPool Object") errors. Now loaded via `GetInstanceProcAddr` as required for instance
+  extensions. Also loads `vkCreateDebugUtilsMessengerEXT` and `vkDestroyDebugUtilsMessengerEXT`
+  which were previously missing — debug messenger callback now works correctly.
+  ([gogpu#98](https://github.com/gogpu/gogpu/issues/98))
+
 ## [0.16.12] - 2026-02-23
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,9 +19,13 @@
 
 ---
 
-## Current State: v0.16.12
+## Current State: v0.16.13
 
 ✅ **All 5 HAL backends complete** (~80K LOC, ~100K total):
+
+**New in v0.16.13:**
+- Vulkan: load VK_EXT_debug_utils via `GetInstanceProcAddr` — fixes "Invalid VkDescriptorPool" validation errors on NVIDIA (gogpu#98)
+- Debug messenger callback now works (was missing function pointer loading)
 
 **New in v0.16.12:**
 - Vulkan debug object naming (VK-VAL-002) — labels every Vulkan object via `vkSetDebugUtilsObjectNameEXT`, eliminates false-positive validation errors on NVIDIA (gogpu#98)
@@ -120,7 +124,8 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| **v0.16.12** | 2026-02 | Vulkan debug object naming (VK-VAL-002, gogpu#98) |
+| **v0.16.13** | 2026-02 | Vulkan: debug_utils via GetInstanceProcAddr (gogpu#98) |
+| v0.16.12 | 2026-02 | Vulkan debug object naming (VK-VAL-002, gogpu#98) |
 | v0.16.11 | 2026-02 | Vulkan zero-extent swapchain fix (VK-VAL-001, gogpu#98) |
 | v0.16.10 | 2026-02 | Vulkan pre-acquire semaphore wait (VK-IMPL-004) |
 | v0.16.6 | 2026-02 | Metal debug logging (23 log points), goffi v0.3.9 |

--- a/hal/vulkan/vk/commands.go
+++ b/hal/vulkan/vk/commands.go
@@ -104,6 +104,14 @@ func (c *Commands) LoadInstance(instance Instance) error {
 	c.getPhysicalDeviceFeatures2 = GetInstanceProcAddr(instance, "vkGetPhysicalDeviceFeatures2")
 	c.getPhysicalDeviceProperties2 = GetInstanceProcAddr(instance, "vkGetPhysicalDeviceProperties2")
 
+	// VK_EXT_debug_utils (instance extension — MUST use GetInstanceProcAddr).
+	// Loading via GetDeviceProcAddr bypasses the validation layer's handle
+	// wrapping on NVIDIA drivers, causing "Invalid VkDescriptorPool" errors.
+	// See: https://github.com/gogpu/gogpu/issues/98
+	c.setDebugUtilsObjectNameEXT = GetInstanceProcAddr(instance, "vkSetDebugUtilsObjectNameEXT")
+	c.createDebugUtilsMessengerEXT = GetInstanceProcAddr(instance, "vkCreateDebugUtilsMessengerEXT")
+	c.destroyDebugUtilsMessengerEXT = GetInstanceProcAddr(instance, "vkDestroyDebugUtilsMessengerEXT")
+
 	// Verify critical functions loaded
 	if c.destroyInstance == nil || c.enumeratePhysicalDevices == nil || c.createDevice == nil {
 		return fmt.Errorf("failed to load critical instance functions")
@@ -254,9 +262,6 @@ func (c *Commands) LoadDevice(device Device) error {
 	c.getSwapchainImagesKHR = GetDeviceProcAddr(device, "vkGetSwapchainImagesKHR")
 	c.acquireNextImageKHR = GetDeviceProcAddr(device, "vkAcquireNextImageKHR")
 	c.queuePresentKHR = GetDeviceProcAddr(device, "vkQueuePresentKHR")
-
-	// VK_EXT_debug_utils (optional — loaded from device for object naming)
-	c.setDebugUtilsObjectNameEXT = GetDeviceProcAddr(device, "vkSetDebugUtilsObjectNameEXT")
 
 	// Verify critical functions loaded
 	if c.destroyDevice == nil || c.getDeviceQueue == nil || c.queueSubmit == nil {


### PR DESCRIPTION
## Summary

- **Load VK_EXT_debug_utils functions via `GetInstanceProcAddr` instead of `GetDeviceProcAddr`**
- Fixes "Invalid VkDescriptorPool Object" validation error on NVIDIA (gogpu#98)
- Also loads `vkCreateDebugUtilsMessengerEXT` and `vkDestroyDebugUtilsMessengerEXT` which were previously missing

## Root Cause

`VK_EXT_debug_utils` is an **instance extension**. Loading `vkSetDebugUtilsObjectNameEXT` via `GetDeviceProcAddr` bypasses the Vulkan loader's layer dispatch on NVIDIA drivers — the validation layer cannot unwrap non-dispatchable handles (DescriptorPool, Buffer, etc.), causing VUID-02590 errors.

Additionally, `vkCreateDebugUtilsMessengerEXT` and `vkDestroyDebugUtilsMessengerEXT` were never loaded, so the debug messenger callback was silently not working (validation errors were only visible via stderr default output).

**Reference:** [NVIDIA Developer Forums — vkSetDebugUtilsObjectNameEXT crash with vkGetDeviceProcAddr](https://forums.developer.nvidia.com/t/vksetdebugutilsobjectnameext-causes-a-crash-when-attempting-to-set-a-name-for-vkphysicaldevice/79517)

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — 28 packages OK
- [x] `golangci-lint run` — 0 issues
- [x] `go fmt` — clean
- [x] Downstream build (gogpu) — clean
- [ ] Runtime verification on NVIDIA needed (reporter: @qq1792569310)
