### PR TITLE
fix: Vulkan buffer-to-image copy row stride corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.1] - 2026-02-27
+
+### Fixed
+
+- **Vulkan: buffer-to-image copy row stride corruption** — `convertBufferImageCopyRegions` incorrectly
+  inferred `bytesPerTexel` via integer division `BytesPerRow / Width` instead of using the texture
+  format's known block size. When `BytesPerRow` was padded to 256-byte alignment, the division
+  produced wrong results for most image widths (126 out of 204 possible widths for RGBA8).
+  For example, width=204: `1024 / 204 = 5` (should be 4) → Vulkan received wrong `bufferRowLength`
+  → pixel corruption on rounded rectangles and other non-power-of-2 width textures.
+  Fixed by adding `blockCopySize()` static lookup matching the Rust wgpu reference implementation's
+  `TextureFormat::block_copy_size()`. Covers all non-compressed WebGPU texture formats.
+  ([gogpu#96](https://github.com/gogpu/gogpu/discussions/96))
+
 ## [0.18.0] - 2026-02-27
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,10 +19,13 @@
 
 ---
 
-## Current State: v0.18.0
+## Current State: v0.18.1
 
 ✅ **All 5 HAL backends complete** (~80K LOC, ~100K total)
 ✅ **Public API root package** — `import "github.com/gogpu/wgpu"`
+
+**New in v0.18.1:**
+- Vulkan: fix buffer-to-image copy row stride corruption — use format's block copy size instead of inferring from padded `BytesPerRow / Width` (gogpu#96)
 
 **New in v0.18.0:**
 - Public API root package with 20 user-facing types wrapping core/ and hal/


### PR DESCRIPTION
## Summary

- Fix Vulkan `convertBufferImageCopyRegions` row stride corruption caused by inferring `bytesPerTexel` from padded `BytesPerRow / Width` instead of using the texture format's known block size
- Add `blockCopySize()` static lookup matching Rust wgpu reference `TextureFormat::block_copy_size()`, covering all non-compressed WebGPU formats
- Pass texture format from `CopyBufferToTexture` / `CopyTextureToBuffer` call sites

**Root cause:** For width=204, RGBA8: `BytesPerRow` padded to 1024, then `1024 / 204 = 5` (should be 4) → wrong `bufferRowLength` → pixel corruption. Affects 126 out of 204 possible widths.

Fixes [gogpu#96](https://github.com/gogpu/gogpu/discussions/96)

## Test plan

- [x] `go build ./...` passes on Linux, Windows, macOS
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] `go fmt` — no changes needed
- [ ] CI green
- [ ] Manual test: render 204px-wide rounded rectangle on Vulkan — no pixel corruption
