### PR TITLE
fix: Metal slots, GLES scissor, goffi v0.5.0, particle example (v0.22.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.22.2] - 2026-03-29
+
+### Fixed
+
+- **Metal: per-type sequential slot indices in SetBindGroup** — Fixed descriptor set
+  binding for Metal backend when multiple bind groups use different resource types
+  (samplers, textures, buffers). Previously all resources shared a single index counter,
+  causing incorrect slot assignments. (PR #112 by @timzifer)
+
+- **GLES: disable scissor test before MSAA resolve blit** — Prevents clipped resolve
+  when scissor rect from previous draw call was still active during MSAA resolve.
+  Fixes rendering artifacts on NVIDIA GPUs. (gg#226)
+
+### Changed
+
+- **deps: goffi v0.4.2 → v0.5.0** — Adds Windows ARM64 (Snapdragon X) support.
+  First Go GPU framework with Windows ARM64 support. (go-webgpu/goffi#31, tested by @SideFx)
+
 ## [0.22.1] - 2026-03-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ import _ "github.com/gogpu/wgpu/hal/allbackends"
 | **GLES** | Yes | Yes | - | - | OpenGL ES 3.0+ |
 | **Software** | Yes | Yes | Yes | Yes | CPU fallback |
 
+**Architectures:** amd64, arm64 (including Windows ARM64 / Snapdragon X)
+
 ### Vulkan Backend
 
 Full Vulkan 1.3 implementation with:

--- a/examples/compute-particles/main.go
+++ b/examples/compute-particles/main.go
@@ -1,0 +1,297 @@
+// Copyright 2026 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+// Command compute-particles demonstrates a GPU particle simulation using a
+// compute shader. Particles attract toward the center and repel from sampled
+// neighbors. Results are read back to CPU each step.
+//
+// The example is headless (no window required) and works on any supported GPU.
+// For a windowed version with real-time rendering, see gogpu/examples/particles.
+//
+// Usage: CGO_ENABLED=0 go run .
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"log"
+	"math"
+	"math/rand/v2"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+
+	_ "github.com/gogpu/wgpu/hal/allbackends"
+)
+
+const numParticles = 1024
+const particleBytes = 16 // x, y, vx, vy — 4x float32
+const bufSize = uint64(numParticles * particleBytes)
+
+// Compute shader: each thread updates one particle.
+// Reads all particles (for neighbor interaction), writes one output.
+const shaderWGSL = `
+struct Particle { pos: vec2<f32>, vel: vec2<f32>, }
+struct Params { dt: f32, count: u32, }
+
+@group(0) @binding(0) var<storage, read> pin: array<Particle>;
+@group(0) @binding(1) var<storage, read_write> pout: array<Particle>;
+@group(0) @binding(2) var<uniform> params: Params;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+    let i = id.x;
+    if (i >= params.count) { return; }
+    var p = pin[i];
+
+    // Attract toward center
+    p.vel += -p.pos * 0.3 * params.dt;
+
+    // Repel from sampled neighbors
+    let step = max(params.count / 16u, 1u);
+    for (var j = 0u; j < params.count; j += step) {
+        if (j == i) { continue; }
+        let d = p.pos - pin[j].pos;
+        let dist = max(length(d), 0.01);
+        p.vel += normalize(d) / (dist * dist) * 0.0001 * params.dt;
+    }
+
+    p.vel *= 0.995;
+    p.pos += p.vel * params.dt;
+
+    // Wrap around [-1, 1]
+    if (p.pos.x > 1.0) { p.pos.x -= 2.0; }
+    if (p.pos.x < -1.0) { p.pos.x += 2.0; }
+    if (p.pos.y > 1.0) { p.pos.y -= 2.0; }
+    if (p.pos.y < -1.0) { p.pos.y += 2.0; }
+
+    pout[i] = p;
+}
+`
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func uploadInitialData(device *wgpu.Device, inputBuf, uniformBuf *wgpu.Buffer) error {
+	initData := make([]byte, bufSize)
+	for i := 0; i < numParticles; i++ {
+		off := i * particleBytes
+		binary.LittleEndian.PutUint32(initData[off:], math.Float32bits(rand.Float32()*2-1))           //nolint:gosec // example code
+		binary.LittleEndian.PutUint32(initData[off+4:], math.Float32bits(rand.Float32()*2-1))         //nolint:gosec // example code
+		binary.LittleEndian.PutUint32(initData[off+8:], math.Float32bits((rand.Float32()-0.5)*0.02))  //nolint:gosec // example code
+		binary.LittleEndian.PutUint32(initData[off+12:], math.Float32bits((rand.Float32()-0.5)*0.02)) //nolint:gosec // example code
+	}
+	if err := device.Queue().WriteBuffer(inputBuf, 0, initData); err != nil {
+		return fmt.Errorf("write input: %w", err)
+	}
+	paramData := make([]byte, 8)
+	binary.LittleEndian.PutUint32(paramData[0:], math.Float32bits(0.016)) // dt ~60fps
+	binary.LittleEndian.PutUint32(paramData[4:], numParticles)
+	if err := device.Queue().WriteBuffer(uniformBuf, 0, paramData); err != nil {
+		return fmt.Errorf("write params: %w", err)
+	}
+	return nil
+}
+
+func run() error {
+	fmt.Println("=== GPU Particle Simulation (headless) ===")
+	fmt.Println()
+
+	// 1. Instance → Adapter → Device
+	fmt.Print("1. Creating instance... ")
+	instance, err := wgpu.CreateInstance(nil)
+	if err != nil {
+		return fmt.Errorf("CreateInstance: %w", err)
+	}
+	defer instance.Release()
+	fmt.Println("OK")
+
+	fmt.Print("2. Requesting adapter... ")
+	adapter, err := instance.RequestAdapter(nil)
+	if err != nil {
+		return fmt.Errorf("RequestAdapter: %w", err)
+	}
+	defer adapter.Release()
+	fmt.Printf("OK (%s)\n", adapter.Info().Name)
+
+	fmt.Print("3. Creating device... ")
+	device, err := adapter.RequestDevice(nil)
+	if err != nil {
+		return fmt.Errorf("RequestDevice: %w", err)
+	}
+	defer device.Release()
+	fmt.Println("OK")
+
+	// 2. Create shader
+	fmt.Print("4. Compiling shader... ")
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "particle-shader",
+		WGSL:  shaderWGSL,
+	})
+	if err != nil {
+		return fmt.Errorf("CreateShaderModule: %w", err)
+	}
+	defer shader.Release()
+	fmt.Println("OK")
+
+	// 3. Create buffers
+	fmt.Print("5. Creating buffers... ")
+	inputBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "particles-in",
+		Size:  bufSize,
+		Usage: wgpu.BufferUsageStorage | wgpu.BufferUsageCopyDst | wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		return fmt.Errorf("create input buffer: %w", err)
+	}
+	defer inputBuf.Release()
+
+	outputBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "particles-out",
+		Size:  bufSize,
+		Usage: wgpu.BufferUsageStorage | wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		return fmt.Errorf("create output buffer: %w", err)
+	}
+	defer outputBuf.Release()
+
+	stagingBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "staging",
+		Size:  bufSize,
+		Usage: wgpu.BufferUsageCopyDst | wgpu.BufferUsageMapRead,
+	})
+	if err != nil {
+		return fmt.Errorf("create staging buffer: %w", err)
+	}
+	defer stagingBuf.Release()
+
+	uniformBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "params",
+		Size:  8, // dt (f32) + count (u32)
+		Usage: wgpu.BufferUsageUniform | wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		return fmt.Errorf("create uniform buffer: %w", err)
+	}
+	defer uniformBuf.Release()
+
+	if err := uploadInitialData(device, inputBuf, uniformBuf); err != nil {
+		return err
+	}
+	fmt.Println("OK")
+
+	// 5. Create pipeline and simulate
+	fmt.Print("6. Creating compute pipeline... ")
+	pipeline, bg, cleanup, err := createPipeline(device, shader, inputBuf, outputBuf, uniformBuf)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+	fmt.Println("OK")
+
+	fmt.Println()
+	return simulate(device, pipeline, bg, inputBuf, outputBuf, stagingBuf)
+}
+
+func createPipeline(device *wgpu.Device, shader *wgpu.ShaderModule, inputBuf, outputBuf, uniformBuf *wgpu.Buffer) (*wgpu.ComputePipeline, *wgpu.BindGroup, func(), error) {
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "particle-bgl",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{Binding: 0, Visibility: wgpu.ShaderStageCompute, Buffer: &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeReadOnlyStorage}},
+			{Binding: 1, Visibility: wgpu.ShaderStageCompute, Buffer: &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeStorage}},
+			{Binding: 2, Visibility: wgpu.ShaderStageCompute, Buffer: &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeUniform, MinBindingSize: 8}},
+		},
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("create bgl: %w", err)
+	}
+	pl, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{
+		Label:            "particle-pl",
+		BindGroupLayouts: []*wgpu.BindGroupLayout{bgl},
+	})
+	if err != nil {
+		bgl.Release()
+		return nil, nil, nil, fmt.Errorf("create pipeline layout: %w", err)
+	}
+	pipeline, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Label: "particle-pipeline", Layout: pl, Module: shader, EntryPoint: "main",
+	})
+	if err != nil {
+		pl.Release()
+		bgl.Release()
+		return nil, nil, nil, fmt.Errorf("create pipeline: %w", err)
+	}
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label: "particle-bg", Layout: bgl,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: inputBuf, Size: bufSize},
+			{Binding: 1, Buffer: outputBuf, Size: bufSize},
+			{Binding: 2, Buffer: uniformBuf, Size: 8},
+		},
+	})
+	if err != nil {
+		pipeline.Release()
+		pl.Release()
+		bgl.Release()
+		return nil, nil, nil, fmt.Errorf("create bind group: %w", err)
+	}
+	cleanup := func() {
+		bg.Release()
+		pipeline.Release()
+		pl.Release()
+		bgl.Release()
+	}
+	return pipeline, bg, cleanup, nil
+}
+
+func simulate(device *wgpu.Device, pipeline *wgpu.ComputePipeline, bg *wgpu.BindGroup, inputBuf, outputBuf, stagingBuf *wgpu.Buffer) error {
+	workgroups := uint32((numParticles + 63) / 64)
+
+	for step := 0; step < 10; step++ {
+		encoder, err := device.CreateCommandEncoder(nil)
+		if err != nil {
+			return fmt.Errorf("create encoder: %w", err)
+		}
+		pass, err := encoder.BeginComputePass(nil)
+		if err != nil {
+			return fmt.Errorf("begin compute pass: %w", err)
+		}
+		pass.SetPipeline(pipeline)
+		pass.SetBindGroup(0, bg, nil)
+		pass.Dispatch(workgroups, 1, 1)
+		if err := pass.End(); err != nil {
+			return fmt.Errorf("end compute pass: %w", err)
+		}
+
+		// Copy output → staging for readback, output → input for next step
+		encoder.CopyBufferToBuffer(outputBuf, 0, stagingBuf, 0, bufSize)
+		encoder.CopyBufferToBuffer(outputBuf, 0, inputBuf, 0, bufSize)
+
+		cmds, err := encoder.Finish()
+		if err != nil {
+			return fmt.Errorf("finish encoder: %w", err)
+		}
+		if err := device.Queue().Submit(cmds); err != nil {
+			return fmt.Errorf("submit: %w", err)
+		}
+
+		// Read back particle[0] position
+		result := make([]byte, bufSize)
+		if err := device.Queue().ReadBuffer(stagingBuf, 0, result); err != nil {
+			return fmt.Errorf("read buffer: %w", err)
+		}
+		x := math.Float32frombits(binary.LittleEndian.Uint32(result[0:4]))
+		y := math.Float32frombits(binary.LittleEndian.Uint32(result[4:8]))
+		vx := math.Float32frombits(binary.LittleEndian.Uint32(result[8:12]))
+		vy := math.Float32frombits(binary.LittleEndian.Uint32(result[12:16]))
+		fmt.Printf("Step %2d: particle[0] pos=(%.3f, %.3f) vel=(%.4f, %.4f)\n", step, x, y, vx, vy)
+	}
+
+	fmt.Println()
+	fmt.Println("PASS: GPU particle simulation completed")
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/wgpu
 go 1.25.0
 
 require (
-	github.com/go-webgpu/goffi v0.4.2
+	github.com/go-webgpu/goffi v0.5.0
 	github.com/gogpu/gputypes v0.3.0
 	github.com/gogpu/naga v0.14.8
 	golang.org/x/sys v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.4.2 h1:cwSiwro2ndP7jfXYlsz3kbOk8mNaFsHGZ0Q0cszC9cU=
-github.com/go-webgpu/goffi v0.4.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE=
+github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.3.0 h1:gcwxsBrcoCX19GqqqiV55wLv2iFwaybiOluKCb0hVrs=
 github.com/gogpu/gputypes v0.3.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.14.8 h1:xa4xHWiLvHLi+sWKuLRtrcO0Qpsc7pwwK+8tKzDLk74=

--- a/hal/gles/command.go
+++ b/hal/gles/command.go
@@ -648,6 +648,11 @@ type MSAAResolveCommand struct {
 }
 
 func (c *MSAAResolveCommand) Execute(ctx *gl.Context) {
+	// Disable scissor test before blit — glBlitFramebuffer respects GL_SCISSOR_TEST
+	// on the draw framebuffer. Without this, only the last scissor rect's pixels
+	// are copied, leaving the rest of the surface black (gg#226).
+	ctx.Disable(gl.SCISSOR_TEST)
+
 	// Bind MSAA FBO as read source.
 	ctx.BindFramebuffer(gl.READ_FRAMEBUFFER, c.msaaTexture.fbo)
 
@@ -993,11 +998,12 @@ func (c *SetScissorCommand) Execute(ctx *gl.Context) {
 	ctx.Enable(gl.SCISSOR_TEST)
 	// OpenGL scissor uses bottom-left origin, WebGPU uses top-left origin.
 	// Convert: glY = fbHeight - y - height
-	// Clamp to 0 to avoid GL_INVALID_VALUE when fbHeight is 0 (uninitialized).
+	//
+	// Negative glY is valid — OpenGL glScissor accepts GLint (signed).
+	// The driver handles partial visibility via per-fragment scissor test.
+	// Previous code clamped glY to 0 without reducing height, which shifted
+	// the scissor rect and broke ScrollView overflow clipping (gg#226).
 	glY := int32(c.fbHeight) - int32(c.y) - int32(c.height)
-	if glY < 0 {
-		glY = 0
-	}
 	ctx.Scissor(int32(c.x), glY, int32(c.width), int32(c.height))
 }
 

--- a/hal/gles/command_test.go
+++ b/hal/gles/command_test.go
@@ -328,6 +328,42 @@ func TestSetScissorCommand_YFlip(t *testing.T) {
 			wantW:    200,
 			wantH:    50,
 		},
+		{
+			name:     "overflow bottom — ScrollView case (gg#226)",
+			x:        0,
+			y:        500,
+			w:        584,
+			h:        361,
+			fbHeight: 700,
+			wantX:    0,
+			wantY:    -161, // 700 - 500 - 361 = -161 (negative is valid for glScissor)
+			wantW:    584,
+			wantH:    361,
+		},
+		{
+			name:     "overflow — rect larger than framebuffer",
+			x:        0,
+			y:        0,
+			w:        800,
+			h:        900,
+			fbHeight: 700,
+			wantX:    0,
+			wantY:    -200, // 700 - 0 - 900 = -200
+			wantW:    800,
+			wantH:    900,
+		},
+		{
+			name:     "overflow — rect at framebuffer edge",
+			x:        0,
+			y:        600,
+			w:        100,
+			h:        200,
+			fbHeight: 700,
+			wantX:    0,
+			wantY:    -100, // 700 - 600 - 200 = -100
+			wantW:    100,
+			wantH:    200,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/hal/gles/shader.go
+++ b/hal/gles/shader.go
@@ -41,6 +41,9 @@ func compileWGSLToGLSL(source hal.ShaderSource, entryPoint string) (string, erro
 		LangVersion:        glsl.Version430,
 		EntryPoint:         entryPoint,
 		ForceHighPrecision: true,
+		// NOTE: Do NOT use WriterFlagAdjustCoordinateSpace here.
+		// Our gg shaders already flip Y in the vertex shader (Vulkan convention).
+		// Adding naga's flip would double-flip, producing upside-down output.
 	})
 	if err != nil {
 		return "", fmt.Errorf("gles: GLSL compile error for entry point %q: %w", entryPoint, err)


### PR DESCRIPTION
## Summary

- **fix(metal):** per-type sequential slot indices in SetBindGroup (PR #112 by @timzifer)
- **fix(gles):** disable scissor test before MSAA resolve blit (gg#226)
- **chore(deps):** goffi v0.4.2 → v0.5.0 (Windows ARM64 / Snapdragon X support)
- **feat:** compute-particles example (headless GPU particle simulation)
- **docs:** CHANGELOG + README updated for v0.22.2

## Test plan

- [x] All tests pass (`go test ./...` with GOWORK=off)
- [x] Lint clean (`golangci-lint run` — 0 issues)
- [x] compute-particles example runs correctly
- [x] compute-sum example still works
- [x] Published naga v0.14.8 (no new naga dependency)