### PR TITLE
chore: update naga v0.14.6, CHANGELOG v0.19.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.7] - 2026-03-07
+
+### Added
+
+- **Queue.WriteTexture** — public API for writing data to textures. Includes
+  `ImageCopyTexture` descriptor, `ImageDataLayout` alias, and full nil validation
+  with specific error messages.
+  ([#95](https://github.com/gogpu/wgpu/pull/95) by [@Carmen-Shannon](https://github.com/Carmen-Shannon))
+
+### Changed
+
+- **Update naga v0.14.5 → v0.14.6** — MSL pass-through globals fix: helper
+  functions now receive texture/sampler as extra parameters instead of using
+  `[[binding]]` attributes. Fixes black screen on M3 Mac.
+  ([naga#40](https://github.com/gogpu/naga/pull/40))
+
 ## [0.19.6] - 2026-03-05
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25
 require (
 	github.com/go-webgpu/goffi v0.4.2
 	github.com/gogpu/gputypes v0.2.0
-	github.com/gogpu/naga v0.14.5
+	github.com/gogpu/naga v0.14.6
 	golang.org/x/sys v0.41.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU
 github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.2.0 h1:Quv3ekiU12zK4ZhBZsSZmalHYc+zj2gr9ZWRyzKgkKk=
 github.com/gogpu/gputypes v0.2.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.14.5 h1:eT3yJjXGShNtL//+W7ir2KB40k77OWvLah62ww2HZ4c=
-github.com/gogpu/naga v0.14.5/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.14.6 h1:zXtYxeEt1P70UDVuoa1EgMzKvted9ZsHkVcFV13qkSs=
+github.com/gogpu/naga v0.14.6/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=


### PR DESCRIPTION
## Summary

- Update naga v0.14.5 → v0.14.6 (MSL pass-through globals fix)
- Add CHANGELOG entry for v0.19.7 (WriteTexture + naga update)