### PR TITLE
fix: update naga v0.14.4 — MSL vertex stage_in, discard_fragment namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.3] - 2026-03-01
+
+### Changed
+
+- **Update naga v0.14.3 → v0.14.4** — MSL backend fixes: vertex `[[stage_in]]`
+  for struct-typed arguments, `metal::discard_fragment()` namespace prefix
+  ([naga#38](https://github.com/gogpu/naga/pull/38),
+  [ui#23](https://github.com/gogpu/ui/issues/23))
+
 ## [0.19.2] - 2026-03-01
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25
 require (
 	github.com/go-webgpu/goffi v0.3.9
 	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/naga v0.14.3
+	github.com/gogpu/naga v0.14.4
 	golang.org/x/sys v0.41.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc
 github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.14.3 h1:N/o/2vT+EG/1m7TZEAXjANPbIQaqP3rDAZxARZ9bJTw=
-github.com/gogpu/naga v0.14.3/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.14.4 h1:NarUKITSWImBzNVai2NPkyJxmHliu1/tYVvUdfXTGrw=
+github.com/gogpu/naga v0.14.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/hal/dx12/convert.go
+++ b/hal/dx12/convert.go
@@ -565,8 +565,6 @@ func colorWriteMaskToD3D12(mask gputypes.ColorWriteMask) uint8 {
 }
 
 // shaderStagesToD3D12Visibility converts WebGPU shader stages to D3D12 shader visibility.
-//
-//nolint:unused // Will be used when bind groups are fully implemented
 func shaderStagesToD3D12Visibility(stages gputypes.ShaderStages) d3d12.D3D12_SHADER_VISIBILITY {
 	// If all stages, use ALL
 	if stages&(gputypes.ShaderStageVertex|gputypes.ShaderStageFragment|gputypes.ShaderStageCompute) ==


### PR DESCRIPTION
## Summary

- Update naga v0.14.3 → v0.14.4 — MSL backend fixes for Apple Silicon ([naga#38](https://github.com/gogpu/naga/pull/38), [ui#23](https://github.com/gogpu/ui/issues/23))
- Remove stale `//nolint:unused` directive in `hal/dx12/convert.go`

## Changes

| File | Change |
|------|--------|
| `go.mod` / `go.sum` | naga v0.14.3 → v0.14.4 |
| `CHANGELOG.md` | Add v0.19.3 entry |
| `hal/dx12/convert.go` | Remove invalid `//nolint:unused` directive |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `golangci-lint run` — 0 issues
- [x] `go fmt` clean
