### PR TITLE
fix: null surface handle guard, update naga v0.14.3 (v0.16.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.14] - 2026-02-25
+
+### Fixed
+
+- **Vulkan: null surface handle guard** — `EnumerateAdapters`, `SurfaceCapabilities`, and
+  `createSwapchain` now check for null `VkSurfaceKHR` handle before calling Vulkan surface
+  functions. Prevents SIGSEGV on Linux when surface creation fails (e.g., X11 connection issues).
+  ([gogpu#106](https://github.com/gogpu/gogpu/issues/106))
+
+### Changed
+
+- **Dependencies:** naga v0.14.2 → v0.14.3 (5 SPIR-V compute shader bug fixes)
+
 ## [0.16.13] - 2026-02-24
 
 ### Fixed
@@ -1043,7 +1056,15 @@ The following features are not yet fully implemented in the Vulkan backend:
 - **OpenGL ES backend** (`hal/gles/`) - Pure Go via goffi (~3.5K LOC)
 
 [#55]: https://github.com/gogpu/wgpu/issues/55
-[Unreleased]: https://github.com/gogpu/wgpu/compare/v0.16.6...HEAD
+[Unreleased]: https://github.com/gogpu/wgpu/compare/v0.16.14...HEAD
+[0.16.14]: https://github.com/gogpu/wgpu/compare/v0.16.13...v0.16.14
+[0.16.13]: https://github.com/gogpu/wgpu/compare/v0.16.12...v0.16.13
+[0.16.12]: https://github.com/gogpu/wgpu/compare/v0.16.11...v0.16.12
+[0.16.11]: https://github.com/gogpu/wgpu/compare/v0.16.10...v0.16.11
+[0.16.10]: https://github.com/gogpu/wgpu/compare/v0.16.9...v0.16.10
+[0.16.9]: https://github.com/gogpu/wgpu/compare/v0.16.8...v0.16.9
+[0.16.8]: https://github.com/gogpu/wgpu/compare/v0.16.7...v0.16.8
+[0.16.7]: https://github.com/gogpu/wgpu/compare/v0.16.6...v0.16.7
 [0.16.6]: https://github.com/gogpu/wgpu/compare/v0.16.5...v0.16.6
 [0.16.5]: https://github.com/gogpu/wgpu/compare/v0.16.4...v0.16.5
 [0.16.4]: https://github.com/gogpu/wgpu/compare/v0.16.3...v0.16.4

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25
 require (
 	github.com/go-webgpu/goffi v0.3.9
 	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/naga v0.14.2
+	github.com/gogpu/naga v0.14.3
 	golang.org/x/sys v0.41.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc
 github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.14.2 h1:jja1gsYtJB+2gpcAXU5HYZ9OLA/sTrRMbM1dK+AIQL8=
-github.com/gogpu/naga v0.14.2/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.14.3 h1:N/o/2vT+EG/1m7TZEAXjANPbIQaqP3rDAZxARZ9bJTw=
+github.com/gogpu/naga v0.14.3/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/hal/vulkan/adapter.go
+++ b/hal/vulkan/adapter.go
@@ -203,7 +203,7 @@ func (a *Adapter) TextureFormatCapabilities(format gputypes.TextureFormat) hal.T
 // SurfaceCapabilities returns surface capabilities.
 func (a *Adapter) SurfaceCapabilities(surface hal.Surface) *hal.SurfaceCapabilities {
 	vkSurface, ok := surface.(*Surface)
-	if !ok || vkSurface == nil {
+	if !ok || vkSurface == nil || vkSurface.handle == 0 {
 		return nil
 	}
 

--- a/hal/vulkan/api.go
+++ b/hal/vulkan/api.go
@@ -171,7 +171,7 @@ func (i *Instance) EnumerateAdapters(surfaceHint hal.Surface) []hal.ExposedAdapt
 
 		// Check surface support if surface hint provided
 		if surfaceHint != nil {
-			if s, ok := surfaceHint.(*Surface); ok {
+			if s, ok := surfaceHint.(*Surface); ok && s.handle != 0 {
 				var supported vk.Bool32
 				i.cmds.GetPhysicalDeviceSurfaceSupportKHR(device, 0, s.handle, &supported)
 				if supported == 0 {

--- a/hal/vulkan/swapchain.go
+++ b/hal/vulkan/swapchain.go
@@ -60,6 +60,10 @@ func (t *SwapchainTexture) NativeHandle() uintptr {
 //
 //nolint:maintidx // Vulkan swapchain setup requires many sequential steps
 func (s *Surface) createSwapchain(device *Device, config *hal.SurfaceConfiguration) error {
+	if s.handle == 0 {
+		return fmt.Errorf("vulkan: cannot create swapchain for null surface")
+	}
+
 	// Get surface capabilities
 	var capabilities vk.SurfaceCapabilitiesKHR
 	result := vkGetPhysicalDeviceSurfaceCapabilitiesKHR(s.instance, device.physicalDevice, s.handle, &capabilities)


### PR DESCRIPTION
## Summary

- Vulkan: null `VkSurfaceKHR` handle guard in `EnumerateAdapters`, `SurfaceCapabilities`, `createSwapchain` — prevents SIGSEGV on Linux when surface creation fails ([gogpu#106](https://github.com/gogpu/gogpu/issues/106))
- Dependencies: naga v0.14.2 → v0.14.3 (5 SPIR-V compute shader bug fixes)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 14 packages)
- [x] `golangci-lint run` — 0 issues
- [x] `go fmt` clean
- [ ] CI green
