### PR TITLE
fix: Metal buffer storage mode for CopyDst and staging fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.8] - 2026-03-10
+
+### Fixed
+
+- **Metal: CopyDst buffer storage mode** — buffers with `CopyDst` usage were
+  allocated with `StorageModePrivate` (GPU-only), causing "buffer not mappable"
+  errors on Apple Silicon when `Queue.WriteBuffer()` tried to write. Now uses
+  `StorageModeShared` for `CopyDst` and `MappedAtCreation` buffers, matching
+  the Vulkan backend behavior. On UMA (all Apple Silicon) this is zero-cost.
+  ([gg#170](https://github.com/gogpu/gg/issues/170))
+
+- **Metal: staging buffer fallback for ReadBuffer/WriteBuffer** — defense-in-depth:
+  if a buffer is `StorageModePrivate`, `WriteBuffer` and `ReadBuffer` now fall
+  back to a temporary staging buffer + blit instead of failing. Mirrors the
+  pattern already used by `WriteTexture` and matches Rust wgpu behavior.
+
+- **Metal: zero-length data guard** — `WriteBuffer` and `ReadBuffer` now return
+  early for empty data slices, preventing a potential panic in the staging path.
+
 ## [0.19.7] - 2026-03-07
 
 ### Added

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -62,8 +62,13 @@ func (d *Device) CreateBuffer(desc *hal.BufferDescriptor) (hal.Buffer, error) {
 	var options MTLResourceOptions
 	mapRead := desc.Usage&gputypes.BufferUsageMapRead != 0
 	mapWrite := desc.Usage&gputypes.BufferUsageMapWrite != 0
+	copyDst := desc.Usage&gputypes.BufferUsageCopyDst != 0
 
-	if mapRead || mapWrite {
+	if mapRead || mapWrite || copyDst || desc.MappedAtCreation {
+		// CopyDst buffers need CPU-visible storage for Queue.WriteBuffer().
+		// MappedAtCreation needs CPU-visible storage for the initial mapping.
+		// On Apple Silicon UMA, StorageModeShared is zero-cost (same physical memory).
+		// This matches the Vulkan backend which maps CopyDst/MappedAtCreation to host-visible memory.
 		options = MTLResourceStorageModeShared
 	} else {
 		options = MTLResourceStorageModePrivate

--- a/hal/metal/queue.go
+++ b/hal/metal/queue.go
@@ -116,34 +116,171 @@ func (q *Queue) registerFrameCompletionHandler(cmdBuffer ID) {
 }
 
 // ReadBuffer reads data from a buffer.
+//
+// Fast path: if the buffer is CPU-mappable, reads directly. Slow path: if the
+// buffer is GPU-only, blits to a staging buffer and reads from that.
 func (q *Queue) ReadBuffer(buffer hal.Buffer, offset uint64, data []byte) error {
 	buf, ok := buffer.(*Buffer)
 	if !ok || buf == nil {
-		return fmt.Errorf("metal: invalid buffer")
+		return fmt.Errorf("metal: ReadBuffer: invalid buffer")
 	}
+	if len(data) == 0 {
+		return nil
+	}
+
+	// Fast path: buffer is mappable.
 	ptr := buf.Contents()
-	if ptr == nil {
-		return fmt.Errorf("metal: buffer not mappable")
+	if ptr != nil {
+		src := unsafe.Slice((*byte)(unsafe.Add(ptr, int(offset))), len(data))
+		copy(data, src)
+		return nil
 	}
-	src := unsafe.Slice((*byte)(unsafe.Add(ptr, int(offset))), len(data))
+
+	// Slow path: buffer is Private — blit to staging buffer, then read.
+	return q.readBufferStaged(buf, offset, data)
+}
+
+// readBufferStaged reads from a Private-mode buffer via a temporary staging buffer.
+func (q *Queue) readBufferStaged(buf *Buffer, offset uint64, data []byte) error {
+	hal.Logger().Debug("metal: ReadBuffer using staging path",
+		"size", len(data), "offset", offset)
+
+	pool := NewAutoreleasePool()
+	defer pool.Drain()
+
+	// Create temporary Shared staging buffer.
+	staging := MsgSend(q.device.raw, Sel("newBufferWithLength:options:"),
+		uintptr(len(data)), uintptr(MTLResourceStorageModeShared))
+	if staging == 0 {
+		return fmt.Errorf("metal: ReadBuffer: staging buffer creation failed (size=%d)", len(data))
+	}
+	defer Release(staging)
+
+	// Blit from source to staging.
+	cmdBuffer := MsgSend(q.commandQueue, Sel("commandBuffer"))
+	if cmdBuffer == 0 {
+		return fmt.Errorf("metal: ReadBuffer: command buffer creation failed")
+	}
+	Retain(cmdBuffer)
+	defer Release(cmdBuffer)
+
+	blitEncoder := MsgSend(cmdBuffer, Sel("blitCommandEncoder"))
+	if blitEncoder == 0 {
+		return fmt.Errorf("metal: ReadBuffer: blit encoder creation failed")
+	}
+
+	msgSendVoid(blitEncoder, Sel("copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:"),
+		argPointer(uintptr(buf.raw)),
+		argUint64(offset),
+		argPointer(uintptr(staging)),
+		argUint64(0),
+		argUint64(uint64(len(data))),
+	)
+	_ = MsgSend(blitEncoder, Sel("endEncoding"))
+
+	// Must wait synchronously — caller needs the data immediately.
+	_ = MsgSend(cmdBuffer, Sel("commit"))
+	_ = MsgSend(cmdBuffer, Sel("waitUntilCompleted"))
+
+	// Read from staging buffer.
+	stagingPtr := MsgSend(staging, Sel("contents"))
+	if stagingPtr == 0 {
+		return fmt.Errorf("metal: ReadBuffer: staging buffer not mappable")
+	}
+	src := unsafe.Slice((*byte)(unsafe.Pointer(stagingPtr)), len(data))
 	copy(data, src)
 	return nil
 }
 
 // WriteBuffer writes data to a buffer immediately.
+//
+// Fast path: if the buffer is CPU-mappable (Shared/Managed storage), copies
+// data directly via memcpy. Slow path: if the buffer is GPU-only (Private
+// storage), creates a temporary staging buffer and blits the data. The staging
+// path matches the pattern used by WriteTexture and Rust wgpu.
 func (q *Queue) WriteBuffer(buffer hal.Buffer, offset uint64, data []byte) error {
 	buf, ok := buffer.(*Buffer)
 	if !ok || buf == nil {
 		return fmt.Errorf("metal: WriteBuffer: invalid buffer")
 	}
-
-	ptr := buf.Contents()
-	if ptr == nil {
-		return fmt.Errorf("metal: WriteBuffer: buffer not mappable")
+	if len(data) == 0 {
+		return nil
 	}
 
-	dst := unsafe.Slice((*byte)(unsafe.Add(ptr, int(offset))), len(data))
-	copy(dst, data)
+	// Fast path: buffer is mappable (Shared/Managed storage mode).
+	ptr := buf.Contents()
+	if ptr != nil {
+		dst := unsafe.Slice((*byte)(unsafe.Add(ptr, int(offset))), len(data))
+		copy(dst, data)
+		return nil
+	}
+
+	// Slow path: buffer is Private storage — use staging buffer + blit.
+	// This is a defense-in-depth fallback; with the CopyDst→Shared fix in
+	// CreateBuffer, this path should rarely be reached.
+	return q.writeBufferStaged(buf, offset, data)
+}
+
+// writeBufferStaged copies data to a Private-mode buffer via a temporary
+// Shared staging buffer and a blit command. This mirrors the staging pattern
+// used by WriteTexture and matches Rust wgpu's Queue::write_buffer behavior.
+func (q *Queue) writeBufferStaged(buf *Buffer, offset uint64, data []byte) error {
+	hal.Logger().Debug("metal: WriteBuffer using staging path",
+		"size", len(data), "offset", offset)
+
+	pool := NewAutoreleasePool()
+	defer pool.Drain()
+
+	// Create temporary Shared staging buffer with the data.
+	staging := MsgSend(q.device.raw, Sel("newBufferWithBytes:length:options:"),
+		uintptr(unsafe.Pointer(&data[0])), uintptr(len(data)),
+		uintptr(MTLResourceStorageModeShared))
+	if staging == 0 {
+		return fmt.Errorf("metal: WriteBuffer: staging buffer creation failed (size=%d)", len(data))
+	}
+
+	// Create a one-shot command buffer for the blit.
+	cmdBuffer := MsgSend(q.commandQueue, Sel("commandBuffer"))
+	if cmdBuffer == 0 {
+		Release(staging)
+		return fmt.Errorf("metal: WriteBuffer: command buffer creation failed")
+	}
+	Retain(cmdBuffer)
+
+	blitEncoder := MsgSend(cmdBuffer, Sel("blitCommandEncoder"))
+	if blitEncoder == 0 {
+		Release(staging)
+		Release(cmdBuffer)
+		return fmt.Errorf("metal: WriteBuffer: blit encoder creation failed")
+	}
+
+	// copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:
+	msgSendVoid(blitEncoder, Sel("copyFromBuffer:sourceOffset:toBuffer:destinationOffset:size:"),
+		argPointer(uintptr(staging)),
+		argUint64(0),
+		argPointer(uintptr(buf.raw)),
+		argUint64(offset),
+		argUint64(uint64(len(data))),
+	)
+	_ = MsgSend(blitEncoder, Sel("endEncoding"))
+
+	// Try async release via completion handler (same pattern as WriteTexture).
+	blockPtr, blockID := newCompletedHandlerBlock(staging)
+	if blockPtr != 0 {
+		_ = MsgSend(cmdBuffer, Sel("addCompletedHandler:"), blockPtr)
+		_ = MsgSend(cmdBuffer, Sel("commit"))
+		Release(cmdBuffer)
+		// Block is pinned via blockPinRegistry until the completion callback
+		// fires and unpins it. No runtime.KeepAlive needed.
+		_ = blockID
+		return nil
+	}
+
+	// Fallback: synchronous path.
+	_ = MsgSend(cmdBuffer, Sel("commit"))
+	_ = MsgSend(cmdBuffer, Sel("waitUntilCompleted"))
+	Release(staging)
+	Release(cmdBuffer)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Fix Metal buffer storage mode selection and add staging buffer fallback paths for `WriteBuffer`/`ReadBuffer`.

**Root cause (gg#170):** Buffers with `CopyDst` usage were allocated with `MTLResourceStorageModePrivate` (GPU-only memory). When `Queue.WriteBuffer()` called `Contents()` to get a CPU pointer, it returned nil — causing "buffer not mappable" errors on Apple Silicon.

### Changes

- **`device.go`**: `CopyDst` and `MappedAtCreation` buffers now use `StorageModeShared` (CPU+GPU visible). On Apple Silicon UMA this is zero-cost. Matches the Vulkan backend behavior.
- **`queue.go`**: Defense-in-depth staging buffer fallback — if a buffer is somehow Private, `WriteBuffer`/`ReadBuffer` create a temporary Shared staging buffer and blit instead of failing. Mirrors the existing `WriteTexture` pattern.
- **`queue.go`**: Zero-length data guard prevents panic on empty slices in staging path.

### References

- Fixes https://github.com/gogpu/gg/issues/170 (Metal "buffer not mappable" on macOS M5)
- Reported by @sverrehu

### Test plan

- [x] `GOOS=darwin GOARCH=arm64 go build ./...` — compiles
- [x] `go test ./...` — all tests pass
- [x] `golangci-lint run` (GOWORK=off) — 0 issues
- [x] `gofmt -l hal/metal/` — no formatting issues
- [ ] Manual test on macOS Apple Silicon (requires @sverrehu verification)
