### PR TITLE
fix: Metal vertex descriptor + update deps (v0.19.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Metal: add vertex descriptor to render pipeline creation** — Metal requires
+  an explicit `MTLVertexDescriptor` when the vertex function has input attributes.
+  Without it, pipeline creation fails with "Vertex function has input attributes
+  but no vertex descriptor was set." Added `buildVertexDescriptor()` that maps
+  WebGPU `VertexBufferLayout` to Metal vertex attributes and buffer layouts.
+  ([ui#23](https://github.com/gogpu/ui/issues/23))
+
+### Added
+
+- **Complete Metal vertex format mapping** — all WebGPU vertex formats (8/16/32-bit
+  int/uint/float, normalized, packed 10-10-10-2) now map to corresponding
+  `MTLVertexFormat` constants.
+
 ## [0.19.4] - 2026-03-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.5] - 2026-03-05
+
 ### Fixed
 
 - **Metal: add vertex descriptor to render pipeline creation** — Metal requires
@@ -21,6 +23,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Complete Metal vertex format mapping** — all WebGPU vertex formats (8/16/32-bit
   int/uint/float, normalized, packed 10-10-10-2) now map to corresponding
   `MTLVertexFormat` constants.
+
+### Changed
+
+- **Update goffi v0.4.1 → v0.4.2**
+- **Update naga v0.14.4 → v0.14.5**
 
 ## [0.19.4] - 2026-03-02
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/gogpu/wgpu
 go 1.25
 
 require (
-	github.com/go-webgpu/goffi v0.4.1
+	github.com/go-webgpu/goffi v0.4.2
 	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/naga v0.14.4
+	github.com/gogpu/naga v0.14.5
 	golang.org/x/sys v0.41.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
-github.com/go-webgpu/goffi v0.4.1 h1:2hQH5XXloxTyTtIleYv+Rajlwzp6UOETURhSZ5+zJxU=
-github.com/go-webgpu/goffi v0.4.1/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU=
+github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.14.4 h1:NarUKITSWImBzNVai2NPkyJxmHliu1/tYVvUdfXTGrw=
-github.com/gogpu/naga v0.14.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.14.5 h1:eT3yJjXGShNtL//+W7ir2KB40k77OWvLah62ww2HZ4c=
+github.com/gogpu/naga v0.14.5/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/hal/metal/conv.go
+++ b/hal/metal/conv.go
@@ -356,3 +356,83 @@ func indexFormatToMTL(format gputypes.IndexFormat) MTLIndexType {
 		return MTLIndexTypeUInt32
 	}
 }
+
+func vertexFormatToMTL(format gputypes.VertexFormat) MTLVertexFormat {
+	switch format {
+	case gputypes.VertexFormatUint8x2:
+		return MTLVertexFormatUChar2
+	case gputypes.VertexFormatUint8x4:
+		return MTLVertexFormatUChar4
+	case gputypes.VertexFormatSint8x2:
+		return MTLVertexFormatChar2
+	case gputypes.VertexFormatSint8x4:
+		return MTLVertexFormatChar4
+	case gputypes.VertexFormatUnorm8x2:
+		return MTLVertexFormatUChar2Normalized
+	case gputypes.VertexFormatUnorm8x4:
+		return MTLVertexFormatUChar4Normalized
+	case gputypes.VertexFormatSnorm8x2:
+		return MTLVertexFormatChar2Normalized
+	case gputypes.VertexFormatSnorm8x4:
+		return MTLVertexFormatChar4Normalized
+	case gputypes.VertexFormatUint16x2:
+		return MTLVertexFormatUShort2
+	case gputypes.VertexFormatUint16x4:
+		return MTLVertexFormatUShort4
+	case gputypes.VertexFormatSint16x2:
+		return MTLVertexFormatShort2
+	case gputypes.VertexFormatSint16x4:
+		return MTLVertexFormatShort4
+	case gputypes.VertexFormatUnorm16x2:
+		return MTLVertexFormatUShort2Normalized
+	case gputypes.VertexFormatUnorm16x4:
+		return MTLVertexFormatUShort4Normalized
+	case gputypes.VertexFormatSnorm16x2:
+		return MTLVertexFormatShort2Normalized
+	case gputypes.VertexFormatSnorm16x4:
+		return MTLVertexFormatShort4Normalized
+	case gputypes.VertexFormatFloat16x2:
+		return MTLVertexFormatHalf2
+	case gputypes.VertexFormatFloat16x4:
+		return MTLVertexFormatHalf4
+	case gputypes.VertexFormatFloat32:
+		return MTLVertexFormatFloat
+	case gputypes.VertexFormatFloat32x2:
+		return MTLVertexFormatFloat2
+	case gputypes.VertexFormatFloat32x3:
+		return MTLVertexFormatFloat3
+	case gputypes.VertexFormatFloat32x4:
+		return MTLVertexFormatFloat4
+	case gputypes.VertexFormatUint32:
+		return MTLVertexFormatUInt
+	case gputypes.VertexFormatUint32x2:
+		return MTLVertexFormatUInt2
+	case gputypes.VertexFormatUint32x3:
+		return MTLVertexFormatUInt3
+	case gputypes.VertexFormatUint32x4:
+		return MTLVertexFormatUInt4
+	case gputypes.VertexFormatSint32:
+		return MTLVertexFormatInt
+	case gputypes.VertexFormatSint32x2:
+		return MTLVertexFormatInt2
+	case gputypes.VertexFormatSint32x3:
+		return MTLVertexFormatInt3
+	case gputypes.VertexFormatSint32x4:
+		return MTLVertexFormatInt4
+	case gputypes.VertexFormatUnorm1010102:
+		return MTLVertexFormatUInt1010102Normalized
+	default:
+		return MTLVertexFormatInvalid
+	}
+}
+
+func vertexStepModeToMTL(mode gputypes.VertexStepMode) MTLVertexStepFunction {
+	switch mode {
+	case gputypes.VertexStepModeVertex:
+		return MTLVertexStepFunctionPerVertex
+	case gputypes.VertexStepModeInstance:
+		return MTLVertexStepFunctionPerInstance
+	default:
+		return MTLVertexStepFunctionPerVertex
+	}
+}

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -534,6 +534,15 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 	// Set vertex function
 	_ = MsgSend(pipelineDesc, Sel("setVertexFunction:"), uintptr(vertexFunc))
 
+	// Configure vertex descriptor from vertex buffer layouts
+	if len(desc.Vertex.Buffers) > 0 {
+		if vd, err := d.buildVertexDescriptor(desc.Vertex.Buffers); err != nil {
+			return nil, err
+		} else if vd != 0 {
+			_ = MsgSend(pipelineDesc, Sel("setVertexDescriptor:"), uintptr(vd))
+		}
+	}
+
 	// Get and set fragment function if present
 	if fragmentModule != nil && desc.Fragment != nil {
 		fragmentFuncName := NSString(desc.Fragment.EntryPoint)
@@ -605,6 +614,38 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 	)
 
 	return &RenderPipeline{raw: pipelineState, device: d}, nil
+}
+
+// buildVertexDescriptor creates an MTLVertexDescriptor from WebGPU vertex buffer layouts.
+func (d *Device) buildVertexDescriptor(buffers []gputypes.VertexBufferLayout) (ID, error) {
+	vertexDesc := MsgSend(ID(GetClass("MTLVertexDescriptor")), Sel("vertexDescriptor"))
+	if vertexDesc == 0 {
+		return 0, fmt.Errorf("metal: failed to create vertex descriptor")
+	}
+
+	attributes := MsgSend(vertexDesc, Sel("attributes"))
+	layouts := MsgSend(vertexDesc, Sel("layouts"))
+
+	for bufIdx, buf := range buffers {
+		for _, attr := range buf.Attributes {
+			attrDesc := MsgSend(attributes, Sel("objectAtIndexedSubscript:"), uintptr(attr.ShaderLocation))
+			if attrDesc == 0 {
+				continue
+			}
+			_ = MsgSend(attrDesc, Sel("setFormat:"), uintptr(vertexFormatToMTL(attr.Format)))
+			_ = MsgSend(attrDesc, Sel("setOffset:"), uintptr(attr.Offset))
+			_ = MsgSend(attrDesc, Sel("setBufferIndex:"), uintptr(bufIdx))
+		}
+
+		layoutDesc := MsgSend(layouts, Sel("objectAtIndexedSubscript:"), uintptr(bufIdx))
+		if layoutDesc != 0 {
+			_ = MsgSend(layoutDesc, Sel("setStride:"), uintptr(buf.ArrayStride))
+			_ = MsgSend(layoutDesc, Sel("setStepFunction:"), uintptr(vertexStepModeToMTL(buf.StepMode)))
+			_ = MsgSend(layoutDesc, Sel("setStepRate:"), uintptr(1))
+		}
+	}
+
+	return vertexDesc, nil
 }
 
 // DestroyRenderPipeline destroys a render pipeline.

--- a/hal/metal/types.go
+++ b/hal/metal/types.go
@@ -438,26 +438,39 @@ const (
 type MTLVertexFormat NSUInteger
 
 const (
-	MTLVertexFormatInvalid MTLVertexFormat = 0
-	MTLVertexFormatFloat   MTLVertexFormat = 28
-	MTLVertexFormatFloat2  MTLVertexFormat = 29
-	MTLVertexFormatFloat3  MTLVertexFormat = 30
-	MTLVertexFormatFloat4  MTLVertexFormat = 31
-	MTLVertexFormatInt     MTLVertexFormat = 32
-	MTLVertexFormatInt2    MTLVertexFormat = 33
-	MTLVertexFormatInt3    MTLVertexFormat = 34
-	MTLVertexFormatInt4    MTLVertexFormat = 35
-	MTLVertexFormatUInt    MTLVertexFormat = 36
-	MTLVertexFormatUInt2   MTLVertexFormat = 37
-	MTLVertexFormatUInt3   MTLVertexFormat = 38
-	MTLVertexFormatUInt4   MTLVertexFormat = 39
-	MTLVertexFormatHalf2   MTLVertexFormat = 25
-	MTLVertexFormatHalf3   MTLVertexFormat = 26
-	MTLVertexFormatHalf4   MTLVertexFormat = 27
-	MTLVertexFormatUChar4  MTLVertexFormat = 3
-	MTLVertexFormatChar4   MTLVertexFormat = 6
-	MTLVertexFormatUShort2 MTLVertexFormat = 13
-	MTLVertexFormatShort2  MTLVertexFormat = 16
+	MTLVertexFormatInvalid               MTLVertexFormat = 0
+	MTLVertexFormatUChar2                MTLVertexFormat = 1
+	MTLVertexFormatUChar4                MTLVertexFormat = 3
+	MTLVertexFormatChar2                 MTLVertexFormat = 4
+	MTLVertexFormatChar4                 MTLVertexFormat = 6
+	MTLVertexFormatUChar2Normalized      MTLVertexFormat = 7
+	MTLVertexFormatUChar4Normalized      MTLVertexFormat = 9
+	MTLVertexFormatChar2Normalized       MTLVertexFormat = 10
+	MTLVertexFormatChar4Normalized       MTLVertexFormat = 12
+	MTLVertexFormatUShort2               MTLVertexFormat = 13
+	MTLVertexFormatUShort4               MTLVertexFormat = 15
+	MTLVertexFormatShort2                MTLVertexFormat = 16
+	MTLVertexFormatShort4                MTLVertexFormat = 18
+	MTLVertexFormatUShort2Normalized     MTLVertexFormat = 19
+	MTLVertexFormatUShort4Normalized     MTLVertexFormat = 21
+	MTLVertexFormatShort2Normalized      MTLVertexFormat = 22
+	MTLVertexFormatShort4Normalized      MTLVertexFormat = 24
+	MTLVertexFormatHalf2                 MTLVertexFormat = 25
+	MTLVertexFormatHalf3                 MTLVertexFormat = 26
+	MTLVertexFormatHalf4                 MTLVertexFormat = 27
+	MTLVertexFormatFloat                 MTLVertexFormat = 28
+	MTLVertexFormatFloat2                MTLVertexFormat = 29
+	MTLVertexFormatFloat3                MTLVertexFormat = 30
+	MTLVertexFormatFloat4                MTLVertexFormat = 31
+	MTLVertexFormatInt                   MTLVertexFormat = 32
+	MTLVertexFormatInt2                  MTLVertexFormat = 33
+	MTLVertexFormatInt3                  MTLVertexFormat = 34
+	MTLVertexFormatInt4                  MTLVertexFormat = 35
+	MTLVertexFormatUInt                  MTLVertexFormat = 36
+	MTLVertexFormatUInt2                 MTLVertexFormat = 37
+	MTLVertexFormatUInt3                 MTLVertexFormat = 38
+	MTLVertexFormatUInt4                 MTLVertexFormat = 39
+	MTLVertexFormatUInt1010102Normalized MTLVertexFormat = 40
 )
 
 // MTLVertexStepFunction represents vertex step functions.


### PR DESCRIPTION
## Summary

- **Fix Metal render pipeline creation** — add `MTLVertexDescriptor` mapping from WebGPU `VertexBufferLayout`. Without it, Metal fails with "Vertex function has input attributes but no vertex descriptor was set."
- **Complete Metal vertex format constants** — all WebGPU vertex formats (8/16/32-bit int/uint/float, normalized, packed 10-10-10-2) mapped to `MTLVertexFormat`
- **Update goffi v0.4.1 → v0.4.2, naga v0.14.4 → v0.14.5**

Fixes gogpu/ui#23

## Test plan

- [x] Cross-compile darwin/arm64 + darwin/amd64 — builds clean
- [x] Full test suite passes (`go test ./...`)
- [x] Lint: 0 new issues (only pre-existing)
