### PR TITLE
fix: SIGBUS on Apple Silicon — ObjC block PAC re-signing (v0.19.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.2] - 2026-03-01
+
+### Fixed
+
+- **Metal: SIGBUS crash on Apple Silicon from ObjC block PAC re-signing** —
+  ObjC blocks were constructed with `_NSConcreteStackBlock` but allocated on the
+  Go heap. When Metal calls `Block_copy()` during `addCompletedHandler:`, ARM64e
+  Pointer Authentication (PAC) re-signs the invoke function pointer. Since
+  `ffi.NewCallback` pointers are unsigned, authentication fails and produces a
+  corrupted pointer that causes SIGBUS ~0.7s after launch when Metal's completion
+  queue invokes the callback. Fixed by switching to `_NSConcreteGlobalBlock` with
+  `BLOCK_IS_GLOBAL` flag, which makes `Block_copy()` a complete no-op (no memmove,
+  no PAC re-signing). Added `blockPinRegistry` to prevent GC collection of block
+  literals while Metal holds references. Removed stale `runtime.KeepAlive(uintptr)`
+  calls that were no-ops (GC doesn't track `uintptr` as roots).
+  ([wgpu#89](https://github.com/gogpu/wgpu/issues/89),
+  [ui#23](https://github.com/gogpu/ui/issues/23))
+
+### Changed
+
+- **CI: upgraded codecov-action v4 → v5**, added `codecov.yml` configuration
+- **Tests: added coverage tests** for core, HAL backends, and format conversion
+
 ## [0.19.1] - 2026-03-01
 
 ### Fixed

--- a/core/backend_test.go
+++ b/core/backend_test.go
@@ -1,0 +1,379 @@
+package core
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/hal"
+)
+
+// testProvider implements BackendProvider for testing.
+type testProvider struct {
+	variant   gputypes.Backend
+	available bool
+}
+
+func (p *testProvider) Variant() gputypes.Backend { return p.variant }
+func (p *testProvider) CreateInstance(_ *hal.InstanceDescriptor) (hal.Instance, error) {
+	return nil, nil //nolint:nilnil
+}
+func (p *testProvider) IsAvailable() bool { return p.available }
+
+func TestRegisterBackendProvider(t *testing.T) {
+	// Save and restore state
+	providersMu.Lock()
+	savedProviders := make(map[gputypes.Backend]BackendProvider)
+	for k, v := range providers {
+		savedProviders[k] = v
+	}
+	providers = make(map[gputypes.Backend]BackendProvider)
+	providersMu.Unlock()
+	defer func() {
+		providersMu.Lock()
+		providers = savedProviders
+		providersMu.Unlock()
+	}()
+
+	provider := &testProvider{variant: gputypes.BackendVulkan, available: true}
+	RegisterBackendProvider(provider)
+
+	got, ok := GetBackendProvider(gputypes.BackendVulkan)
+	if !ok {
+		t.Fatal("expected provider to be registered")
+	}
+	if got.Variant() != gputypes.BackendVulkan {
+		t.Errorf("variant = %v, want BackendVulkan", got.Variant())
+	}
+}
+
+func TestGetBackendProvider_NotRegistered(t *testing.T) {
+	// Save and restore state
+	providersMu.Lock()
+	savedProviders := make(map[gputypes.Backend]BackendProvider)
+	for k, v := range providers {
+		savedProviders[k] = v
+	}
+	providers = make(map[gputypes.Backend]BackendProvider)
+	providersMu.Unlock()
+	defer func() {
+		providersMu.Lock()
+		providers = savedProviders
+		providersMu.Unlock()
+	}()
+
+	_, ok := GetBackendProvider(gputypes.BackendVulkan)
+	if ok {
+		t.Error("expected GetBackendProvider to return false for unregistered provider")
+	}
+}
+
+func TestAvailableBackendProviders(t *testing.T) {
+	// Save and restore state
+	providersMu.Lock()
+	savedProviders := make(map[gputypes.Backend]BackendProvider)
+	for k, v := range providers {
+		savedProviders[k] = v
+	}
+	providers = make(map[gputypes.Backend]BackendProvider)
+	providersMu.Unlock()
+	defer func() {
+		providersMu.Lock()
+		providers = savedProviders
+		providersMu.Unlock()
+	}()
+
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendVulkan, available: true})
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendMetal, available: true})
+
+	available := AvailableBackendProviders()
+	if len(available) != 2 {
+		t.Errorf("expected 2 providers, got %d", len(available))
+	}
+}
+
+func TestGetOrderedBackendProviders(t *testing.T) {
+	// Save and restore state
+	providersMu.Lock()
+	savedProviders := make(map[gputypes.Backend]BackendProvider)
+	for k, v := range providers {
+		savedProviders[k] = v
+	}
+	providers = make(map[gputypes.Backend]BackendProvider)
+	providersMu.Unlock()
+	defer func() {
+		providersMu.Lock()
+		providers = savedProviders
+		providersMu.Unlock()
+	}()
+
+	// Register in non-priority order
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendEmpty, available: true})
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendVulkan, available: true})
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendGL, available: true})
+
+	ordered := GetOrderedBackendProviders()
+	if len(ordered) != 3 {
+		t.Fatalf("expected 3 providers, got %d", len(ordered))
+	}
+
+	// Vulkan should be first (highest priority)
+	if ordered[0].Variant() != gputypes.BackendVulkan {
+		t.Errorf("first provider = %v, want BackendVulkan", ordered[0].Variant())
+	}
+	// GL should be second
+	if ordered[1].Variant() != gputypes.BackendGL {
+		t.Errorf("second provider = %v, want BackendGL", ordered[1].Variant())
+	}
+	// Empty should be last
+	if ordered[2].Variant() != gputypes.BackendEmpty {
+		t.Errorf("third provider = %v, want BackendEmpty", ordered[2].Variant())
+	}
+}
+
+func TestGetOrderedBackendProviders_SkipsUnavailable(t *testing.T) {
+	// Save and restore state
+	providersMu.Lock()
+	savedProviders := make(map[gputypes.Backend]BackendProvider)
+	for k, v := range providers {
+		savedProviders[k] = v
+	}
+	providers = make(map[gputypes.Backend]BackendProvider)
+	providersMu.Unlock()
+	defer func() {
+		providersMu.Lock()
+		providers = savedProviders
+		providersMu.Unlock()
+	}()
+
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendVulkan, available: false})
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendGL, available: true})
+
+	ordered := GetOrderedBackendProviders()
+	if len(ordered) != 1 {
+		t.Fatalf("expected 1 available provider, got %d", len(ordered))
+	}
+	if ordered[0].Variant() != gputypes.BackendGL {
+		t.Errorf("expected BackendGL, got %v", ordered[0].Variant())
+	}
+}
+
+func TestGetOrderedBackendProviders_CustomBackends(t *testing.T) {
+	// Save and restore state
+	providersMu.Lock()
+	savedProviders := make(map[gputypes.Backend]BackendProvider)
+	for k, v := range providers {
+		savedProviders[k] = v
+	}
+	providers = make(map[gputypes.Backend]BackendProvider)
+	providersMu.Unlock()
+	defer func() {
+		providersMu.Lock()
+		providers = savedProviders
+		providersMu.Unlock()
+	}()
+
+	// Register a custom backend not in the priority list
+	customVariant := gputypes.Backend(42)
+	RegisterBackendProvider(&testProvider{variant: customVariant, available: true})
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendVulkan, available: true})
+
+	ordered := GetOrderedBackendProviders()
+	if len(ordered) != 2 {
+		t.Fatalf("expected 2 providers, got %d", len(ordered))
+	}
+
+	// Vulkan should be first (in priority list)
+	if ordered[0].Variant() != gputypes.BackendVulkan {
+		t.Errorf("first = %v, want BackendVulkan", ordered[0].Variant())
+	}
+	// Custom should be last (not in priority list)
+	if ordered[1].Variant() != customVariant {
+		t.Errorf("second = %v, want custom(%d)", ordered[1].Variant(), customVariant)
+	}
+}
+
+func TestSelectBestBackendProvider(t *testing.T) {
+	// Save and restore state
+	providersMu.Lock()
+	savedProviders := make(map[gputypes.Backend]BackendProvider)
+	for k, v := range providers {
+		savedProviders[k] = v
+	}
+	providers = make(map[gputypes.Backend]BackendProvider)
+	providersMu.Unlock()
+	defer func() {
+		providersMu.Lock()
+		providers = savedProviders
+		providersMu.Unlock()
+	}()
+
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendGL, available: true})
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendVulkan, available: true})
+
+	best := SelectBestBackendProvider()
+	if best == nil {
+		t.Fatal("SelectBestBackendProvider returned nil")
+	}
+	if best.Variant() != gputypes.BackendVulkan {
+		t.Errorf("best = %v, want BackendVulkan (highest priority)", best.Variant())
+	}
+}
+
+func TestSelectBestBackendProvider_NoneAvailable(t *testing.T) {
+	// Save and restore state
+	providersMu.Lock()
+	savedProviders := make(map[gputypes.Backend]BackendProvider)
+	for k, v := range providers {
+		savedProviders[k] = v
+	}
+	providers = make(map[gputypes.Backend]BackendProvider)
+	providersMu.Unlock()
+	defer func() {
+		providersMu.Lock()
+		providers = savedProviders
+		providersMu.Unlock()
+	}()
+
+	best := SelectBestBackendProvider()
+	if best != nil {
+		t.Errorf("expected nil when no providers registered, got %v", best.Variant())
+	}
+}
+
+func TestFilterBackendsByMask(t *testing.T) {
+	// Save and restore state
+	providersMu.Lock()
+	savedProviders := make(map[gputypes.Backend]BackendProvider)
+	for k, v := range providers {
+		savedProviders[k] = v
+	}
+	providers = make(map[gputypes.Backend]BackendProvider)
+	providersMu.Unlock()
+	defer func() {
+		providersMu.Lock()
+		providers = savedProviders
+		providersMu.Unlock()
+	}()
+
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendVulkan, available: true})
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendMetal, available: true})
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendDX12, available: true})
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendGL, available: true})
+	RegisterBackendProvider(&testProvider{variant: gputypes.BackendEmpty, available: true})
+
+	tests := []struct {
+		name    string
+		mask    gputypes.Backends
+		wantLen int
+		wantHas []gputypes.Backend
+		wantNot []gputypes.Backend
+	}{
+		{
+			name:    "Vulkan only",
+			mask:    gputypes.BackendsVulkan,
+			wantLen: 2, // Vulkan + Empty (always included)
+			wantHas: []gputypes.Backend{gputypes.BackendVulkan, gputypes.BackendEmpty},
+			wantNot: []gputypes.Backend{gputypes.BackendMetal, gputypes.BackendDX12},
+		},
+		{
+			name:    "Metal only",
+			mask:    gputypes.BackendsMetal,
+			wantLen: 2, // Metal + Empty
+			wantHas: []gputypes.Backend{gputypes.BackendMetal, gputypes.BackendEmpty},
+		},
+		{
+			name:    "DX12 only",
+			mask:    gputypes.BackendsDX12,
+			wantLen: 2, // DX12 + Empty
+			wantHas: []gputypes.Backend{gputypes.BackendDX12, gputypes.BackendEmpty},
+		},
+		{
+			name:    "GL only",
+			mask:    gputypes.BackendsGL,
+			wantLen: 2, // GL + Empty
+			wantHas: []gputypes.Backend{gputypes.BackendGL, gputypes.BackendEmpty},
+		},
+		{
+			name:    "Vulkan + Metal",
+			mask:    gputypes.BackendsVulkan | gputypes.BackendsMetal,
+			wantLen: 3, // Vulkan + Metal + Empty
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filtered := FilterBackendsByMask(tt.mask)
+
+			if len(filtered) != tt.wantLen {
+				variants := make([]gputypes.Backend, len(filtered))
+				for i, p := range filtered {
+					variants[i] = p.Variant()
+				}
+				t.Errorf("len = %d, want %d (variants: %v)", len(filtered), tt.wantLen, variants)
+			}
+
+			for _, want := range tt.wantHas {
+				found := false
+				for _, p := range filtered {
+					if p.Variant() == want {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected to find %v in filtered results", want)
+				}
+			}
+
+			for _, notWant := range tt.wantNot {
+				for _, p := range filtered {
+					if p.Variant() == notWant {
+						t.Errorf("did not expect %v in filtered results", notWant)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestHALBackendProvider(t *testing.T) {
+	// Register a HAL backend and then create a provider for it
+	// Since we're in the core package, we test the halBackendProvider wrapper
+
+	mockBackend := &testHALBackend{variant: gputypes.BackendGL}
+	provider := &halBackendProvider{backend: mockBackend}
+
+	if provider.Variant() != gputypes.BackendGL {
+		t.Errorf("Variant() = %v, want BackendGL", provider.Variant())
+	}
+
+	if !provider.IsAvailable() {
+		t.Error("IsAvailable() = false, want true (HAL backends always available)")
+	}
+
+	instance, err := provider.CreateInstance(&hal.InstanceDescriptor{})
+	if err != nil {
+		t.Fatalf("CreateInstance failed: %v", err)
+	}
+	if instance == nil {
+		t.Fatal("CreateInstance returned nil")
+	}
+}
+
+// testHALBackend implements hal.Backend for testing.
+type testHALBackend struct {
+	variant gputypes.Backend
+}
+
+func (b *testHALBackend) Variant() gputypes.Backend { return b.variant }
+func (b *testHALBackend) CreateInstance(_ *hal.InstanceDescriptor) (hal.Instance, error) {
+	return &testHALInstance{}, nil
+}
+
+type testHALInstance struct{}
+
+func (i *testHALInstance) CreateSurface(_, _ uintptr) (hal.Surface, error) { return nil, nil } //nolint:nilnil
+func (i *testHALInstance) EnumerateAdapters(_ hal.Surface) []hal.ExposedAdapter {
+	return nil
+}
+func (i *testHALInstance) Destroy() {}

--- a/hal/backends_test.go
+++ b/hal/backends_test.go
@@ -1,0 +1,173 @@
+package hal_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/hal"
+	_ "github.com/gogpu/wgpu/hal/noop" // Import for side effect of registering noop backend
+)
+
+// Use non-standard backend variant numbers to avoid interfering with
+// registry_test.go which checks that specific standard variants are not registered.
+const (
+	testFactoryVariant1 = gputypes.Backend(200) // unique test variant
+	testFactoryVariant2 = gputypes.Backend(201) // unique test variant
+	testFactoryVariant3 = gputypes.Backend(202) // unique test variant
+)
+
+// factoryTestBackend implements hal.Backend for factory tests.
+type factoryTestBackend struct {
+	variant gputypes.Backend
+}
+
+func (b *factoryTestBackend) Variant() gputypes.Backend { return b.variant }
+func (b *factoryTestBackend) CreateInstance(_ *hal.InstanceDescriptor) (hal.Instance, error) {
+	return &factoryTestInstance{}, nil
+}
+
+// factoryTestInstance implements hal.Instance for factory tests.
+type factoryTestInstance struct{}
+
+func (i *factoryTestInstance) CreateSurface(_, _ uintptr) (hal.Surface, error) { return nil, nil } //nolint:nilnil
+func (i *factoryTestInstance) EnumerateAdapters(_ hal.Surface) []hal.ExposedAdapter {
+	return nil
+}
+func (i *factoryTestInstance) Destroy() {}
+
+// TestRegisterBackendFactory tests factory registration.
+func TestRegisterBackendFactory(t *testing.T) {
+	callCount := 0
+	factory := func() (hal.Backend, error) {
+		callCount++
+		return &factoryTestBackend{variant: testFactoryVariant1}, nil
+	}
+
+	hal.RegisterBackendFactory(testFactoryVariant1, factory)
+
+	// Factory should not be called until CreateBackend
+	if callCount != 0 {
+		t.Errorf("factory called during registration, want lazy")
+	}
+}
+
+// TestCreateBackend tests lazy backend creation.
+func TestCreateBackend(t *testing.T) {
+	hal.RegisterBackendFactory(testFactoryVariant1, func() (hal.Backend, error) {
+		return &factoryTestBackend{variant: testFactoryVariant1}, nil
+	})
+
+	backend, err := hal.CreateBackend(testFactoryVariant1)
+	if err != nil {
+		t.Fatalf("CreateBackend failed: %v", err)
+	}
+	if backend == nil {
+		t.Fatal("CreateBackend returned nil backend")
+	}
+	if backend.Variant() != testFactoryVariant1 {
+		t.Errorf("variant = %v, want %v", backend.Variant(), testFactoryVariant1)
+	}
+}
+
+// TestCreateBackendNotRegistered tests CreateBackend with unregistered variant.
+func TestCreateBackendNotRegistered(t *testing.T) {
+	_, err := hal.CreateBackend(gputypes.Backend(99))
+	if !errors.Is(err, hal.ErrBackendNotFound) {
+		t.Errorf("expected ErrBackendNotFound, got %v", err)
+	}
+}
+
+// TestCreateBackendFactoryError tests CreateBackend when factory returns error.
+func TestCreateBackendFactoryError(t *testing.T) {
+	factoryErr := errors.New("init failed")
+	hal.RegisterBackendFactory(testFactoryVariant2, func() (hal.Backend, error) {
+		return nil, factoryErr
+	})
+
+	_, err := hal.CreateBackend(testFactoryVariant2)
+	if !errors.Is(err, factoryErr) {
+		t.Errorf("expected factory error, got %v", err)
+	}
+}
+
+// TestProbeBackendRegistered tests ProbeBackend with an already-registered backend.
+func TestProbeBackendRegistered(t *testing.T) {
+	// noop is registered via init()
+	info, err := hal.ProbeBackend(gputypes.BackendEmpty)
+	if err != nil {
+		t.Fatalf("ProbeBackend for noop failed: %v", err)
+	}
+	if info == nil {
+		t.Fatal("ProbeBackend returned nil info")
+	}
+	if info.Variant != gputypes.BackendEmpty {
+		t.Errorf("variant = %v, want BackendEmpty", info.Variant)
+	}
+}
+
+// TestProbeBackendViaFactory tests ProbeBackend with a factory.
+func TestProbeBackendViaFactory(t *testing.T) {
+	hal.RegisterBackendFactory(testFactoryVariant3, func() (hal.Backend, error) {
+		return &factoryTestBackend{variant: testFactoryVariant3}, nil
+	})
+
+	info, err := hal.ProbeBackend(testFactoryVariant3)
+	if err != nil {
+		t.Fatalf("ProbeBackend via factory failed: %v", err)
+	}
+	if info == nil {
+		t.Fatal("ProbeBackend returned nil info")
+	}
+	if info.Variant != testFactoryVariant3 {
+		t.Errorf("variant = %v, want %v", info.Variant, testFactoryVariant3)
+	}
+}
+
+// TestProbeBackendNotFound tests ProbeBackend with unknown backend.
+func TestProbeBackendNotFound(t *testing.T) {
+	_, err := hal.ProbeBackend(gputypes.Backend(77))
+	if !errors.Is(err, hal.ErrBackendNotFound) {
+		t.Errorf("expected ErrBackendNotFound, got %v", err)
+	}
+}
+
+// TestSelectBestBackend tests backend selection priority.
+func TestSelectBestBackend(t *testing.T) {
+	// With noop registered, SelectBestBackend should return something
+	backend, err := hal.SelectBestBackend()
+	if err != nil {
+		t.Fatalf("SelectBestBackend failed: %v", err)
+	}
+	if backend == nil {
+		t.Fatal("SelectBestBackend returned nil")
+	}
+}
+
+// TestBackendInfo tests BackendInfo struct fields.
+func TestBackendInfo(t *testing.T) {
+	info := hal.BackendInfo{
+		Variant: gputypes.BackendVulkan,
+		Name:    "Vulkan",
+		Version: "1.3.0",
+		Features: hal.BackendFeatures{
+			SupportsCompute:    true,
+			SupportsMultiQueue: true,
+			MaxTextureSize:     16384,
+			MaxBufferSize:      1 << 30,
+		},
+		Limitations: hal.BackendLimitations{
+			NoAsyncCompute: false,
+		},
+	}
+
+	if info.Variant != gputypes.BackendVulkan {
+		t.Errorf("Variant = %v, want BackendVulkan", info.Variant)
+	}
+	if !info.Features.SupportsCompute {
+		t.Error("SupportsCompute should be true")
+	}
+	if info.Features.MaxTextureSize != 16384 {
+		t.Errorf("MaxTextureSize = %d, want 16384", info.Features.MaxTextureSize)
+	}
+}

--- a/hal/dx12/convert_test.go
+++ b/hal/dx12/convert_test.go
@@ -1,0 +1,679 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build windows
+
+package dx12
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/hal"
+	"github.com/gogpu/wgpu/hal/dx12/d3d12"
+)
+
+func TestTextureFormatToD3D12(t *testing.T) {
+	tests := []struct {
+		name   string
+		format gputypes.TextureFormat
+		expect d3d12.DXGI_FORMAT
+	}{
+		// 8-bit formats
+		{"R8Unorm", gputypes.TextureFormatR8Unorm, d3d12.DXGI_FORMAT_R8_UNORM},
+		{"R8Snorm", gputypes.TextureFormatR8Snorm, d3d12.DXGI_FORMAT_R8_SNORM},
+		{"R8Uint", gputypes.TextureFormatR8Uint, d3d12.DXGI_FORMAT_R8_UINT},
+		{"R8Sint", gputypes.TextureFormatR8Sint, d3d12.DXGI_FORMAT_R8_SINT},
+
+		// 16-bit formats
+		{"R16Uint", gputypes.TextureFormatR16Uint, d3d12.DXGI_FORMAT_R16_UINT},
+		{"R16Sint", gputypes.TextureFormatR16Sint, d3d12.DXGI_FORMAT_R16_SINT},
+		{"R16Float", gputypes.TextureFormatR16Float, d3d12.DXGI_FORMAT_R16_FLOAT},
+		{"RG8Unorm", gputypes.TextureFormatRG8Unorm, d3d12.DXGI_FORMAT_R8G8_UNORM},
+		{"RG8Snorm", gputypes.TextureFormatRG8Snorm, d3d12.DXGI_FORMAT_R8G8_SNORM},
+		{"RG8Uint", gputypes.TextureFormatRG8Uint, d3d12.DXGI_FORMAT_R8G8_UINT},
+		{"RG8Sint", gputypes.TextureFormatRG8Sint, d3d12.DXGI_FORMAT_R8G8_SINT},
+
+		// 32-bit formats
+		{"R32Uint", gputypes.TextureFormatR32Uint, d3d12.DXGI_FORMAT_R32_UINT},
+		{"R32Sint", gputypes.TextureFormatR32Sint, d3d12.DXGI_FORMAT_R32_SINT},
+		{"R32Float", gputypes.TextureFormatR32Float, d3d12.DXGI_FORMAT_R32_FLOAT},
+		{"RG16Uint", gputypes.TextureFormatRG16Uint, d3d12.DXGI_FORMAT_R16G16_UINT},
+		{"RG16Sint", gputypes.TextureFormatRG16Sint, d3d12.DXGI_FORMAT_R16G16_SINT},
+		{"RG16Float", gputypes.TextureFormatRG16Float, d3d12.DXGI_FORMAT_R16G16_FLOAT},
+		{"RGBA8Unorm", gputypes.TextureFormatRGBA8Unorm, d3d12.DXGI_FORMAT_R8G8B8A8_UNORM},
+		{"RGBA8UnormSrgb", gputypes.TextureFormatRGBA8UnormSrgb, d3d12.DXGI_FORMAT_R8G8B8A8_UNORM_SRGB},
+		{"RGBA8Snorm", gputypes.TextureFormatRGBA8Snorm, d3d12.DXGI_FORMAT_R8G8B8A8_SNORM},
+		{"RGBA8Uint", gputypes.TextureFormatRGBA8Uint, d3d12.DXGI_FORMAT_R8G8B8A8_UINT},
+		{"RGBA8Sint", gputypes.TextureFormatRGBA8Sint, d3d12.DXGI_FORMAT_R8G8B8A8_SINT},
+		{"BGRA8Unorm", gputypes.TextureFormatBGRA8Unorm, d3d12.DXGI_FORMAT_B8G8R8A8_UNORM},
+		{"BGRA8UnormSrgb", gputypes.TextureFormatBGRA8UnormSrgb, d3d12.DXGI_FORMAT_B8G8R8A8_UNORM_SRGB},
+
+		// Packed formats
+		{"RGB10A2Uint", gputypes.TextureFormatRGB10A2Uint, d3d12.DXGI_FORMAT_R10G10B10A2_UINT},
+		{"RGB10A2Unorm", gputypes.TextureFormatRGB10A2Unorm, d3d12.DXGI_FORMAT_R10G10B10A2_UNORM},
+		{"RG11B10Ufloat", gputypes.TextureFormatRG11B10Ufloat, d3d12.DXGI_FORMAT_R11G11B10_FLOAT},
+
+		// 64-bit formats
+		{"RG32Uint", gputypes.TextureFormatRG32Uint, d3d12.DXGI_FORMAT_R32G32_UINT},
+		{"RG32Sint", gputypes.TextureFormatRG32Sint, d3d12.DXGI_FORMAT_R32G32_SINT},
+		{"RG32Float", gputypes.TextureFormatRG32Float, d3d12.DXGI_FORMAT_R32G32_FLOAT},
+		{"RGBA16Uint", gputypes.TextureFormatRGBA16Uint, d3d12.DXGI_FORMAT_R16G16B16A16_UINT},
+		{"RGBA16Sint", gputypes.TextureFormatRGBA16Sint, d3d12.DXGI_FORMAT_R16G16B16A16_SINT},
+		{"RGBA16Float", gputypes.TextureFormatRGBA16Float, d3d12.DXGI_FORMAT_R16G16B16A16_FLOAT},
+
+		// 128-bit formats
+		{"RGBA32Uint", gputypes.TextureFormatRGBA32Uint, d3d12.DXGI_FORMAT_R32G32B32A32_UINT},
+		{"RGBA32Sint", gputypes.TextureFormatRGBA32Sint, d3d12.DXGI_FORMAT_R32G32B32A32_SINT},
+		{"RGBA32Float", gputypes.TextureFormatRGBA32Float, d3d12.DXGI_FORMAT_R32G32B32A32_FLOAT},
+
+		// Depth/stencil formats
+		{"Depth16Unorm", gputypes.TextureFormatDepth16Unorm, d3d12.DXGI_FORMAT_D16_UNORM},
+		{"Depth24Plus", gputypes.TextureFormatDepth24Plus, d3d12.DXGI_FORMAT_D24_UNORM_S8_UINT},
+		{"Depth24PlusStencil8", gputypes.TextureFormatDepth24PlusStencil8, d3d12.DXGI_FORMAT_D24_UNORM_S8_UINT},
+		{"Depth32Float", gputypes.TextureFormatDepth32Float, d3d12.DXGI_FORMAT_D32_FLOAT},
+		{"Depth32FloatStencil8", gputypes.TextureFormatDepth32FloatStencil8, d3d12.DXGI_FORMAT_D32_FLOAT_S8X24_UINT},
+		{"Stencil8", gputypes.TextureFormatStencil8, d3d12.DXGI_FORMAT_D24_UNORM_S8_UINT},
+
+		// BC compressed formats
+		{"BC1RGBAUnorm", gputypes.TextureFormatBC1RGBAUnorm, d3d12.DXGI_FORMAT_BC1_UNORM},
+		{"BC1RGBAUnormSrgb", gputypes.TextureFormatBC1RGBAUnormSrgb, d3d12.DXGI_FORMAT_BC1_UNORM_SRGB},
+		{"BC2RGBAUnorm", gputypes.TextureFormatBC2RGBAUnorm, d3d12.DXGI_FORMAT_BC2_UNORM},
+		{"BC2RGBAUnormSrgb", gputypes.TextureFormatBC2RGBAUnormSrgb, d3d12.DXGI_FORMAT_BC2_UNORM_SRGB},
+		{"BC3RGBAUnorm", gputypes.TextureFormatBC3RGBAUnorm, d3d12.DXGI_FORMAT_BC3_UNORM},
+		{"BC3RGBAUnormSrgb", gputypes.TextureFormatBC3RGBAUnormSrgb, d3d12.DXGI_FORMAT_BC3_UNORM_SRGB},
+		{"BC4RUnorm", gputypes.TextureFormatBC4RUnorm, d3d12.DXGI_FORMAT_BC4_UNORM},
+		{"BC4RSnorm", gputypes.TextureFormatBC4RSnorm, d3d12.DXGI_FORMAT_BC4_SNORM},
+		{"BC5RGUnorm", gputypes.TextureFormatBC5RGUnorm, d3d12.DXGI_FORMAT_BC5_UNORM},
+		{"BC5RGSnorm", gputypes.TextureFormatBC5RGSnorm, d3d12.DXGI_FORMAT_BC5_SNORM},
+		{"BC6HRGBUfloat", gputypes.TextureFormatBC6HRGBUfloat, d3d12.DXGI_FORMAT_BC6H_UF16},
+		{"BC6HRGBFloat", gputypes.TextureFormatBC6HRGBFloat, d3d12.DXGI_FORMAT_BC6H_SF16},
+		{"BC7RGBAUnorm", gputypes.TextureFormatBC7RGBAUnorm, d3d12.DXGI_FORMAT_BC7_UNORM},
+		{"BC7RGBAUnormSrgb", gputypes.TextureFormatBC7RGBAUnormSrgb, d3d12.DXGI_FORMAT_BC7_UNORM_SRGB},
+
+		// Unknown format
+		{"Unknown", gputypes.TextureFormat(65535), d3d12.DXGI_FORMAT_UNKNOWN},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := textureFormatToD3D12(tt.format)
+			if got != tt.expect {
+				t.Errorf("textureFormatToD3D12(%v) = %v, want %v", tt.format, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestTextureDimensionToD3D12(t *testing.T) {
+	tests := []struct {
+		name   string
+		dim    gputypes.TextureDimension
+		expect d3d12.D3D12_RESOURCE_DIMENSION
+	}{
+		{"1D", gputypes.TextureDimension1D, d3d12.D3D12_RESOURCE_DIMENSION_TEXTURE1D},
+		{"2D", gputypes.TextureDimension2D, d3d12.D3D12_RESOURCE_DIMENSION_TEXTURE2D},
+		{"3D", gputypes.TextureDimension3D, d3d12.D3D12_RESOURCE_DIMENSION_TEXTURE3D},
+		{"Unknown defaults to 2D", gputypes.TextureDimension(99), d3d12.D3D12_RESOURCE_DIMENSION_TEXTURE2D},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := textureDimensionToD3D12(tt.dim)
+			if got != tt.expect {
+				t.Errorf("textureDimensionToD3D12(%v) = %v, want %v", tt.dim, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestTextureViewDimensionToSRV(t *testing.T) {
+	tests := []struct {
+		name   string
+		dim    gputypes.TextureViewDimension
+		expect d3d12.D3D12_SRV_DIMENSION
+	}{
+		{"1D", gputypes.TextureViewDimension1D, d3d12.D3D12_SRV_DIMENSION_TEXTURE1D},
+		{"2D", gputypes.TextureViewDimension2D, d3d12.D3D12_SRV_DIMENSION_TEXTURE2D},
+		{"2DArray", gputypes.TextureViewDimension2DArray, d3d12.D3D12_SRV_DIMENSION_TEXTURE2DARRAY},
+		{"Cube", gputypes.TextureViewDimensionCube, d3d12.D3D12_SRV_DIMENSION_TEXTURECUBE},
+		{"CubeArray", gputypes.TextureViewDimensionCubeArray, d3d12.D3D12_SRV_DIMENSION_TEXTURECUBEARRAY},
+		{"3D", gputypes.TextureViewDimension3D, d3d12.D3D12_SRV_DIMENSION_TEXTURE3D},
+		{"Unknown defaults to 2D", gputypes.TextureViewDimension(99), d3d12.D3D12_SRV_DIMENSION_TEXTURE2D},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := textureViewDimensionToSRV(tt.dim)
+			if got != tt.expect {
+				t.Errorf("textureViewDimensionToSRV(%v) = %v, want %v", tt.dim, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestTextureViewDimensionToRTV(t *testing.T) {
+	tests := []struct {
+		name   string
+		dim    gputypes.TextureViewDimension
+		expect d3d12.D3D12_RTV_DIMENSION
+	}{
+		{"1D", gputypes.TextureViewDimension1D, d3d12.D3D12_RTV_DIMENSION_TEXTURE1D},
+		{"2D", gputypes.TextureViewDimension2D, d3d12.D3D12_RTV_DIMENSION_TEXTURE2D},
+		{"2DArray", gputypes.TextureViewDimension2DArray, d3d12.D3D12_RTV_DIMENSION_TEXTURE2DARRAY},
+		{"3D", gputypes.TextureViewDimension3D, d3d12.D3D12_RTV_DIMENSION_TEXTURE3D},
+		{"Unknown defaults to 2D", gputypes.TextureViewDimension(99), d3d12.D3D12_RTV_DIMENSION_TEXTURE2D},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := textureViewDimensionToRTV(tt.dim)
+			if got != tt.expect {
+				t.Errorf("textureViewDimensionToRTV(%v) = %v, want %v", tt.dim, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestTextureViewDimensionToDSV(t *testing.T) {
+	tests := []struct {
+		name   string
+		dim    gputypes.TextureViewDimension
+		expect d3d12.D3D12_DSV_DIMENSION
+	}{
+		{"1D", gputypes.TextureViewDimension1D, d3d12.D3D12_DSV_DIMENSION_TEXTURE1D},
+		{"2D", gputypes.TextureViewDimension2D, d3d12.D3D12_DSV_DIMENSION_TEXTURE2D},
+		{"2DArray", gputypes.TextureViewDimension2DArray, d3d12.D3D12_DSV_DIMENSION_TEXTURE2DARRAY},
+		{"Unknown defaults to 2D", gputypes.TextureViewDimension(99), d3d12.D3D12_DSV_DIMENSION_TEXTURE2D},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := textureViewDimensionToDSV(tt.dim)
+			if got != tt.expect {
+				t.Errorf("textureViewDimensionToDSV(%v) = %v, want %v", tt.dim, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestIsDepthFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		format gputypes.TextureFormat
+		expect bool
+	}{
+		{"Depth16Unorm", gputypes.TextureFormatDepth16Unorm, true},
+		{"Depth24Plus", gputypes.TextureFormatDepth24Plus, true},
+		{"Depth24PlusStencil8", gputypes.TextureFormatDepth24PlusStencil8, true},
+		{"Depth32Float", gputypes.TextureFormatDepth32Float, true},
+		{"Depth32FloatStencil8", gputypes.TextureFormatDepth32FloatStencil8, true},
+		{"Stencil8", gputypes.TextureFormatStencil8, true},
+		{"RGBA8Unorm", gputypes.TextureFormatRGBA8Unorm, false},
+		{"R32Float", gputypes.TextureFormatR32Float, false},
+		{"BGRA8Unorm", gputypes.TextureFormatBGRA8Unorm, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isDepthFormat(tt.format)
+			if got != tt.expect {
+				t.Errorf("isDepthFormat(%v) = %v, want %v", tt.format, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestDepthFormatToTypeless(t *testing.T) {
+	tests := []struct {
+		name   string
+		format gputypes.TextureFormat
+		expect d3d12.DXGI_FORMAT
+	}{
+		{"Depth16Unorm", gputypes.TextureFormatDepth16Unorm, d3d12.DXGI_FORMAT_R16_TYPELESS},
+		{"Depth24Plus", gputypes.TextureFormatDepth24Plus, d3d12.DXGI_FORMAT_R24G8_TYPELESS},
+		{"Depth24PlusStencil8", gputypes.TextureFormatDepth24PlusStencil8, d3d12.DXGI_FORMAT_R24G8_TYPELESS},
+		{"Depth32Float", gputypes.TextureFormatDepth32Float, d3d12.DXGI_FORMAT_R32_TYPELESS},
+		{"Depth32FloatStencil8", gputypes.TextureFormatDepth32FloatStencil8, d3d12.DXGI_FORMAT_R32G8X24_TYPELESS},
+		{"Non-depth returns UNKNOWN", gputypes.TextureFormatRGBA8Unorm, d3d12.DXGI_FORMAT_UNKNOWN},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := depthFormatToTypeless(tt.format)
+			if got != tt.expect {
+				t.Errorf("depthFormatToTypeless(%v) = %v, want %v", tt.format, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestDepthFormatToSRV(t *testing.T) {
+	tests := []struct {
+		name   string
+		format gputypes.TextureFormat
+		expect d3d12.DXGI_FORMAT
+	}{
+		{"Depth16Unorm", gputypes.TextureFormatDepth16Unorm, d3d12.DXGI_FORMAT_R16_UNORM},
+		{"Depth24Plus", gputypes.TextureFormatDepth24Plus, d3d12.DXGI_FORMAT_R24_UNORM_X8_TYPELESS},
+		{"Depth24PlusStencil8", gputypes.TextureFormatDepth24PlusStencil8, d3d12.DXGI_FORMAT_R24_UNORM_X8_TYPELESS},
+		{"Depth32Float", gputypes.TextureFormatDepth32Float, d3d12.DXGI_FORMAT_R32_FLOAT},
+		{"Depth32FloatStencil8", gputypes.TextureFormatDepth32FloatStencil8, d3d12.DXGI_FORMAT_R32_FLOAT_X8X24_TYPELESS},
+		{"Non-depth returns UNKNOWN", gputypes.TextureFormatRGBA8Unorm, d3d12.DXGI_FORMAT_UNKNOWN},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := depthFormatToSRV(tt.format)
+			if got != tt.expect {
+				t.Errorf("depthFormatToSRV(%v) = %v, want %v", tt.format, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestAddressModeToD3D12(t *testing.T) {
+	tests := []struct {
+		name   string
+		mode   gputypes.AddressMode
+		expect d3d12.D3D12_TEXTURE_ADDRESS_MODE
+	}{
+		{"Repeat", gputypes.AddressModeRepeat, d3d12.D3D12_TEXTURE_ADDRESS_MODE_WRAP},
+		{"MirrorRepeat", gputypes.AddressModeMirrorRepeat, d3d12.D3D12_TEXTURE_ADDRESS_MODE_MIRROR},
+		{"ClampToEdge", gputypes.AddressModeClampToEdge, d3d12.D3D12_TEXTURE_ADDRESS_MODE_CLAMP},
+		{"Unknown defaults to Clamp", gputypes.AddressMode(99), d3d12.D3D12_TEXTURE_ADDRESS_MODE_CLAMP},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := addressModeToD3D12(tt.mode)
+			if got != tt.expect {
+				t.Errorf("addressModeToD3D12(%v) = %v, want %v", tt.mode, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestFilterModeToD3D12(t *testing.T) {
+	tests := []struct {
+		name    string
+		min     gputypes.FilterMode
+		mag     gputypes.FilterMode
+		mipmap  gputypes.FilterMode
+		compare gputypes.CompareFunction
+		expect  d3d12.D3D12_FILTER
+	}{
+		{"AllNearest", gputypes.FilterModeNearest, gputypes.FilterModeNearest, gputypes.FilterModeNearest, gputypes.CompareFunctionUndefined, d3d12.D3D12_FILTER(0x00)},
+		{"MipLinear", gputypes.FilterModeNearest, gputypes.FilterModeNearest, gputypes.FilterModeLinear, gputypes.CompareFunctionUndefined, d3d12.D3D12_FILTER(0x01)},
+		{"MagLinear", gputypes.FilterModeNearest, gputypes.FilterModeLinear, gputypes.FilterModeNearest, gputypes.CompareFunctionUndefined, d3d12.D3D12_FILTER(0x04)},
+		{"MinLinear", gputypes.FilterModeLinear, gputypes.FilterModeNearest, gputypes.FilterModeNearest, gputypes.CompareFunctionUndefined, d3d12.D3D12_FILTER(0x10)},
+		{"AllLinear", gputypes.FilterModeLinear, gputypes.FilterModeLinear, gputypes.FilterModeLinear, gputypes.CompareFunctionUndefined, d3d12.D3D12_FILTER(0x15)},
+		{"ComparisonAllNearest", gputypes.FilterModeNearest, gputypes.FilterModeNearest, gputypes.FilterModeNearest, gputypes.CompareFunctionLess, d3d12.D3D12_FILTER(0x80)},
+		{"ComparisonAllLinear", gputypes.FilterModeLinear, gputypes.FilterModeLinear, gputypes.FilterModeLinear, gputypes.CompareFunctionLess, d3d12.D3D12_FILTER(0x95)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterModeToD3D12(tt.min, tt.mag, tt.mipmap, tt.compare)
+			if got != tt.expect {
+				t.Errorf("filterModeToD3D12() = %#x, want %#x", got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestCompareFunctionToD3D12(t *testing.T) {
+	tests := []struct {
+		name   string
+		fn     gputypes.CompareFunction
+		expect d3d12.D3D12_COMPARISON_FUNC
+	}{
+		{"Never", gputypes.CompareFunctionNever, d3d12.D3D12_COMPARISON_FUNC_NEVER},
+		{"Less", gputypes.CompareFunctionLess, d3d12.D3D12_COMPARISON_FUNC_LESS},
+		{"Equal", gputypes.CompareFunctionEqual, d3d12.D3D12_COMPARISON_FUNC_EQUAL},
+		{"LessEqual", gputypes.CompareFunctionLessEqual, d3d12.D3D12_COMPARISON_FUNC_LESS_EQUAL},
+		{"Greater", gputypes.CompareFunctionGreater, d3d12.D3D12_COMPARISON_FUNC_GREATER},
+		{"NotEqual", gputypes.CompareFunctionNotEqual, d3d12.D3D12_COMPARISON_FUNC_NOT_EQUAL},
+		{"GreaterEqual", gputypes.CompareFunctionGreaterEqual, d3d12.D3D12_COMPARISON_FUNC_GREATER_EQUAL},
+		{"Always", gputypes.CompareFunctionAlways, d3d12.D3D12_COMPARISON_FUNC_ALWAYS},
+		{"Unknown defaults to Never", gputypes.CompareFunction(99), d3d12.D3D12_COMPARISON_FUNC_NEVER},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareFunctionToD3D12(tt.fn)
+			if got != tt.expect {
+				t.Errorf("compareFunctionToD3D12(%v) = %v, want %v", tt.fn, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestAlignTo256(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  uint64
+		expect uint64
+	}{
+		{"zero", 0, 0},
+		{"1", 1, 256},
+		{"255", 255, 256},
+		{"256", 256, 256},
+		{"257", 257, 512},
+		{"512", 512, 512},
+		{"1000", 1000, 1024},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := alignTo256(tt.input)
+			if got != tt.expect {
+				t.Errorf("alignTo256(%d) = %d, want %d", tt.input, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestBlendFactorToD3D12(t *testing.T) {
+	tests := []struct {
+		name   string
+		factor gputypes.BlendFactor
+		expect d3d12.D3D12_BLEND
+	}{
+		{"Zero", gputypes.BlendFactorZero, d3d12.D3D12_BLEND_ZERO},
+		{"One", gputypes.BlendFactorOne, d3d12.D3D12_BLEND_ONE},
+		{"Src", gputypes.BlendFactorSrc, d3d12.D3D12_BLEND_SRC_COLOR},
+		{"OneMinusSrc", gputypes.BlendFactorOneMinusSrc, d3d12.D3D12_BLEND_INV_SRC_COLOR},
+		{"SrcAlpha", gputypes.BlendFactorSrcAlpha, d3d12.D3D12_BLEND_SRC_ALPHA},
+		{"OneMinusSrcAlpha", gputypes.BlendFactorOneMinusSrcAlpha, d3d12.D3D12_BLEND_INV_SRC_ALPHA},
+		{"Dst", gputypes.BlendFactorDst, d3d12.D3D12_BLEND_DEST_COLOR},
+		{"OneMinusDst", gputypes.BlendFactorOneMinusDst, d3d12.D3D12_BLEND_INV_DEST_COLOR},
+		{"DstAlpha", gputypes.BlendFactorDstAlpha, d3d12.D3D12_BLEND_DEST_ALPHA},
+		{"OneMinusDstAlpha", gputypes.BlendFactorOneMinusDstAlpha, d3d12.D3D12_BLEND_INV_DEST_ALPHA},
+		{"SrcAlphaSaturated", gputypes.BlendFactorSrcAlphaSaturated, d3d12.D3D12_BLEND_SRC_ALPHA_SAT},
+		{"Constant", gputypes.BlendFactorConstant, d3d12.D3D12_BLEND_BLEND_FACTOR},
+		{"OneMinusConstant", gputypes.BlendFactorOneMinusConstant, d3d12.D3D12_BLEND_INV_BLEND_FACTOR},
+		{"Unknown defaults to One", gputypes.BlendFactor(99), d3d12.D3D12_BLEND_ONE},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := blendFactorToD3D12(tt.factor)
+			if got != tt.expect {
+				t.Errorf("blendFactorToD3D12(%v) = %v, want %v", tt.factor, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestBlendOperationToD3D12(t *testing.T) {
+	tests := []struct {
+		name   string
+		op     gputypes.BlendOperation
+		expect d3d12.D3D12_BLEND_OP
+	}{
+		{"Add", gputypes.BlendOperationAdd, d3d12.D3D12_BLEND_OP_ADD},
+		{"Subtract", gputypes.BlendOperationSubtract, d3d12.D3D12_BLEND_OP_SUBTRACT},
+		{"ReverseSubtract", gputypes.BlendOperationReverseSubtract, d3d12.D3D12_BLEND_OP_REV_SUBTRACT},
+		{"Min", gputypes.BlendOperationMin, d3d12.D3D12_BLEND_OP_MIN},
+		{"Max", gputypes.BlendOperationMax, d3d12.D3D12_BLEND_OP_MAX},
+		{"Unknown defaults to Add", gputypes.BlendOperation(99), d3d12.D3D12_BLEND_OP_ADD},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := blendOperationToD3D12(tt.op)
+			if got != tt.expect {
+				t.Errorf("blendOperationToD3D12(%v) = %v, want %v", tt.op, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestCullModeToD3D12(t *testing.T) {
+	tests := []struct {
+		name   string
+		mode   gputypes.CullMode
+		expect d3d12.D3D12_CULL_MODE
+	}{
+		{"None", gputypes.CullModeNone, d3d12.D3D12_CULL_MODE_NONE},
+		{"Front", gputypes.CullModeFront, d3d12.D3D12_CULL_MODE_FRONT},
+		{"Back", gputypes.CullModeBack, d3d12.D3D12_CULL_MODE_BACK},
+		{"Unknown defaults to None", gputypes.CullMode(99), d3d12.D3D12_CULL_MODE_NONE},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cullModeToD3D12(tt.mode)
+			if got != tt.expect {
+				t.Errorf("cullModeToD3D12(%v) = %v, want %v", tt.mode, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestFrontFaceToD3D12(t *testing.T) {
+	tests := []struct {
+		name   string
+		face   gputypes.FrontFace
+		expect int32
+	}{
+		{"CCW", gputypes.FrontFaceCCW, 1},
+		{"CW", gputypes.FrontFaceCW, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := frontFaceToD3D12(tt.face)
+			if got != tt.expect {
+				t.Errorf("frontFaceToD3D12(%v) = %v, want %v", tt.face, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestPrimitiveTopologyTypeToD3D12(t *testing.T) {
+	tests := []struct {
+		name     string
+		topology gputypes.PrimitiveTopology
+		expect   d3d12.D3D12_PRIMITIVE_TOPOLOGY_TYPE
+	}{
+		{"PointList", gputypes.PrimitiveTopologyPointList, d3d12.D3D12_PRIMITIVE_TOPOLOGY_TYPE_POINT},
+		{"LineList", gputypes.PrimitiveTopologyLineList, d3d12.D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE},
+		{"LineStrip", gputypes.PrimitiveTopologyLineStrip, d3d12.D3D12_PRIMITIVE_TOPOLOGY_TYPE_LINE},
+		{"TriangleList", gputypes.PrimitiveTopologyTriangleList, d3d12.D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE},
+		{"TriangleStrip", gputypes.PrimitiveTopologyTriangleStrip, d3d12.D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE},
+		{"Unknown defaults to Triangle", gputypes.PrimitiveTopology(99), d3d12.D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := primitiveTopologyTypeToD3D12(tt.topology)
+			if got != tt.expect {
+				t.Errorf("primitiveTopologyTypeToD3D12(%v) = %v, want %v", tt.topology, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestPrimitiveTopologyToD3D12(t *testing.T) {
+	tests := []struct {
+		name     string
+		topology gputypes.PrimitiveTopology
+		expect   d3d12.D3D_PRIMITIVE_TOPOLOGY
+	}{
+		{"PointList", gputypes.PrimitiveTopologyPointList, d3d12.D3D_PRIMITIVE_TOPOLOGY_POINTLIST},
+		{"LineList", gputypes.PrimitiveTopologyLineList, d3d12.D3D_PRIMITIVE_TOPOLOGY_LINELIST},
+		{"LineStrip", gputypes.PrimitiveTopologyLineStrip, d3d12.D3D_PRIMITIVE_TOPOLOGY_LINESTRIP},
+		{"TriangleList", gputypes.PrimitiveTopologyTriangleList, d3d12.D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST},
+		{"TriangleStrip", gputypes.PrimitiveTopologyTriangleStrip, d3d12.D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP},
+		{"Unknown defaults to TriangleList", gputypes.PrimitiveTopology(99), d3d12.D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := primitiveTopologyToD3D12(tt.topology)
+			if got != tt.expect {
+				t.Errorf("primitiveTopologyToD3D12(%v) = %v, want %v", tt.topology, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestStencilOpToD3D12(t *testing.T) {
+	tests := []struct {
+		name   string
+		op     hal.StencilOperation
+		expect d3d12.D3D12_STENCIL_OP
+	}{
+		{"Keep", hal.StencilOperationKeep, d3d12.D3D12_STENCIL_OP_KEEP},
+		{"Zero", hal.StencilOperationZero, d3d12.D3D12_STENCIL_OP_ZERO},
+		{"Replace", hal.StencilOperationReplace, d3d12.D3D12_STENCIL_OP_REPLACE},
+		{"Invert", hal.StencilOperationInvert, d3d12.D3D12_STENCIL_OP_INVERT},
+		{"IncrementClamp", hal.StencilOperationIncrementClamp, d3d12.D3D12_STENCIL_OP_INCR_SAT},
+		{"DecrementClamp", hal.StencilOperationDecrementClamp, d3d12.D3D12_STENCIL_OP_DECR_SAT},
+		{"IncrementWrap", hal.StencilOperationIncrementWrap, d3d12.D3D12_STENCIL_OP_INCR},
+		{"DecrementWrap", hal.StencilOperationDecrementWrap, d3d12.D3D12_STENCIL_OP_DECR},
+		{"Unknown defaults to Keep", hal.StencilOperation(99), d3d12.D3D12_STENCIL_OP_KEEP},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stencilOpToD3D12(tt.op)
+			if got != tt.expect {
+				t.Errorf("stencilOpToD3D12(%v) = %v, want %v", tt.op, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestInputStepModeToD3D12(t *testing.T) {
+	tests := []struct {
+		name   string
+		mode   gputypes.VertexStepMode
+		expect d3d12.D3D12_INPUT_CLASSIFICATION
+	}{
+		{"Vertex", gputypes.VertexStepModeVertex, d3d12.D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA},
+		{"Instance", gputypes.VertexStepModeInstance, d3d12.D3D12_INPUT_CLASSIFICATION_PER_INSTANCE_DATA},
+		{"Unknown defaults to Vertex", gputypes.VertexStepMode(99), d3d12.D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inputStepModeToD3D12(tt.mode)
+			if got != tt.expect {
+				t.Errorf("inputStepModeToD3D12(%v) = %v, want %v", tt.mode, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestVertexFormatToD3D12(t *testing.T) {
+	tests := []struct {
+		name   string
+		format gputypes.VertexFormat
+		expect d3d12.DXGI_FORMAT
+	}{
+		// 8-bit formats
+		{"Uint8x2", gputypes.VertexFormatUint8x2, d3d12.DXGI_FORMAT_R8G8_UINT},
+		{"Uint8x4", gputypes.VertexFormatUint8x4, d3d12.DXGI_FORMAT_R8G8B8A8_UINT},
+		{"Sint8x2", gputypes.VertexFormatSint8x2, d3d12.DXGI_FORMAT_R8G8_SINT},
+		{"Sint8x4", gputypes.VertexFormatSint8x4, d3d12.DXGI_FORMAT_R8G8B8A8_SINT},
+		{"Unorm8x2", gputypes.VertexFormatUnorm8x2, d3d12.DXGI_FORMAT_R8G8_UNORM},
+		{"Unorm8x4", gputypes.VertexFormatUnorm8x4, d3d12.DXGI_FORMAT_R8G8B8A8_UNORM},
+		{"Snorm8x2", gputypes.VertexFormatSnorm8x2, d3d12.DXGI_FORMAT_R8G8_SNORM},
+		{"Snorm8x4", gputypes.VertexFormatSnorm8x4, d3d12.DXGI_FORMAT_R8G8B8A8_SNORM},
+
+		// 16-bit formats
+		{"Uint16x2", gputypes.VertexFormatUint16x2, d3d12.DXGI_FORMAT_R16G16_UINT},
+		{"Uint16x4", gputypes.VertexFormatUint16x4, d3d12.DXGI_FORMAT_R16G16B16A16_UINT},
+		{"Sint16x2", gputypes.VertexFormatSint16x2, d3d12.DXGI_FORMAT_R16G16_SINT},
+		{"Sint16x4", gputypes.VertexFormatSint16x4, d3d12.DXGI_FORMAT_R16G16B16A16_SINT},
+		{"Unorm16x2", gputypes.VertexFormatUnorm16x2, d3d12.DXGI_FORMAT_R16G16_UNORM},
+		{"Unorm16x4", gputypes.VertexFormatUnorm16x4, d3d12.DXGI_FORMAT_R16G16B16A16_UNORM},
+		{"Snorm16x2", gputypes.VertexFormatSnorm16x2, d3d12.DXGI_FORMAT_R16G16_SNORM},
+		{"Snorm16x4", gputypes.VertexFormatSnorm16x4, d3d12.DXGI_FORMAT_R16G16B16A16_SNORM},
+		{"Float16x2", gputypes.VertexFormatFloat16x2, d3d12.DXGI_FORMAT_R16G16_FLOAT},
+		{"Float16x4", gputypes.VertexFormatFloat16x4, d3d12.DXGI_FORMAT_R16G16B16A16_FLOAT},
+
+		// 32-bit formats
+		{"Float32", gputypes.VertexFormatFloat32, d3d12.DXGI_FORMAT_R32_FLOAT},
+		{"Float32x2", gputypes.VertexFormatFloat32x2, d3d12.DXGI_FORMAT_R32G32_FLOAT},
+		{"Float32x3", gputypes.VertexFormatFloat32x3, d3d12.DXGI_FORMAT_R32G32B32_FLOAT},
+		{"Float32x4", gputypes.VertexFormatFloat32x4, d3d12.DXGI_FORMAT_R32G32B32A32_FLOAT},
+		{"Uint32", gputypes.VertexFormatUint32, d3d12.DXGI_FORMAT_R32_UINT},
+		{"Uint32x2", gputypes.VertexFormatUint32x2, d3d12.DXGI_FORMAT_R32G32_UINT},
+		{"Uint32x3", gputypes.VertexFormatUint32x3, d3d12.DXGI_FORMAT_R32G32B32_UINT},
+		{"Uint32x4", gputypes.VertexFormatUint32x4, d3d12.DXGI_FORMAT_R32G32B32A32_UINT},
+		{"Sint32", gputypes.VertexFormatSint32, d3d12.DXGI_FORMAT_R32_SINT},
+		{"Sint32x2", gputypes.VertexFormatSint32x2, d3d12.DXGI_FORMAT_R32G32_SINT},
+		{"Sint32x3", gputypes.VertexFormatSint32x3, d3d12.DXGI_FORMAT_R32G32B32_SINT},
+		{"Sint32x4", gputypes.VertexFormatSint32x4, d3d12.DXGI_FORMAT_R32G32B32A32_SINT},
+
+		// Packed
+		{"Unorm1010102", gputypes.VertexFormatUnorm1010102, d3d12.DXGI_FORMAT_R10G10B10A2_UNORM},
+
+		// Unknown
+		{"Unknown", gputypes.VertexFormat(255), d3d12.DXGI_FORMAT_UNKNOWN},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := vertexFormatToD3D12(tt.format)
+			if got != tt.expect {
+				t.Errorf("vertexFormatToD3D12(%v) = %v, want %v", tt.format, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestColorWriteMaskToD3D12(t *testing.T) {
+	tests := []struct {
+		name   string
+		mask   gputypes.ColorWriteMask
+		expect uint8
+	}{
+		{"Red", gputypes.ColorWriteMaskRed, uint8(d3d12.D3D12_COLOR_WRITE_ENABLE_RED)},
+		{"Green", gputypes.ColorWriteMaskGreen, uint8(d3d12.D3D12_COLOR_WRITE_ENABLE_GREEN)},
+		{"Blue", gputypes.ColorWriteMaskBlue, uint8(d3d12.D3D12_COLOR_WRITE_ENABLE_BLUE)},
+		{"Alpha", gputypes.ColorWriteMaskAlpha, uint8(d3d12.D3D12_COLOR_WRITE_ENABLE_ALPHA)},
+		{
+			"All",
+			gputypes.ColorWriteMaskRed | gputypes.ColorWriteMaskGreen | gputypes.ColorWriteMaskBlue | gputypes.ColorWriteMaskAlpha,
+			uint8(d3d12.D3D12_COLOR_WRITE_ENABLE_RED) | uint8(d3d12.D3D12_COLOR_WRITE_ENABLE_GREEN) | uint8(d3d12.D3D12_COLOR_WRITE_ENABLE_BLUE) | uint8(d3d12.D3D12_COLOR_WRITE_ENABLE_ALPHA),
+		},
+		{"None", gputypes.ColorWriteMask(0), 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := colorWriteMaskToD3D12(tt.mask)
+			if got != tt.expect {
+				t.Errorf("colorWriteMaskToD3D12(%v) = %v, want %v", tt.mask, got, tt.expect)
+			}
+		})
+	}
+}
+
+func TestShaderStagesToD3D12Visibility(t *testing.T) {
+	tests := []struct {
+		name   string
+		stages gputypes.ShaderStages
+		expect d3d12.D3D12_SHADER_VISIBILITY
+	}{
+		{"Vertex only", gputypes.ShaderStageVertex, d3d12.D3D12_SHADER_VISIBILITY_VERTEX},
+		{"Fragment only", gputypes.ShaderStageFragment, d3d12.D3D12_SHADER_VISIBILITY_PIXEL},
+		{"All stages", gputypes.ShaderStageVertex | gputypes.ShaderStageFragment | gputypes.ShaderStageCompute, d3d12.D3D12_SHADER_VISIBILITY_ALL},
+		{"Vertex+Fragment", gputypes.ShaderStageVertex | gputypes.ShaderStageFragment, d3d12.D3D12_SHADER_VISIBILITY_ALL},
+		{"Compute only", gputypes.ShaderStageCompute, d3d12.D3D12_SHADER_VISIBILITY_ALL},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shaderStagesToD3D12Visibility(tt.stages)
+			if got != tt.expect {
+				t.Errorf("shaderStagesToD3D12Visibility(%v) = %v, want %v", tt.stages, got, tt.expect)
+			}
+		})
+	}
+}

--- a/hal/metal/adapter.go
+++ b/hal/metal/adapter.go
@@ -52,7 +52,7 @@ func (a *Adapter) Open(features gputypes.Features, limits gputypes.Limits) (hal.
 	// Uses a buffered channel of size maxFramesInFlight pre-filled with tokens.
 	// Each Submit() consumes a token; the GPU's addCompletedHandler: returns it.
 	// If block support is unavailable, frameSemaphore stays nil (no throttling).
-	if symNSConcreteStackBlock != 0 {
+	if symNSConcreteGlobalBlock != 0 {
 		queue.frameSemaphore = make(chan struct{}, maxFramesInFlight)
 		for i := 0; i < maxFramesInFlight; i++ {
 			queue.frameSemaphore <- struct{}{}
@@ -64,7 +64,7 @@ func (a *Adapter) Open(features gputypes.Features, limits gputypes.Limits) (hal.
 
 	hal.Logger().Debug("metal: adapter opened",
 		"maxFramesInFlight", maxFramesInFlight,
-		"blockSupport", symNSConcreteStackBlock != 0,
+		"blockSupport", symNSConcreteGlobalBlock != 0,
 	)
 
 	return hal.OpenDevice{

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -832,10 +832,9 @@ func (d *Device) waitEventDriven(mtlFence *Fence, value uint64, timeout time.Dur
 		argPointer(blockPtr),
 	)
 
-	// Keep block alive until notification fires or times out.
-	// The block struct is on the Go heap; runtime.KeepAlive prevents GC
-	// from collecting the underlying memory while Metal holds a reference.
-	defer runtime.KeepAlive(blockPtr)
+	// Block is pinned via blockPinRegistry until releaseBlock(blockID).
+	// No runtime.KeepAlive needed — the deferred releaseBlock above
+	// keeps the pin alive for the entire function scope.
 
 	// Wait for the callback or timeout.
 	select {

--- a/hal/software/software_test.go
+++ b/hal/software/software_test.go
@@ -345,3 +345,800 @@ func TestAdapterDownlevelNoCompute(t *testing.T) {
 		t.Error("software backend should not report compute shader support")
 	}
 }
+
+// =============================================================================
+// Device Resource Tests
+// =============================================================================
+
+func createSoftwareDevice(t *testing.T) (*Device, hal.Queue, func()) {
+	t.Helper()
+	backend := API{}
+	instance, _ := backend.CreateInstance(&hal.InstanceDescriptor{})
+	adapters := instance.EnumerateAdapters(nil)
+	openDev, _ := adapters[0].Adapter.Open(0, gputypes.DefaultLimits())
+	dev := openDev.Device.(*Device)
+	cleanup := func() {
+		openDev.Device.Destroy()
+		instance.Destroy()
+	}
+	return dev, openDev.Queue, cleanup
+}
+
+func TestDeviceCreateTextureView(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	tex, err := dev.CreateTexture(&hal.TextureDescriptor{
+		Size:   hal.Extent3D{Width: 32, Height: 32, DepthOrArrayLayers: 1},
+		Format: gputypes.TextureFormatRGBA8Unorm,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture failed: %v", err)
+	}
+	defer dev.DestroyTexture(tex)
+
+	view, err := dev.CreateTextureView(tex, &hal.TextureViewDescriptor{})
+	if err != nil {
+		t.Fatalf("CreateTextureView failed: %v", err)
+	}
+	if view == nil {
+		t.Fatal("TextureView is nil")
+	}
+	defer dev.DestroyTextureView(view)
+
+	// View should reference the original texture
+	tv, ok := view.(*TextureView)
+	if !ok {
+		t.Fatal("expected *TextureView")
+	}
+	if tv.texture == nil {
+		t.Fatal("TextureView.texture is nil")
+	}
+}
+
+func TestDeviceCreateTextureViewNonSoftwareTexture(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	// Pass a non-software texture (using noop Resource as mock)
+	view, err := dev.CreateTextureView(&Resource{}, &hal.TextureViewDescriptor{})
+	if err != nil {
+		t.Fatalf("CreateTextureView with non-software texture should not error: %v", err)
+	}
+	// Should return a plain Resource
+	_, isResource := view.(*Resource)
+	if !isResource {
+		t.Error("expected *Resource for non-software texture")
+	}
+}
+
+func TestDeviceCreateSampler(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	sampler, err := dev.CreateSampler(&hal.SamplerDescriptor{Label: "test"})
+	if err != nil {
+		t.Fatalf("CreateSampler failed: %v", err)
+	}
+	if sampler == nil {
+		t.Fatal("sampler is nil")
+	}
+	dev.DestroySampler(sampler) // no-op, should not panic
+}
+
+func TestDeviceCreateBindGroupLayout(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	bgl, err := dev.CreateBindGroupLayout(&hal.BindGroupLayoutDescriptor{Label: "test"})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout failed: %v", err)
+	}
+	if bgl == nil {
+		t.Fatal("BindGroupLayout is nil")
+	}
+	dev.DestroyBindGroupLayout(bgl)
+}
+
+func TestDeviceCreateBindGroup(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	bg, err := dev.CreateBindGroup(&hal.BindGroupDescriptor{Label: "test"})
+	if err != nil {
+		t.Fatalf("CreateBindGroup failed: %v", err)
+	}
+	if bg == nil {
+		t.Fatal("BindGroup is nil")
+	}
+	dev.DestroyBindGroup(bg)
+}
+
+func TestDeviceCreatePipelineLayout(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	pl, err := dev.CreatePipelineLayout(&hal.PipelineLayoutDescriptor{Label: "test"})
+	if err != nil {
+		t.Fatalf("CreatePipelineLayout failed: %v", err)
+	}
+	if pl == nil {
+		t.Fatal("PipelineLayout is nil")
+	}
+	dev.DestroyPipelineLayout(pl)
+}
+
+func TestDeviceCreateShaderModule(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	sm, err := dev.CreateShaderModule(&hal.ShaderModuleDescriptor{Label: "test"})
+	if err != nil {
+		t.Fatalf("CreateShaderModule failed: %v", err)
+	}
+	if sm == nil {
+		t.Fatal("ShaderModule is nil")
+	}
+	dev.DestroyShaderModule(sm)
+}
+
+func TestDeviceCreateRenderPipeline(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	rp, err := dev.CreateRenderPipeline(&hal.RenderPipelineDescriptor{Label: "test"})
+	if err != nil {
+		t.Fatalf("CreateRenderPipeline failed: %v", err)
+	}
+	if rp == nil {
+		t.Fatal("RenderPipeline is nil")
+	}
+	dev.DestroyRenderPipeline(rp)
+}
+
+func TestDeviceCreateQuerySet(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	qs, err := dev.CreateQuerySet(&hal.QuerySetDescriptor{})
+	if err == nil {
+		t.Fatal("CreateQuerySet should return error for software backend")
+	}
+	if qs != nil {
+		t.Fatal("CreateQuerySet should return nil")
+	}
+}
+
+func TestDeviceCreateRenderBundleEncoder(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, err := dev.CreateRenderBundleEncoder(&hal.RenderBundleEncoderDescriptor{})
+	if err == nil {
+		t.Fatal("CreateRenderBundleEncoder should return error for software backend")
+	}
+	if enc != nil {
+		t.Fatal("CreateRenderBundleEncoder should return nil")
+	}
+}
+
+func TestDeviceCreateCommandEncoder(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, err := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{Label: "test"})
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder failed: %v", err)
+	}
+	if enc == nil {
+		t.Fatal("CommandEncoder is nil")
+	}
+}
+
+func TestDeviceFenceOperations(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	fence, err := dev.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence failed: %v", err)
+	}
+	defer dev.DestroyFence(fence)
+
+	// Initial status should be unsignaled
+	signaled, err := dev.GetFenceStatus(fence)
+	if err != nil {
+		t.Fatalf("GetFenceStatus failed: %v", err)
+	}
+	if signaled {
+		t.Error("fence should not be signaled initially")
+	}
+
+	// Signal the fence
+	f := fence.(*Fence)
+	f.value.Store(1)
+
+	// Now should be signaled
+	signaled, err = dev.GetFenceStatus(fence)
+	if err != nil {
+		t.Fatalf("GetFenceStatus failed: %v", err)
+	}
+	if !signaled {
+		t.Error("fence should be signaled after store")
+	}
+
+	// Wait should return true (already at value)
+	ok, err := dev.Wait(fence, 1, 0)
+	if err != nil {
+		t.Fatalf("Wait failed: %v", err)
+	}
+	if !ok {
+		t.Error("Wait should return true when fence has reached value")
+	}
+
+	// Wait for a higher value should return false
+	ok, err = dev.Wait(fence, 100, 0)
+	if err != nil {
+		t.Fatalf("Wait failed: %v", err)
+	}
+	if ok {
+		t.Error("Wait should return false when fence hasn't reached value")
+	}
+
+	// Reset fence
+	err = dev.ResetFence(fence)
+	if err != nil {
+		t.Fatalf("ResetFence failed: %v", err)
+	}
+	if f.value.Load() != 0 {
+		t.Error("fence value should be 0 after reset")
+	}
+}
+
+func TestDeviceFenceWithNonSoftwareFence(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	// Use nil fence -- tests type assertion fallback paths
+	var fake hal.Fence
+
+	ok, err := dev.Wait(fake, 0, 0)
+	if err != nil {
+		t.Errorf("Wait with nil fence should not error: %v", err)
+	}
+	if !ok {
+		t.Error("Wait with nil fence should return true (fallback)")
+	}
+
+	signaled, err := dev.GetFenceStatus(fake)
+	if err != nil {
+		t.Errorf("GetFenceStatus with nil fence should not error: %v", err)
+	}
+	if signaled {
+		t.Error("GetFenceStatus with nil fence should return false")
+	}
+
+	err = dev.ResetFence(fake)
+	if err != nil {
+		t.Errorf("ResetFence with nil fence should not error: %v", err)
+	}
+}
+
+func TestDeviceWaitIdle(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	if err := dev.WaitIdle(); err != nil {
+		t.Fatalf("WaitIdle failed: %v", err)
+	}
+}
+
+func TestDeviceDestroyNoOps(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	// All Destroy methods are no-ops; should not panic with nil
+	dev.DestroyBuffer(nil)
+	dev.DestroyTexture(nil)
+	dev.DestroyTextureView(nil)
+	dev.DestroySampler(nil)
+	dev.DestroyBindGroupLayout(nil)
+	dev.DestroyBindGroup(nil)
+	dev.DestroyPipelineLayout(nil)
+	dev.DestroyShaderModule(nil)
+	dev.DestroyRenderPipeline(nil)
+	dev.DestroyComputePipeline(nil)
+	dev.DestroyQuerySet(nil)
+	dev.DestroyRenderBundle(nil)
+	dev.DestroyFence(nil)
+	dev.FreeCommandBuffer(nil)
+}
+
+// =============================================================================
+// Command Encoder Tests
+// =============================================================================
+
+func TestCommandEncoderBeginEnd(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+
+	if err := enc.BeginEncoding("test-pass"); err != nil {
+		t.Fatalf("BeginEncoding failed: %v", err)
+	}
+
+	cmdBuf, err := enc.EndEncoding()
+	if err != nil {
+		t.Fatalf("EndEncoding failed: %v", err)
+	}
+	if cmdBuf == nil {
+		t.Fatal("EndEncoding returned nil")
+	}
+}
+
+func TestCommandEncoderDiscardAndReset(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+
+	_ = enc.BeginEncoding("test")
+	enc.DiscardEncoding() // should not panic
+
+	enc.ResetAll(nil)
+	enc.ResetAll([]hal.CommandBuffer{})
+}
+
+func TestCommandEncoderTransitions(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+
+	enc.TransitionBuffers(nil)
+	enc.TransitionBuffers([]hal.BufferBarrier{{}})
+	enc.TransitionTextures(nil)
+	enc.TransitionTextures([]hal.TextureBarrier{{}})
+}
+
+func TestCommandEncoderClearBuffer(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+
+	buf, _ := dev.CreateBuffer(&hal.BufferDescriptor{Size: 256, Usage: gputypes.BufferUsageCopyDst})
+	defer dev.DestroyBuffer(buf)
+
+	// Write some data first
+	b := buf.(*Buffer)
+	b.WriteData(0, []byte{1, 2, 3, 4, 5, 6, 7, 8})
+
+	// Clear the buffer
+	enc.ClearBuffer(buf, 0, 8)
+
+	// Verify cleared
+	data := b.GetData()
+	for i := 0; i < 8; i++ {
+		if data[i] != 0 {
+			t.Errorf("byte %d = %d, want 0 after clear", i, data[i])
+		}
+	}
+}
+
+func TestCommandEncoderCopyBufferToBuffer(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+
+	srcBuf, _ := dev.CreateBuffer(&hal.BufferDescriptor{Size: 256})
+	dstBuf, _ := dev.CreateBuffer(&hal.BufferDescriptor{Size: 256})
+	defer dev.DestroyBuffer(srcBuf)
+	defer dev.DestroyBuffer(dstBuf)
+
+	// Write test data
+	src := srcBuf.(*Buffer)
+	src.WriteData(0, []byte{10, 20, 30, 40})
+
+	enc.CopyBufferToBuffer(srcBuf, dstBuf, []hal.BufferCopy{
+		{SrcOffset: 0, DstOffset: 0, Size: 4},
+	})
+
+	dst := dstBuf.(*Buffer)
+	data := dst.GetData()
+	for i := 0; i < 4; i++ {
+		expected := byte((i + 1) * 10)
+		if data[i] != expected {
+			t.Errorf("byte %d = %d, want %d", i, data[i], expected)
+		}
+	}
+}
+
+func TestCommandEncoderCopyBufferToTexture(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+
+	buf, _ := dev.CreateBuffer(&hal.BufferDescriptor{Size: 64})
+	tex, _ := dev.CreateTexture(&hal.TextureDescriptor{
+		Size: hal.Extent3D{Width: 2, Height: 2, DepthOrArrayLayers: 1},
+	})
+	defer dev.DestroyBuffer(buf)
+	defer dev.DestroyTexture(tex)
+
+	// Write 16 bytes (2x2 RGBA)
+	srcBuf := buf.(*Buffer)
+	srcBuf.WriteData(0, []byte{
+		255, 0, 0, 255, // R
+		0, 255, 0, 255, // G
+		0, 0, 255, 255, // B
+		255, 255, 0, 255, // Y
+	})
+
+	enc.CopyBufferToTexture(buf, tex, []hal.BufferTextureCopy{
+		{
+			BufferLayout: hal.ImageDataLayout{Offset: 0},
+			Size:         hal.Extent3D{Width: 2, Height: 2, DepthOrArrayLayers: 1},
+		},
+	})
+
+	// Verify texture has data
+	dstTex := tex.(*Texture)
+	data := dstTex.GetData()
+	if data[0] != 255 || data[1] != 0 || data[2] != 0 || data[3] != 255 {
+		t.Errorf("first pixel = (%d,%d,%d,%d), want (255,0,0,255)", data[0], data[1], data[2], data[3])
+	}
+}
+
+func TestCommandEncoderCopyTextureToBuffer(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+
+	tex, _ := dev.CreateTexture(&hal.TextureDescriptor{
+		Size: hal.Extent3D{Width: 2, Height: 2, DepthOrArrayLayers: 1},
+	})
+	buf, _ := dev.CreateBuffer(&hal.BufferDescriptor{Size: 64})
+	defer dev.DestroyTexture(tex)
+	defer dev.DestroyBuffer(buf)
+
+	// Write data to texture
+	srcTex := tex.(*Texture)
+	srcTex.WriteData(0, []byte{100, 200, 150, 255, 50, 75, 25, 128})
+
+	enc.CopyTextureToBuffer(tex, buf, []hal.BufferTextureCopy{
+		{
+			BufferLayout: hal.ImageDataLayout{Offset: 0},
+			Size:         hal.Extent3D{Width: 2, Height: 1, DepthOrArrayLayers: 1},
+		},
+	})
+
+	dstBuf := buf.(*Buffer)
+	data := dstBuf.GetData()
+	if data[0] != 100 || data[1] != 200 {
+		t.Errorf("copied data = (%d,%d,...), want (100,200,...)", data[0], data[1])
+	}
+}
+
+func TestCommandEncoderCopyTextureToTexture(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+
+	tex1, _ := dev.CreateTexture(&hal.TextureDescriptor{
+		Size: hal.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+	})
+	tex2, _ := dev.CreateTexture(&hal.TextureDescriptor{
+		Size: hal.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+	})
+	defer dev.DestroyTexture(tex1)
+	defer dev.DestroyTexture(tex2)
+
+	// Write data to source
+	srcTex := tex1.(*Texture)
+	srcTex.Clear(gputypes.Color{R: 0.5, G: 0.25, B: 0.75, A: 1.0})
+
+	enc.CopyTextureToTexture(tex1, tex2, []hal.TextureCopy{
+		{Size: hal.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1}},
+	})
+
+	dstTex := tex2.(*Texture)
+	data := dstTex.GetData()
+	// 0.5 * 255 = 127
+	if data[0] != 127 {
+		t.Errorf("first byte = %d, want ~127", data[0])
+	}
+}
+
+func TestCommandEncoderCopyWithNonSoftwareBuffers(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+
+	// Use Resource (non-Buffer/non-Texture) -- should not panic, just return
+	r := &Resource{}
+	enc.ClearBuffer(r, 0, 64)                          // non-Buffer, no-op
+	enc.CopyBufferToBuffer(r, r, []hal.BufferCopy{{}}) // non-Buffer, no-op
+	enc.CopyBufferToTexture(r, r, []hal.BufferTextureCopy{{}})
+	enc.CopyTextureToBuffer(r, r, []hal.BufferTextureCopy{{}})
+	enc.CopyTextureToTexture(r, r, []hal.TextureCopy{{}})
+}
+
+func TestCommandEncoderResolveQuerySet(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+	buf, _ := dev.CreateBuffer(&hal.BufferDescriptor{Size: 64})
+	defer dev.DestroyBuffer(buf)
+
+	enc.ResolveQuerySet(nil, 0, 1, buf, 0) // no-op
+}
+
+// =============================================================================
+// Render Pass Encoder Tests
+// =============================================================================
+
+func TestRenderPassEncoderEnd(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	tex, _ := dev.CreateTexture(&hal.TextureDescriptor{
+		Size:  hal.Extent3D{Width: 16, Height: 16, DepthOrArrayLayers: 1},
+		Usage: gputypes.TextureUsageRenderAttachment,
+	})
+	defer dev.DestroyTexture(tex)
+
+	view, _ := dev.CreateTextureView(tex, &hal.TextureViewDescriptor{})
+	defer dev.DestroyTextureView(view)
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+	pass := enc.BeginRenderPass(&hal.RenderPassDescriptor{
+		ColorAttachments: []hal.RenderPassColorAttachment{
+			{
+				View:       view,
+				LoadOp:     gputypes.LoadOpClear,
+				StoreOp:    gputypes.StoreOpStore,
+				ClearValue: gputypes.Color{R: 1, G: 0, B: 0, A: 1},
+			},
+		},
+	})
+
+	pass.End()
+
+	// Verify that the clear color was applied
+	underlyingTex := tex.(*Texture)
+	data := underlyingTex.GetData()
+	if data[0] != 255 || data[1] != 0 || data[2] != 0 || data[3] != 255 {
+		t.Errorf("after clear: pixel = (%d,%d,%d,%d), want (255,0,0,255)", data[0], data[1], data[2], data[3])
+	}
+}
+
+func TestRenderPassEncoderWithDepthStencil(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	colorTex, _ := dev.CreateTexture(&hal.TextureDescriptor{
+		Size: hal.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+	})
+	depthTex, _ := dev.CreateTexture(&hal.TextureDescriptor{
+		Size: hal.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+	})
+	defer dev.DestroyTexture(colorTex)
+	defer dev.DestroyTexture(depthTex)
+
+	colorView, _ := dev.CreateTextureView(colorTex, &hal.TextureViewDescriptor{})
+	depthView, _ := dev.CreateTextureView(depthTex, &hal.TextureViewDescriptor{})
+	defer dev.DestroyTextureView(colorView)
+	defer dev.DestroyTextureView(depthView)
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+	pass := enc.BeginRenderPass(&hal.RenderPassDescriptor{
+		ColorAttachments: []hal.RenderPassColorAttachment{
+			{View: colorView, LoadOp: gputypes.LoadOpClear},
+		},
+		DepthStencilAttachment: &hal.RenderPassDepthStencilAttachment{
+			View:            depthView,
+			DepthLoadOp:     gputypes.LoadOpClear,
+			DepthClearValue: 1.0,
+		},
+	})
+	pass.End() // should not panic
+}
+
+func TestRenderPassEncoderAllNoOps(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+	pass := enc.BeginRenderPass(&hal.RenderPassDescriptor{
+		ColorAttachments: []hal.RenderPassColorAttachment{},
+	})
+
+	buf, _ := dev.CreateBuffer(&hal.BufferDescriptor{Size: 256})
+	defer dev.DestroyBuffer(buf)
+
+	// All no-ops
+	pass.SetPipeline(nil)
+	pass.SetBindGroup(0, nil, nil)
+	pass.SetVertexBuffer(0, buf, 0)
+	pass.SetIndexBuffer(buf, gputypes.IndexFormatUint16, 0)
+	pass.SetViewport(0, 0, 800, 600, 0, 1)
+	pass.SetScissorRect(0, 0, 800, 600)
+	pass.SetBlendConstant(&gputypes.Color{R: 1, G: 1, B: 1, A: 1})
+	pass.SetStencilReference(0xFF)
+	pass.Draw(3, 1, 0, 0)
+	pass.DrawIndexed(6, 1, 0, 0, 0)
+	pass.DrawIndirect(buf, 0)
+	pass.DrawIndexedIndirect(buf, 0)
+	pass.ExecuteBundle(nil)
+	pass.End()
+}
+
+// =============================================================================
+// Compute Pass Encoder Tests
+// =============================================================================
+
+func TestComputePassEncoderAllNoOps(t *testing.T) {
+	dev, _, cleanup := createSoftwareDevice(t)
+	defer cleanup()
+
+	enc, _ := dev.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
+	pass := enc.BeginComputePass(&hal.ComputePassDescriptor{Label: "test-cp"})
+
+	pass.SetPipeline(nil)
+	pass.SetBindGroup(0, nil, nil)
+	pass.Dispatch(1, 1, 1)
+	pass.DispatchIndirect(nil, 0)
+	pass.End()
+}
+
+// =============================================================================
+// Surface Tests
+// =============================================================================
+
+func TestSurfaceZeroArea(t *testing.T) {
+	backend := API{}
+	instance, _ := backend.CreateInstance(&hal.InstanceDescriptor{})
+	defer instance.Destroy()
+
+	surface, _ := instance.CreateSurface(0, 0)
+	defer surface.Destroy()
+
+	adapters := instance.EnumerateAdapters(nil)
+	openDev, _ := adapters[0].Adapter.Open(0, gputypes.DefaultLimits())
+	defer openDev.Device.Destroy()
+
+	// Width=0 should return ErrZeroArea
+	err := surface.Configure(openDev.Device, &hal.SurfaceConfiguration{
+		Width:  0,
+		Height: 600,
+	})
+	if !errors.Is(err, hal.ErrZeroArea) {
+		t.Errorf("expected ErrZeroArea, got %v", err)
+	}
+
+	// Height=0 should return ErrZeroArea
+	err = surface.Configure(openDev.Device, &hal.SurfaceConfiguration{
+		Width:  800,
+		Height: 0,
+	})
+	if !errors.Is(err, hal.ErrZeroArea) {
+		t.Errorf("expected ErrZeroArea for zero height, got %v", err)
+	}
+}
+
+func TestSurfaceAcquireTexture(t *testing.T) {
+	backend := API{}
+	instance, _ := backend.CreateInstance(&hal.InstanceDescriptor{})
+	defer instance.Destroy()
+
+	surface, _ := instance.CreateSurface(0, 0)
+	defer surface.Destroy()
+
+	adapters := instance.EnumerateAdapters(nil)
+	openDev, _ := adapters[0].Adapter.Open(0, gputypes.DefaultLimits())
+	defer openDev.Device.Destroy()
+
+	surface.Configure(openDev.Device, &hal.SurfaceConfiguration{
+		Width:       100,
+		Height:      100,
+		Format:      gputypes.TextureFormatRGBA8Unorm,
+		PresentMode: hal.PresentModeImmediate,
+	})
+
+	acquired, err := surface.AcquireTexture(nil)
+	if err != nil {
+		t.Fatalf("AcquireTexture failed: %v", err)
+	}
+	if acquired == nil {
+		t.Fatal("acquired is nil")
+	}
+	if acquired.Texture == nil {
+		t.Fatal("acquired.Texture is nil")
+	}
+	if acquired.Suboptimal {
+		t.Error("expected Suboptimal=false")
+	}
+
+	// Discard should not panic
+	surface.DiscardTexture(acquired.Texture)
+}
+
+func TestSurfaceGetFramebufferNil(t *testing.T) {
+	s := &Surface{}
+	fb := s.GetFramebuffer()
+	if fb != nil {
+		t.Error("GetFramebuffer should return nil for unconfigured surface")
+	}
+}
+
+// =============================================================================
+// Resource Tests
+// =============================================================================
+
+func TestResourceNativeHandle(t *testing.T) {
+	r := &Resource{}
+	if r.NativeHandle() != 0 {
+		t.Error("Resource.NativeHandle should return 0")
+	}
+
+	b := &Buffer{data: make([]byte, 64)}
+	if b.NativeHandle() != 0 {
+		t.Error("Buffer.NativeHandle should return 0")
+	}
+
+	tex := &Texture{data: make([]byte, 64)}
+	if tex.NativeHandle() != 0 {
+		t.Error("Texture.NativeHandle should return 0")
+	}
+
+	v := &TextureView{}
+	if v.NativeHandle() != 0 {
+		t.Error("TextureView.NativeHandle should return 0")
+	}
+}
+
+func TestBufferGetWriteData(t *testing.T) {
+	buf := &Buffer{data: make([]byte, 16)}
+
+	// Write some data
+	buf.WriteData(4, []byte{0xAA, 0xBB, 0xCC})
+
+	// Read it back
+	data := buf.GetData()
+	if data[4] != 0xAA || data[5] != 0xBB || data[6] != 0xCC {
+		t.Errorf("WriteData/GetData mismatch: got (%x,%x,%x)", data[4], data[5], data[6])
+	}
+
+	// GetData should return a copy (modifying it should not affect buffer)
+	data[4] = 0xFF
+	original := buf.GetData()
+	if original[4] != 0xAA {
+		t.Error("GetData should return a copy, not the original slice")
+	}
+}
+
+func TestTextureGetWriteData(t *testing.T) {
+	tex := &Texture{data: make([]byte, 32)}
+
+	tex.WriteData(0, []byte{10, 20, 30, 40})
+
+	data := tex.GetData()
+	if data[0] != 10 || data[1] != 20 || data[2] != 30 || data[3] != 40 {
+		t.Errorf("WriteData/GetData mismatch: got (%d,%d,%d,%d)", data[0], data[1], data[2], data[3])
+	}
+
+	// GetData should return a copy
+	data[0] = 0xFF
+	original := tex.GetData()
+	if original[0] != 10 {
+		t.Error("GetData should return a copy, not the original slice")
+	}
+}


### PR DESCRIPTION
## Summary

- **Fix SIGBUS crash on Apple Silicon** caused by incorrect ObjC block ABI (`_NSConcreteStackBlock` on Go heap → PAC re-signing failure). Switch to `_NSConcreteGlobalBlock` + `BLOCK_IS_GLOBAL` flag, add `blockPinRegistry` for GC safety, remove stale `runtime.KeepAlive(uintptr)` no-ops.
- **CI: upgrade codecov-action v4 → v5**, add `codecov.yml`
- **Tests: add coverage tests** for core, HAL backends, format conversion

Fixes #89

## Test plan

- [x] `GOOS=darwin GOARCH=arm64` cross-compile clean
- [x] `GOOS=darwin GOARCH=amd64` cross-compile clean
- [x] Windows tests pass (`go test ./...`)
- [x] Lint clean (`golangci-lint run`)
- [ ] CI green
- [ ] Real-device test by reporter (rcarlier, Apple M3) after release
