### PR TITLE
fix: Metal depth24 crash on Apple Silicon (M1/M2/M3/M4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1] - 2026-03-01
+
+### Fixed
+
+- **Metal: crash on Apple Silicon (M1/M2/M3/M4) with depth/stencil textures** —
+  `Depth24PlusStencil8` was hardcoded to `MTLPixelFormatDepth24UnormStencil8` (255),
+  which is unsupported on Apple Silicon GPUs (only available on legacy AMD GPUs in
+  Intel-era Macs). Metal rejected the invalid pixel format with SIGABRT. Additionally,
+  `Depth24Plus` was completely missing from the format mapping, returning
+  `MTLPixelFormatInvalid` (0). Fixed by detecting device capability via
+  `isDepth24Stencil8PixelFormatSupported` at adapter enumeration and choosing
+  `Depth32Float`/`Depth32FloatStencil8` (universally supported) when Depth24 is
+  unavailable. Follows the same pattern as wgpu-rs (`wgpu-hal/src/metal/adapter.rs`).
+  ([ui#23](https://github.com/gogpu/ui/issues/23))
+
 ## [0.19.0] - 2026-03-01
 
 ### Changed

--- a/hal/metal/adapter.go
+++ b/hal/metal/adapter.go
@@ -13,7 +13,7 @@ import (
 // Adapter implements hal.Adapter for Metal.
 type Adapter struct {
 	instance              *Instance
-	raw                   ID // id<MTLDevice>
+	raw                   ID   // id<MTLDevice>
 	formatDepth24Stencil8 bool // true if Depth24UnormStencil8 supported (Intel-era AMD only)
 }
 

--- a/hal/metal/adapter.go
+++ b/hal/metal/adapter.go
@@ -12,8 +12,28 @@ import (
 
 // Adapter implements hal.Adapter for Metal.
 type Adapter struct {
-	instance *Instance
-	raw      ID // id<MTLDevice>
+	instance              *Instance
+	raw                   ID // id<MTLDevice>
+	formatDepth24Stencil8 bool // true if Depth24UnormStencil8 supported (Intel-era AMD only)
+}
+
+// mapTextureFormat converts a WebGPU texture format to Metal pixel format,
+// accounting for device capabilities (e.g. Depth24 support on Apple Silicon).
+func (a *Adapter) mapTextureFormat(format gputypes.TextureFormat) MTLPixelFormat {
+	switch format {
+	case gputypes.TextureFormatDepth24Plus:
+		if a.formatDepth24Stencil8 {
+			return MTLPixelFormatDepth24UnormStencil8
+		}
+		return MTLPixelFormatDepth32Float
+	case gputypes.TextureFormatDepth24PlusStencil8:
+		if a.formatDepth24Stencil8 {
+			return MTLPixelFormatDepth24UnormStencil8
+		}
+		return MTLPixelFormatDepth32FloatStencil8
+	default:
+		return textureFormatToMTL(format)
+	}
 }
 
 // Open opens a logical device with the requested features and limits.

--- a/hal/metal/api.go
+++ b/hal/metal/api.go
@@ -76,8 +76,9 @@ func (i *Instance) EnumerateAdapters(surfaceHint hal.Surface) []hal.ExposedAdapt
 		features.Insert(gputypes.FeatureTextureCompressionBC)
 
 		adapter := &Adapter{
-			instance: i,
-			raw:      device,
+			instance:              i,
+			raw:                   device,
+			formatDepth24Stencil8: MsgSendBool(device, Sel("isDepth24Stencil8PixelFormatSupported")),
 		}
 
 		maxBuf := DeviceMaxBufferLength(device)
@@ -89,6 +90,7 @@ func (i *Instance) EnumerateAdapters(surfaceHint hal.Surface) []hal.ExposedAdapt
 			"removable", DeviceIsRemovable(device),
 			"headless", DeviceIsHeadless(device),
 			"maxBuffer", maxBuf,
+			"depth24Stencil8", adapter.formatDepth24Stencil8,
 		)
 
 		adapters = append(adapters, hal.ExposedAdapter{

--- a/hal/metal/conv.go
+++ b/hal/metal/conv.go
@@ -86,8 +86,10 @@ func textureFormatToMTL(format gputypes.TextureFormat) MTLPixelFormat {
 		return MTLPixelFormatDepth16Unorm
 	case gputypes.TextureFormatDepth32Float:
 		return MTLPixelFormatDepth32Float
+	case gputypes.TextureFormatDepth24Plus:
+		return MTLPixelFormatDepth32Float
 	case gputypes.TextureFormatDepth24PlusStencil8:
-		return MTLPixelFormatDepth24UnormStencil8
+		return MTLPixelFormatDepth32FloatStencil8
 	case gputypes.TextureFormatDepth32FloatStencil8:
 		return MTLPixelFormatDepth32FloatStencil8
 	case gputypes.TextureFormatStencil8:

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -131,7 +131,7 @@ func (d *Device) CreateTexture(desc *hal.TextureDescriptor) (hal.Texture, error)
 	texType := textureTypeFromDimension(desc.Dimension, desc.SampleCount, desc.Size.DepthOrArrayLayers)
 	_ = MsgSend(texDesc, Sel("setTextureType:"), uintptr(texType))
 
-	pixelFormat := textureFormatToMTL(desc.Format)
+	pixelFormat := d.adapter.mapTextureFormat(desc.Format)
 	_ = MsgSend(texDesc, Sel("setPixelFormat:"), uintptr(pixelFormat))
 
 	_ = MsgSend(texDesc, Sel("setWidth:"), uintptr(desc.Size.Width))
@@ -223,7 +223,7 @@ func (d *Device) CreateTextureView(texture hal.Texture, desc *hal.TextureViewDes
 	if format == gputypes.TextureFormatUndefined {
 		format = mtlTexture.format
 	}
-	pixelFormat := textureFormatToMTL(format)
+	pixelFormat := d.adapter.mapTextureFormat(format)
 
 	baseMip := desc.BaseMipLevel
 	mipCount := desc.MipLevelCount
@@ -555,7 +555,7 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 			}
 
 			// Set pixel format
-			pixelFormat := textureFormatToMTL(target.Format)
+			pixelFormat := d.adapter.mapTextureFormat(target.Format)
 			_ = MsgSend(attachment, Sel("setPixelFormat:"), uintptr(pixelFormat))
 
 			// Set write mask


### PR DESCRIPTION
## Summary

- Fix Metal backend crash on **all Apple Silicon** Macs (M1/M2/M3/M4) when creating depth/stencil textures
- `Depth24PlusStencil8` was hardcoded to `MTLPixelFormatDepth24UnormStencil8` (255) — unsupported on Apple Silicon (only legacy AMD GPUs in Intel-era Macs)
- `Depth24Plus` was completely missing from the format mapping — returned `MTLPixelFormatInvalid` (0)
- Detect `isDepth24Stencil8PixelFormatSupported` at adapter enumeration and fall back to `Depth32Float`/`Depth32FloatStencil8` on Apple Silicon
- Follows the wgpu-rs reference pattern (`wgpu-hal/src/metal/adapter.rs:668`)

Fixes gogpu/ui#23

## Changes

| File | Change |
|------|--------|
| `hal/metal/adapter.go` | Add `formatDepth24Stencil8` capability field + `mapTextureFormat()` method |
| `hal/metal/api.go` | Query `isDepth24Stencil8PixelFormatSupported` at adapter enumeration |
| `hal/metal/conv.go` | Add missing `Depth24Plus` case, change `D24S8` default to safe `D32FS8` |
| `hal/metal/device.go` | Replace 3 `textureFormatToMTL()` calls with capability-aware `mapTextureFormat()` |
| `CHANGELOG.md` | Add v0.19.1 entry |

## Test plan

- [x] `GOOS=darwin GOARCH=arm64 go build ./...` — cross-compile passes
- [x] `go test ./...` — all existing tests pass
- [x] `golangci-lint run` — 0 issues
- [x] Downstream `gogpu` and `gg` builds pass
- [ ] Real device testing by reporter (rcarlier) on Apple M3
