### PR TITLE
fix: remove software backend build tags, always compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.15] - 2026-02-25
+
+### Changed
+
+- **Software backend: always compiled** — removed `//go:build software` build tags from all 34 files
+  in `hal/software/`, `hal/software/raster/`, and `hal/software/shader/`. The software backend is now
+  always available without `-tags software`. Pure Go, zero system dependencies — ideal for CI/CD,
+  headless rendering, and fallback when no GPU is available.
+  ([gogpu#106](https://github.com/gogpu/gogpu/issues/106))
+
+### Fixed
+
+- **Software backend: nestif complexity** — extracted `clearDepthStencilAttachment()` helper in
+  `RenderPassEncoder.End()` to reduce nesting depth (pre-existing issue exposed by build tag removal).
+
 ## [0.16.14] - 2026-02-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -225,9 +225,12 @@ Cross-platform GPU access via OpenGL ES 3.0+:
 
 ### Software Backend
 
-Full-featured CPU rasterizer for headless rendering:
+Full-featured CPU rasterizer for headless rendering. Always compiled — no build tags or GPU hardware required.
 
 ```go
+// Software backend auto-registers via init().
+// No explicit import needed when using hal/allbackends.
+// For standalone usage:
 import _ "github.com/gogpu/wgpu/hal/software"
 
 // Use cases:
@@ -235,6 +238,7 @@ import _ "github.com/gogpu/wgpu/hal/software"
 // - Server-side image generation
 // - Reference implementation
 // - Fallback when GPU unavailable
+// - Embedded systems without GPU
 ```
 
 **Rasterization Features:**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,9 +19,16 @@
 
 ---
 
-## Current State: v0.16.13
+## Current State: v0.16.15
 
 ✅ **All 5 HAL backends complete** (~80K LOC, ~100K total):
+
+**New in v0.16.15:**
+- Software backend always compiled — removed `//go:build software` from all 34 files. No build tags required, always available as fallback (gogpu#106)
+
+**New in v0.16.14:**
+- Vulkan null surface handle guard — prevents SIGSEGV on Linux when surface creation fails (gogpu#106)
+- naga v0.14.3 (5 SPIR-V compute shader bug fixes)
 
 **New in v0.16.13:**
 - Vulkan: load VK_EXT_debug_utils via `GetInstanceProcAddr` — fixes "Invalid VkDescriptorPool" validation errors on NVIDIA (gogpu#98)
@@ -124,7 +131,9 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| **v0.16.13** | 2026-02 | Vulkan: debug_utils via GetInstanceProcAddr (gogpu#98) |
+| **v0.16.15** | 2026-02 | Software backend always compiled, no build tags (gogpu#106) |
+| v0.16.14 | 2026-02 | Vulkan null surface handle guard (gogpu#106), naga v0.14.3 |
+| v0.16.13 | 2026-02 | Vulkan: debug_utils via GetInstanceProcAddr (gogpu#98) |
 | v0.16.12 | 2026-02 | Vulkan debug object naming (VK-VAL-002, gogpu#98) |
 | v0.16.11 | 2026-02 | Vulkan zero-extent swapchain fix (VK-VAL-001, gogpu#98) |
 | v0.16.10 | 2026-02 | Vulkan pre-acquire semaphore wait (VK-IMPL-004) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,10 +97,12 @@ Pure Go OpenGL ES 3.0+ implementation.
 
 ### `hal/software/` — Software Backend
 
-CPU-based rasterizer for testing and fallback.
+CPU-based rasterizer. Always compiled (no build tags required). Pure Go, zero system dependencies.
 
 - `raster/` — Triangle rasterization, blending, depth/stencil, tiling
 - `shader/` — Software shader execution (callback-based)
+
+Use cases: headless rendering (servers, CI/CD), testing without GPU, embedded systems, fallback when no GPU available.
 
 ### `hal/noop/` — No-op Backend
 

--- a/hal/software/adapter.go
+++ b/hal/software/adapter.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package software
 
 import (

--- a/hal/software/api.go
+++ b/hal/software/api.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package software
 
 import (

--- a/hal/software/command.go
+++ b/hal/software/command.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package software
 
 import (
@@ -187,18 +185,21 @@ func (r *RenderPassEncoder) End() {
 	}
 
 	// Depth/stencil attachment handling (simplified - just clear if needed)
-	if r.desc.DepthStencilAttachment != nil {
-		if r.desc.DepthStencilAttachment.DepthLoadOp == gputypes.LoadOpClear {
-			if view, ok := r.desc.DepthStencilAttachment.View.(*TextureView); ok {
-				if view.texture != nil {
-					// Clear depth to clearValue (as grayscale for simplicity)
-					val := r.desc.DepthStencilAttachment.DepthClearValue
-					color := gputypes.Color{R: float64(val), G: float64(val), B: float64(val), A: 1.0}
-					view.texture.Clear(color)
-				}
-			}
-		}
+	r.clearDepthStencilAttachment()
+}
+
+// clearDepthStencilAttachment clears the depth/stencil attachment if present and LoadOp is Clear.
+func (r *RenderPassEncoder) clearDepthStencilAttachment() {
+	ds := r.desc.DepthStencilAttachment
+	if ds == nil || ds.DepthLoadOp != gputypes.LoadOpClear {
+		return
 	}
+	view, ok := ds.View.(*TextureView)
+	if !ok || view.texture == nil {
+		return
+	}
+	val := ds.DepthClearValue
+	view.texture.Clear(gputypes.Color{R: float64(val), G: float64(val), B: float64(val), A: 1.0})
 }
 
 // SetPipeline is a no-op.

--- a/hal/software/device.go
+++ b/hal/software/device.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package software
 
 import (

--- a/hal/software/doc.go
+++ b/hal/software/doc.go
@@ -1,5 +1,3 @@
-//go:build software
-
 // Package software provides a CPU-based software rendering backend.
 //
 // Status: IMPLEMENTED (Phase 1 - Headless Rendering)
@@ -28,7 +26,7 @@
 //   - No rasterization yet (draw calls are no-op - Phase 2)
 //   - No shader execution (basic resources only)
 //
-// Build tag: -tags software
+// Always compiled (no build tags required).
 //
 // Example:
 //

--- a/hal/software/init.go
+++ b/hal/software/init.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package software
 
 import "github.com/gogpu/wgpu/hal"

--- a/hal/software/queue.go
+++ b/hal/software/queue.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package software
 
 import (

--- a/hal/software/raster/blend.go
+++ b/hal/software/raster/blend.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 // BlendFactor specifies the blend factor for source or destination color.

--- a/hal/software/raster/blend_test.go
+++ b/hal/software/raster/blend_test.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/clip.go
+++ b/hal/software/raster/clip.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 // ClipPlane represents a clipping plane in homogeneous clip space.

--- a/hal/software/raster/clip_test.go
+++ b/hal/software/raster/clip_test.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/cull.go
+++ b/hal/software/raster/cull.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/depth.go
+++ b/hal/software/raster/depth.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/doc.go
+++ b/hal/software/raster/doc.go
@@ -1,5 +1,3 @@
-//go:build software
-
 // Package raster provides CPU-based triangle rasterization for the software backend.
 //
 // The raster package implements the core rendering pipeline using the Edge Function

--- a/hal/software/raster/incremental.go
+++ b/hal/software/raster/incremental.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 // IncrementalEdge optimizes edge function evaluation by using incremental

--- a/hal/software/raster/incremental_test.go
+++ b/hal/software/raster/incremental_test.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/interpolate.go
+++ b/hal/software/raster/interpolate.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 // InterpolateFloat32 interpolates a single float32 attribute with perspective correction.

--- a/hal/software/raster/interpolate_test.go
+++ b/hal/software/raster/interpolate_test.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/parallel.go
+++ b/hal/software/raster/parallel.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/parallel_test.go
+++ b/hal/software/raster/parallel_test.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/pipeline.go
+++ b/hal/software/raster/pipeline.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/raster_test.go
+++ b/hal/software/raster/raster_test.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/stencil.go
+++ b/hal/software/raster/stencil.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/stencil_test.go
+++ b/hal/software/raster/stencil_test.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/tile.go
+++ b/hal/software/raster/tile.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 // TileSize is the size of each tile in pixels (8x8).

--- a/hal/software/raster/tile_test.go
+++ b/hal/software/raster/tile_test.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/triangle.go
+++ b/hal/software/raster/triangle.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 import (

--- a/hal/software/raster/types.go
+++ b/hal/software/raster/types.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package raster
 
 // ClipSpaceVertex is the output of vertex shader processing.

--- a/hal/software/resource.go
+++ b/hal/software/resource.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package software
 
 import (

--- a/hal/software/shader/builtin.go
+++ b/hal/software/shader/builtin.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package shader
 
 import "github.com/gogpu/wgpu/hal/software/raster"

--- a/hal/software/shader/callback.go
+++ b/hal/software/shader/callback.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package shader
 
 import "github.com/gogpu/wgpu/hal/software/raster"

--- a/hal/software/shader/doc.go
+++ b/hal/software/shader/doc.go
@@ -1,5 +1,3 @@
-//go:build software
-
 // Package shader provides callback-based shader execution for the software backend.
 //
 // Since there is no SPIR-V interpreter in Go, we use callback functions to define

--- a/hal/software/shader/shader_test.go
+++ b/hal/software/shader/shader_test.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package shader
 
 import (

--- a/hal/software/software_test.go
+++ b/hal/software/software_test.go
@@ -1,5 +1,3 @@
-//go:build software
-
 package software
 
 import (


### PR DESCRIPTION
## Summary

- Remove `//go:build software` from all 34 files in `hal/software/`, `hal/software/raster/`, `hal/software/shader/`
- Software backend is now always compiled — no build tags required
- Extract `clearDepthStencilAttachment()` helper to fix pre-existing nestif lint issue

Pure Go, zero system dependencies. Always available as fallback for CI/CD, headless rendering, and systems without GPU.

Fixes gogpu/gogpu#106
