### PR TITLE
fix(vulkan): validate WSI query functions in LoadInstance (v0.20.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.2] - 2026-03-12
+
+### Fixed
+
+- **Vulkan: validate WSI query functions in LoadInstance** — `vkGetPhysicalDevice-
+  SurfaceCapabilitiesKHR`, `vkGetPhysicalDeviceSurfaceFormatsKHR`, and
+  `vkGetPhysicalDeviceSurfacePresentModesKHR` are now verified during instance
+  initialization. Previously, if any WSI function failed to load (returned nil),
+  the error was silent until a later SIGSEGV via goffi nil function pointer call.
+  Now fails fast with a clear error message.
+
 ## [0.20.1] - 2026-03-11
 
 ### Fixed

--- a/hal/vulkan/vk/commands.go
+++ b/hal/vulkan/vk/commands.go
@@ -121,6 +121,17 @@ func (c *Commands) LoadInstance(instance Instance) error {
 		return fmt.Errorf("failed to load critical instance functions")
 	}
 
+	// Verify WSI (Window System Integration) query functions.
+	// These are required for any surface-based rendering. Platform-specific
+	// surface creation functions (vkCreate*SurfaceKHR) are optional and
+	// checked at call sites via Has* methods, but the query functions are
+	// part of VK_KHR_surface which is always enabled for windowed rendering.
+	if c.getPhysicalDeviceSurfaceCapabilitiesKHR == nil ||
+		c.getPhysicalDeviceSurfaceFormatsKHR == nil ||
+		c.getPhysicalDeviceSurfacePresentModesKHR == nil {
+		return fmt.Errorf("failed to load WSI query functions (VK_KHR_surface)")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Validate WSI query functions (`vkGetPhysicalDeviceSurfaceCapabilitiesKHR`, `SurfaceFormatsKHR`, `SurfacePresentModesKHR`) during `LoadInstance()`
- Previously, if any WSI function failed to load (nil), the error was silent until a later SIGSEGV via goffi nil function pointer call
- Now fails fast with a clear error message: `"failed to load WSI query functions (VK_KHR_surface)"`

Defense-in-depth for gogpu/ui#45 (SIGSEGV on Wayland/Sway).

## Test plan

- [x] `go build ./...` passes (Windows, cross-compile)
- [x] `GOWORK=off golangci-lint run --timeout=5m` — 0 issues
- [ ] CI: build on Linux, macOS, Windows
- [ ] CI: tests and lint pass