### PR TITLE
chore: update goffi v0.3.9 → v0.4.1 (Linux/macOS SIGSEGV fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.4] - 2026-03-02
+
+### Changed
+
+- **Update goffi v0.3.9 → v0.4.1** — fix SIGSEGV on Linux/macOS for Vulkan
+  functions with >6 arguments (`vkCmdPipelineBarrier`, etc.)
+  ([goffi#19](https://github.com/go-webgpu/goffi/issues/19),
+  [gogpu#119](https://github.com/gogpu/gogpu/issues/119))
+
 ## [0.19.3] - 2026-03-01
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/wgpu
 go 1.25
 
 require (
-	github.com/go-webgpu/goffi v0.3.9
+	github.com/go-webgpu/goffi v0.4.1
 	github.com/gogpu/gputypes v0.2.0
 	github.com/gogpu/naga v0.14.4
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.3.9 h1:dD1F7GZQV54ET6Fdcb+4776W1/OfbSb9DOJADVZEQLc=
-github.com/go-webgpu/goffi v0.3.9/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.4.1 h1:2hQH5XXloxTyTtIleYv+Rajlwzp6UOETURhSZ5+zJxU=
+github.com/go-webgpu/goffi v0.4.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.14.4 h1:NarUKITSWImBzNVai2NPkyJxmHliu1/tYVvUdfXTGrw=


### PR DESCRIPTION
Update goffi v0.3.9 → v0.4.1 — fix SIGSEGV on Linux/macOS for Vulkan functions with >6 arguments.

goffi `Call6Float` had no stack spill on Unix amd64 — arguments 7+ were silently dropped, causing crashes in `vkCmdPipelineBarrier` (10 params) and other multi-arg Vulkan functions.

- goffi#19
- gogpu#119 (reported by @darkliquid)