### PR TITLE
fix: load platform Vulkan surface creation functions (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.17] - 2026-02-26
+
+### Fixed
+
+- **Vulkan: load platform surface creation functions** — `vkCreateXlibSurfaceKHR`,
+  `vkCreateXcbSurfaceKHR`, `vkCreateWaylandSurfaceKHR`, and `vkCreateMetalSurfaceEXT` were never
+  loaded via `GetInstanceProcAddr` — only `vkCreateWin32SurfaceKHR` was. On Linux/macOS the
+  function pointer stayed nil, and goffi FFI returned zeros (result=0, surface=0x0) instead of
+  crashing, causing "null surface" errors downstream.
+  ([gogpu#106](https://github.com/gogpu/gogpu/issues/106))
+
 ## [0.16.16] - 2026-02-25
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,9 +19,12 @@
 
 ---
 
-## Current State: v0.16.16
+## Current State: v0.16.17
 
 ✅ **All 5 HAL backends complete** (~80K LOC, ~100K total):
+
+**New in v0.16.17:**
+- Vulkan: load platform surface creation functions — `vkCreateXlibSurfaceKHR`, `vkCreateXcbSurfaceKHR`, `vkCreateWaylandSurfaceKHR`, `vkCreateMetalSurfaceEXT` were never loaded via `GetInstanceProcAddr` (only Win32 was). Fixed — Linux/macOS Vulkan surfaces now work (gogpu#106)
 
 **New in v0.16.16:**
 - Vulkan X11/macOS surface creation pointer fix — `unsafe.Pointer(&display)` → `unsafe.Pointer(display)`. Old code passed Go stack address instead of Display*/CAMetalLayer* value (gogpu#106)

--- a/hal/vulkan/api_darwin.go
+++ b/hal/vulkan/api_darwin.go
@@ -33,10 +33,17 @@ func (i *Instance) CreateSurface(_, metalLayer uintptr) (hal.Surface, error) {
 	// Previous bug: &metalLayer stored Go stack address instead of CAMetalLayer* value.
 	*(*uintptr)(unsafe.Pointer(&createInfo.PLayer)) = metalLayer
 
+	if !i.cmds.HasCreateMetalSurfaceEXT() {
+		return nil, fmt.Errorf("vulkan: vkCreateMetalSurfaceEXT not available (VK_EXT_metal_surface extension not loaded)")
+	}
+
 	var surface vk.SurfaceKHR
 	result := i.cmds.CreateMetalSurfaceEXT(i.handle, &createInfo, nil, &surface)
 	if result != vk.Success {
 		return nil, fmt.Errorf("vulkan: vkCreateMetalSurfaceEXT failed: %d", result)
+	}
+	if surface == 0 {
+		return nil, fmt.Errorf("vulkan: vkCreateMetalSurfaceEXT returned success but surface is null")
 	}
 
 	return &Surface{

--- a/hal/vulkan/api_linux.go
+++ b/hal/vulkan/api_linux.go
@@ -34,10 +34,17 @@ func (i *Instance) CreateSurface(display, window uintptr) (hal.Surface, error) {
 	// Previous bug: &display stored Go stack address instead of Display* value.
 	*(*uintptr)(unsafe.Pointer(&createInfo.Dpy)) = display
 
+	if !i.cmds.HasCreateXlibSurfaceKHR() {
+		return nil, fmt.Errorf("vulkan: vkCreateXlibSurfaceKHR not available (VK_KHR_xlib_surface extension not loaded)")
+	}
+
 	var surface vk.SurfaceKHR
 	result := i.cmds.CreateXlibSurfaceKHR(i.handle, &createInfo, nil, &surface)
 	if result != vk.Success {
 		return nil, fmt.Errorf("vulkan: vkCreateXlibSurfaceKHR failed: %d", result)
+	}
+	if surface == 0 {
+		return nil, fmt.Errorf("vulkan: vkCreateXlibSurfaceKHR returned success but surface is null")
 	}
 
 	return &Surface{

--- a/hal/vulkan/api_windows.go
+++ b/hal/vulkan/api_windows.go
@@ -36,10 +36,17 @@ func (i *Instance) CreateSurface(hinstance, hwnd uintptr) (hal.Surface, error) {
 		Hwnd:      hwnd,
 	}
 
+	if !i.cmds.HasCreateWin32SurfaceKHR() {
+		return nil, fmt.Errorf("vulkan: vkCreateWin32SurfaceKHR not available (VK_KHR_win32_surface extension not loaded)")
+	}
+
 	var surface vk.SurfaceKHR
 	result := i.cmds.CreateWin32SurfaceKHR(i.handle, &createInfo, nil, &surface)
 	if result != vk.Success {
 		return nil, fmt.Errorf("vulkan: vkCreateWin32SurfaceKHR failed: %d", result)
+	}
+	if surface == 0 {
+		return nil, fmt.Errorf("vulkan: vkCreateWin32SurfaceKHR returned success but surface is null")
 	}
 
 	return &Surface{

--- a/hal/vulkan/vk/commands.go
+++ b/hal/vulkan/vk/commands.go
@@ -97,8 +97,12 @@ func (c *Commands) LoadInstance(instance Instance) error {
 	c.getPhysicalDeviceSurfaceFormatsKHR = GetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfaceFormatsKHR")
 	c.getPhysicalDeviceSurfacePresentModesKHR = GetInstanceProcAddr(instance, "vkGetPhysicalDeviceSurfacePresentModesKHR")
 
-	// Platform-specific surface creation
+	// Platform-specific surface creation (nil on unsupported platforms)
 	c.createWin32SurfaceKHR = GetInstanceProcAddr(instance, "vkCreateWin32SurfaceKHR")
+	c.createXlibSurfaceKHR = GetInstanceProcAddr(instance, "vkCreateXlibSurfaceKHR")
+	c.createXcbSurfaceKHR = GetInstanceProcAddr(instance, "vkCreateXcbSurfaceKHR")
+	c.createWaylandSurfaceKHR = GetInstanceProcAddr(instance, "vkCreateWaylandSurfaceKHR")
+	c.createMetalSurfaceEXT = GetInstanceProcAddr(instance, "vkCreateMetalSurfaceEXT")
 
 	// Vulkan 1.1+ instance functions
 	c.getPhysicalDeviceFeatures2 = GetInstanceProcAddr(instance, "vkGetPhysicalDeviceFeatures2")
@@ -283,6 +287,21 @@ func (c *Commands) HasTimelineSemaphore() bool {
 // This is a Vulkan 1.1 core function used to query extended feature support via PNext chains.
 func (c *Commands) HasPhysicalDeviceFeatures2() bool {
 	return c.getPhysicalDeviceFeatures2 != nil
+}
+
+// HasCreateWin32SurfaceKHR returns true if vkCreateWin32SurfaceKHR is available.
+func (c *Commands) HasCreateWin32SurfaceKHR() bool {
+	return c.createWin32SurfaceKHR != nil
+}
+
+// HasCreateXlibSurfaceKHR returns true if vkCreateXlibSurfaceKHR is available.
+func (c *Commands) HasCreateXlibSurfaceKHR() bool {
+	return c.createXlibSurfaceKHR != nil
+}
+
+// HasCreateMetalSurfaceEXT returns true if vkCreateMetalSurfaceEXT is available.
+func (c *Commands) HasCreateMetalSurfaceEXT() bool {
+	return c.createMetalSurfaceEXT != nil
 }
 
 // HasDebugUtils returns true if vkSetDebugUtilsObjectNameEXT is available.


### PR DESCRIPTION
## Summary

- Load platform-specific Vulkan surface creation functions via `GetInstanceProcAddr` — `vkCreateXlibSurfaceKHR`, `vkCreateXcbSurfaceKHR`, `vkCreateWaylandSurfaceKHR`, and `vkCreateMetalSurfaceEXT` were never loaded (only `vkCreateWin32SurfaceKHR` was). On Linux/macOS the nil function pointer caused goffi FFI to silently return zeros (`result=0, surface=0x0`) instead of crashing.
- Add `Has*()` guards and null surface checks to `CreateSurface` on all 3 platforms — clear error messages instead of silent failures downstream.

Fixes gogpu/gogpu#106

## Root Cause

`commands.go:LoadInstance()` only loaded `vkCreateWin32SurfaceKHR`. The Xlib, Xcb, Wayland, and Metal surface creation function pointers stayed nil. When `ffi.CallFunction` received a nil function pointer, it returned all zeros — which meant `VK_SUCCESS` (0) with a null `VkSurfaceKHR` handle.

## Changes

| File | Change |
|------|--------|
| `hal/vulkan/vk/commands.go` | Load 4 missing platform surface functions + add `Has*()` methods |
| `hal/vulkan/api_linux.go` | Add nil function pointer check + null surface check |
| `hal/vulkan/api_darwin.go` | Add nil function pointer check + null surface check |
| `hal/vulkan/api_windows.go` | Add nil function pointer check + null surface check |

## Verified

Tested on WSL2 Ubuntu with mesa-vulkan-drivers — triangle renders correctly via Vulkan X11.
