### PR TITLE
feat: enterprise fence architecture + naga v0.15.0 (v0.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.0] - 2026-03-30
+
+### Added
+
+- **`Adapter.GetSurfaceCapabilities(surface)`** — New public API. Returns supported
+  texture formats, present modes, and composite alpha modes for a surface. Queries
+  HAL capabilities (`vkGetPhysicalDeviceSurfacePresentModesKHR` on Vulkan). Follows
+  Rust wgpu `surface.get_capabilities(&adapter)` pattern.
+
+- **`Queue.Poll()`** — Non-blocking completion query. Returns the highest submission
+  index known to be completed by the GPU.
+
+### Changed
+
+- **Enterprise fence architecture** — HAL `Queue.Submit()` no longer accepts user
+  fence parameter. Returns `(submissionIndex uint64, err error)` instead. HAL owns
+  all fence management internally (binary fence pool or timeline semaphore). Matches
+  Rust wgpu, Dawn, Godot, DXVK, vkd3d-proton architecture. All 6 backends updated
+  (Vulkan, DX12, Metal, GLES, Software, Noop). Eliminates double `vkQueueSubmit`
+  on binary fence path that caused first-frame loss on llvmpipe Vulkan 1.0.2.
+  (BUG-GOGPU-004, fixes ui#66)
+
+- **`Queue.Submit()` is now non-blocking** — Returns `(uint64, error)` with
+  submission index for deferred resource tracking. Use `Queue.Poll()` to check
+  completion.
+
+- **deps: naga v0.14.8 → v0.15.0** — Full Rust parity: IR 144/144, SPIR-V 87/87,
+  MSL 91/91, HLSL 58/58, GLSL 68/68.
+
+### Removed
+
+- **`Queue.SubmitWithFence()`** — Replaced by `Queue.Submit()` + `Queue.Poll()`.
+  HAL manages fences internally, application layer uses submission indices.
+
 ## [0.22.2] - 2026-03-29
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ pass.Dispatch(64, 1, 1)
 pass.End()
 
 cmdBuffer, _ := encoder.Finish()
-device.Queue().Submit(cmdBuffer)
+_, _ = device.Queue().Submit(cmdBuffer)  // returns (submissionIndex, error)
 ```
 
 **Guides:** [Getting Started](docs/COMPUTE-SHADERS.md) | [Backend Differences](docs/COMPUTE-BACKENDS.md)

--- a/adapter.go
+++ b/adapter.go
@@ -68,16 +68,9 @@ func (a *Adapter) requestDeviceHAL(desc *DeviceDescriptor) (*Device, error) {
 
 	coreDevice := core.NewDevice(openDevice.Device, a.core, features, limits, label)
 
-	fence, err := openDevice.Device.CreateFence()
-	if err != nil {
-		coreDevice.Destroy()
-		return nil, fmt.Errorf("wgpu: failed to create fence: %w", err)
-	}
-
 	queue := &Queue{
 		hal:       openDevice.Queue,
 		halDevice: openDevice.Device,
-		fence:     fence,
 	}
 
 	coreDevice.SetAssociatedQueue(&core.Queue{Label: label + " Queue"})
@@ -115,6 +108,44 @@ func (a *Adapter) requestDeviceCore(desc *DeviceDescriptor) (*Device, error) {
 	}
 
 	return &Device{core: coreDevice}, nil
+}
+
+// SurfaceCapabilities describes what a surface supports on this adapter.
+type SurfaceCapabilities struct {
+	// Formats lists the supported surface texture formats.
+	Formats []gputypes.TextureFormat
+
+	// PresentModes lists the supported presentation modes.
+	PresentModes []gputypes.PresentMode
+
+	// AlphaModes lists the supported composite alpha modes.
+	AlphaModes []gputypes.CompositeAlphaMode
+}
+
+// GetSurfaceCapabilities returns the capabilities of a surface for this adapter.
+// Returns nil if the adapter has no HAL (core-only path) or the surface is nil.
+func (a *Adapter) GetSurfaceCapabilities(surface *Surface) *SurfaceCapabilities {
+	if a.released || surface == nil {
+		return nil
+	}
+
+	if !a.core.HasHAL() {
+		// Core-only path: return safe defaults (Fifo is guaranteed by Vulkan spec).
+		return &SurfaceCapabilities{
+			PresentModes: []gputypes.PresentMode{gputypes.PresentModeFifo},
+		}
+	}
+
+	halCaps := a.core.HALAdapter().SurfaceCapabilities(surface.HAL())
+	if halCaps == nil {
+		return nil
+	}
+
+	return &SurfaceCapabilities{
+		Formats:      halCaps.Formats,
+		PresentModes: halCaps.PresentModes,
+		AlphaModes:   halCaps.AlphaModes,
+	}
 }
 
 // Release releases the adapter.

--- a/cmd/vulkan-triangle/main.go
+++ b/cmd/vulkan-triangle/main.go
@@ -463,7 +463,7 @@ func renderFrame(gpu *gpuResources) error {
 	}
 
 	// Submit
-	if err := gpu.queue.Submit([]hal.CommandBuffer{cmdBuffer}, nil, 0); err != nil {
+	if _, err := gpu.queue.Submit([]hal.CommandBuffer{cmdBuffer}); err != nil {
 		gpu.surface.DiscardTexture(acquired.Texture)
 		return fmt.Errorf("submit: %w", err)
 	}

--- a/cmd/wgpu-triangle-mt/main.go
+++ b/cmd/wgpu-triangle-mt/main.go
@@ -208,7 +208,7 @@ func run() error {
 				return
 			}
 
-			if err := device.Queue().Submit(commands); err != nil {
+			if _, err := device.Queue().Submit(commands); err != nil {
 				frameErr = fmt.Errorf("submit: %w", err)
 			}
 

--- a/cmd/wgpu-triangle/main.go
+++ b/cmd/wgpu-triangle/main.go
@@ -132,7 +132,7 @@ func run() error {
 		renderPass.Draw(3, 1, 0, 0)
 		_ = renderPass.End()
 		commands, _ := encoder.Finish()
-		_ = device.Queue().Submit(commands)
+		_, _ = device.Queue().Submit(commands)
 		_ = surface.Present(surfaceTex)
 		view.Release()
 

--- a/device.go
+++ b/device.go
@@ -412,8 +412,8 @@ func (d *Device) CreateCommandEncoder(desc *CommandEncoderDescriptor) (*CommandE
 }
 
 // CreateFence creates a GPU synchronization fence.
-// The returned fence can be used with Queue.SubmitWithFence to track
-// GPU work completion without blocking.
+// Fences are primarily used by the HAL internally for synchronization.
+// Most callers should use Queue.Submit + Queue.Poll instead.
 func (d *Device) CreateFence() (*Fence, error) {
 	if d.released {
 		return nil, ErrReleased

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -177,7 +177,7 @@ pass, _ := encoder.BeginComputePass(nil)
 // ... record commands ...
 pass.End()
 cmdBuf, _ := encoder.Finish()
-device.Queue().Submit(cmdBuf)
+_, _ = device.Queue().Submit(cmdBuf)  // non-blocking, returns submissionIndex
 ```
 
 ### Internal HAL flow

--- a/docs/COMPUTE-SHADERS.md
+++ b/docs/COMPUTE-SHADERS.md
@@ -274,11 +274,13 @@ if err != nil {
 ### Step 2: Submit and Wait
 
 ```go
-// Queue.Submit() handles fencing internally — blocks until GPU is done
-err = device.Queue().Submit(cmdBuffer)
+// Queue.Submit() is non-blocking — returns submission index for tracking
+_, err = device.Queue().Submit(cmdBuffer)
 if err != nil {
     log.Fatal("failed to submit:", err)
 }
+// Wait for GPU to finish before reading back results
+device.WaitIdle()
 ```
 
 ### Step 3: Read Back Data

--- a/examples/compute-copy/main.go
+++ b/examples/compute-copy/main.go
@@ -275,7 +275,7 @@ func dispatchAndReadBack(device *wgpu.Device, pipeline *wgpu.ComputePipeline, bi
 	if err != nil {
 		return nil, fmt.Errorf("finish encoder: %w", err)
 	}
-	if err := device.Queue().Submit(cmdBuf); err != nil {
+	if _, err := device.Queue().Submit(cmdBuf); err != nil {
 		return nil, fmt.Errorf("submit: %w", err)
 	}
 	fmt.Println("OK")

--- a/examples/compute-particles/main.go
+++ b/examples/compute-particles/main.go
@@ -275,7 +275,7 @@ func simulate(device *wgpu.Device, pipeline *wgpu.ComputePipeline, bg *wgpu.Bind
 		if err != nil {
 			return fmt.Errorf("finish encoder: %w", err)
 		}
-		if err := device.Queue().Submit(cmds); err != nil {
+		if _, err := device.Queue().Submit(cmds); err != nil {
 			return fmt.Errorf("submit: %w", err)
 		}
 

--- a/examples/compute-sum/main.go
+++ b/examples/compute-sum/main.go
@@ -275,7 +275,7 @@ func dispatchAndReadBack(device *wgpu.Device, ps *pipelineSet, bufs *bufferSet) 
 	if err != nil {
 		return 0, fmt.Errorf("finish encoder: %w", err)
 	}
-	if err := device.Queue().Submit(cmdBuf); err != nil {
+	if _, err := device.Queue().Submit(cmdBuf); err != nil {
 		return 0, fmt.Errorf("submit: %w", err)
 	}
 	fmt.Println("OK")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.5.0
 	github.com/gogpu/gputypes v0.3.0
-	github.com/gogpu/naga v0.14.8
+	github.com/gogpu/naga v0.15.0
 	golang.org/x/sys v0.42.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.3.0 h1:gcwxsBrcoCX19GqqqiV55wLv2iFwaybiOluKCb0hVrs=
 github.com/gogpu/gputypes v0.3.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.14.8 h1:xa4xHWiLvHLi+sWKuLRtrcO0Qpsc7pwwK+8tKzDLk74=
-github.com/gogpu/naga v0.14.8/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.15.0 h1:vjVjdZPZyvLB/yzT3tDxccR+HJWXyPtKcqAdRTjvi4k=
+github.com/gogpu/naga v0.15.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/hal/api.go
+++ b/hal/api.go
@@ -197,9 +197,15 @@ type Device interface {
 // Queue handles command submission and presentation.
 // Queues are typically thread-safe (backend-specific).
 type Queue interface {
-	// Submit submits command buffers to the GPU.
-	// If fence is not nil, it will be signaled with fenceValue when commands complete.
-	Submit(commandBuffers []CommandBuffer, fence Fence, fenceValue uint64) error
+	// Submit submits command buffers to the GPU for execution.
+	// Returns a monotonically increasing submission index that can be used
+	// with PollCompleted to determine when the GPU has finished the work.
+	// The HAL manages its own internal fences/synchronization.
+	Submit(commandBuffers []CommandBuffer) (submissionIndex uint64, err error)
+
+	// PollCompleted returns the highest submission index known to be completed
+	// by the GPU. Non-blocking. Returns 0 if no submissions have completed.
+	PollCompleted() uint64
 
 	// WriteBuffer writes data to a buffer immediately.
 	// This is a convenience method that creates a staging buffer internally.

--- a/hal/bench_cross_backend_test.go
+++ b/hal/bench_cross_backend_test.go
@@ -56,7 +56,7 @@ func BenchmarkHALSubmitOverhead(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := queue.Submit(cmdBuffers, nil, 0)
+		_, err := queue.Submit(cmdBuffers)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -221,9 +221,6 @@ func BenchmarkHALFullFrameSimulation(b *testing.B) {
 	view, _ := device.CreateTextureView(texture, &hal.TextureViewDescriptor{})
 	defer device.DestroyTextureView(view)
 
-	fence, _ := device.CreateFence()
-	defer device.DestroyFence(fence)
-
 	rpDesc := &hal.RenderPassDescriptor{
 		ColorAttachments: []hal.RenderPassColorAttachment{
 			{
@@ -247,7 +244,7 @@ func BenchmarkHALFullFrameSimulation(b *testing.B) {
 		rp.End()
 
 		cb, _ := encoder.EndEncoding()
-		_ = queue.Submit([]hal.CommandBuffer{cb}, fence, uint64(i+1))
+		_, _ = queue.Submit([]hal.CommandBuffer{cb})
 	}
 }
 

--- a/hal/dx12/device.go
+++ b/hal/dx12/device.go
@@ -498,6 +498,21 @@ func (d *Device) signalFrameFence() error {
 	return nil
 }
 
+// currentFrameFenceValue returns the most recently signaled fence value.
+// This is used as the submission index.
+func (d *Device) currentFrameFenceValue() uint64 {
+	d.fenceMu.Lock()
+	v := d.fenceValue
+	d.fenceMu.Unlock()
+	return v
+}
+
+// completedFrameFenceValue returns the highest fence value completed by the GPU.
+// Non-blocking — queries the D3D12 fence directly.
+func (d *Device) completedFrameFenceValue() uint64 {
+	return d.fence.GetCompletedValue()
+}
+
 // getOrCreateEmptyRootSignature returns a shared empty root signature for
 // pipelines that have no resource bindings (no PipelineLayout).
 // DX12 requires a valid root signature for every PSO — even with zero parameters.
@@ -1591,7 +1606,8 @@ func (d *Device) compileWGSLModule(wgslSource string, module *ShaderModule) erro
 	}
 
 	// Step 5: Compile each entry point separately
-	for _, ep := range irModule.EntryPoints {
+	for i := range irModule.EntryPoints {
+		ep := &irModule.EntryPoints[i]
 		target := shaderStageToTarget(ep.Stage)
 
 		// Use the HLSL entry point name (naga may rename it)

--- a/hal/dx12/queue.go
+++ b/hal/dx12/queue.go
@@ -7,7 +7,6 @@ package dx12
 
 import (
 	"fmt"
-	"time"
 	"unsafe"
 
 	"github.com/gogpu/gputypes"
@@ -32,50 +31,46 @@ func newQueue(device *Device) *Queue {
 }
 
 // Submit submits command buffers to the GPU.
-// If fence is not nil, it will be signaled with fenceValue when commands complete.
-func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenceValue uint64) error {
-	if len(commandBuffers) == 0 && fence == nil {
-		return nil
+// Returns a monotonically increasing submission index for tracking completion.
+func (q *Queue) Submit(commandBuffers []hal.CommandBuffer) (uint64, error) {
+	if len(commandBuffers) == 0 {
+		return 0, nil
 	}
 
 	// Convert command buffers to D3D12 command lists
-	if len(commandBuffers) > 0 {
-		cmdLists := make([]*d3d12.ID3D12GraphicsCommandList, len(commandBuffers))
-		for i, cb := range commandBuffers {
-			dx12CB, ok := cb.(*CommandBuffer)
-			if !ok {
-				return fmt.Errorf("dx12: command buffer is not a DX12 command buffer")
-			}
-			cmdLists[i] = dx12CB.cmdList
+	cmdLists := make([]*d3d12.ID3D12GraphicsCommandList, len(commandBuffers))
+	for i, cb := range commandBuffers {
+		dx12CB, ok := cb.(*CommandBuffer)
+		if !ok {
+			return 0, fmt.Errorf("dx12: command buffer is not a DX12 command buffer")
 		}
+		cmdLists[i] = dx12CB.cmdList
+	}
 
-		// Execute command lists
-		q.raw.ExecuteCommandLists(uint32(len(cmdLists)), &cmdLists[0])
+	// Execute command lists
+	q.raw.ExecuteCommandLists(uint32(len(cmdLists)), &cmdLists[0])
 
-		// Check for immediate device removal after execution.
-		// ExecuteCommandLists is async (void), but some drivers detect errors immediately.
-		if reason := q.device.raw.GetDeviceRemovedReason(); reason != nil {
-			return fmt.Errorf("dx12: device removed after ExecuteCommandLists: %w", reason)
-		}
+	// Check for immediate device removal after execution.
+	// ExecuteCommandLists is async (void), but some drivers detect errors immediately.
+	if reason := q.device.raw.GetDeviceRemovedReason(); reason != nil {
+		return 0, fmt.Errorf("dx12: device removed after ExecuteCommandLists: %w", reason)
 	}
 
 	// Drain debug messages after submission.
 	q.device.DrainDebugMessages()
 
-	// Signal the fence if provided
-	if fence != nil {
-		dx12Fence, ok := fence.(*Fence)
-		if !ok {
-			return fmt.Errorf("dx12: fence is not a DX12 fence")
-		}
-
-		if err := q.raw.Signal(dx12Fence.raw, fenceValue); err != nil {
-			return fmt.Errorf("dx12: queue Signal failed: %w", err)
-		}
+	// Signal the frame fence for per-frame allocator tracking and return its value
+	// as the submission index.
+	if err := q.device.signalFrameFence(); err != nil {
+		return 0, err
 	}
+	return q.device.currentFrameFenceValue(), nil
+}
 
-	// Signal the frame fence for per-frame allocator tracking.
-	return q.device.signalFrameFence()
+// PollCompleted returns the highest submission index known to be completed by the GPU.
+// Non-blocking.
+func (q *Queue) PollCompleted() uint64 {
+	return q.device.completedFrameFenceValue()
 }
 
 // ReadBuffer reads data from a GPU buffer into the provided byte slice.
@@ -221,17 +216,13 @@ func (q *Queue) writeBufferStaged(buf *Buffer, offset uint64, data []byte) error
 		return fmt.Errorf("dx12: WriteBuffer: EndEncoding failed: %w", err)
 	}
 
-	// Submit and wait for GPU completion
-	fence, err := q.device.CreateFence()
+	// Submit and wait for GPU completion.
+	_, err = q.Submit([]hal.CommandBuffer{cmdBuffer})
 	if err != nil {
-		return fmt.Errorf("dx12: WriteBuffer: CreateFence failed: %w", err)
-	}
-	defer q.device.DestroyFence(fence)
-
-	if err := q.Submit([]hal.CommandBuffer{cmdBuffer}, fence, 1); err != nil {
 		return fmt.Errorf("dx12: WriteBuffer: Submit failed: %w", err)
 	}
-	_, _ = q.device.Wait(fence, 1, 60*time.Second)
+	// Block until GPU finishes the copy — staging buffer must remain valid.
+	_ = q.device.WaitIdle()
 	q.device.FreeCommandBuffer(cmdBuffer)
 	return nil
 }
@@ -395,17 +386,13 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 		return fmt.Errorf("dx12: WriteTexture: EndEncoding failed: %w", err)
 	}
 
-	// Submit and wait for GPU completion
-	fence, err := q.device.CreateFence()
+	// Submit and wait for GPU completion.
+	_, err = q.Submit([]hal.CommandBuffer{cmdBuffer})
 	if err != nil {
-		return fmt.Errorf("dx12: WriteTexture: CreateFence failed: %w", err)
-	}
-	defer q.device.DestroyFence(fence)
-
-	if err := q.Submit([]hal.CommandBuffer{cmdBuffer}, fence, 1); err != nil {
 		return fmt.Errorf("dx12: WriteTexture: Submit failed: %w", err)
 	}
-	_, _ = q.device.Wait(fence, 1, 60*time.Second)
+	// Block until GPU finishes the copy — staging buffer must remain valid.
+	_ = q.device.WaitIdle()
 	q.device.FreeCommandBuffer(cmdBuffer)
 
 	// Update tracked state AFTER successful execution.

--- a/hal/gles/queue.go
+++ b/hal/gles/queue.go
@@ -16,16 +16,18 @@ import (
 
 // Queue implements hal.Queue for OpenGL.
 type Queue struct {
-	glCtx  *gl.Context
-	wglCtx *wgl.Context
+	glCtx           *gl.Context
+	wglCtx          *wgl.Context
+	submissionIndex uint64
 }
 
 // Submit submits command buffers to the GPU.
-func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenceValue uint64) error {
+// GLES is synchronous, so the submission is effectively complete immediately after Flush.
+func (q *Queue) Submit(commandBuffers []hal.CommandBuffer) (uint64, error) {
 	for _, cb := range commandBuffers {
 		cmdBuf, ok := cb.(*CommandBuffer)
 		if !ok {
-			return fmt.Errorf("gles: invalid command buffer type")
+			return 0, fmt.Errorf("gles: invalid command buffer type")
 		}
 
 		// Execute recorded commands with GL error checking.
@@ -37,17 +39,17 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenc
 		}
 	}
 
-	// Signal fence if provided
-	if fence != nil {
-		if f, ok := fence.(*Fence); ok {
-			f.Signal(fenceValue)
-		}
-	}
-
 	// Flush GL commands
 	q.glCtx.Flush()
 
-	return nil
+	q.submissionIndex++
+	return q.submissionIndex, nil
+}
+
+// PollCompleted returns the highest submission index known to be completed.
+// GLES is synchronous — after Flush, all submitted work is complete.
+func (q *Queue) PollCompleted() uint64 {
+	return q.submissionIndex
 }
 
 // ReadBuffer reads data from a GPU buffer into the provided byte slice.

--- a/hal/gles/queue_linux.go
+++ b/hal/gles/queue_linux.go
@@ -16,16 +16,18 @@ import (
 
 // Queue implements hal.Queue for OpenGL on Linux.
 type Queue struct {
-	glCtx  *gl.Context
-	eglCtx *egl.Context
+	glCtx           *gl.Context
+	eglCtx          *egl.Context
+	submissionIndex uint64
 }
 
 // Submit submits command buffers to the GPU.
-func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenceValue uint64) error {
+// GLES is synchronous, so the submission is effectively complete immediately after Flush.
+func (q *Queue) Submit(commandBuffers []hal.CommandBuffer) (uint64, error) {
 	for _, cb := range commandBuffers {
 		cmdBuf, ok := cb.(*CommandBuffer)
 		if !ok {
-			return fmt.Errorf("gles: invalid command buffer type")
+			return 0, fmt.Errorf("gles: invalid command buffer type")
 		}
 
 		// Execute recorded commands with GL error checking.
@@ -37,17 +39,17 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenc
 		}
 	}
 
-	// Signal fence if provided
-	if fence != nil {
-		if f, ok := fence.(*Fence); ok {
-			f.Signal(fenceValue)
-		}
-	}
-
 	// Flush GL commands
 	q.glCtx.Flush()
 
-	return nil
+	q.submissionIndex++
+	return q.submissionIndex, nil
+}
+
+// PollCompleted returns the highest submission index known to be completed.
+// GLES is synchronous — after Flush, all submitted work is complete.
+func (q *Queue) PollCompleted() uint64 {
+	return q.submissionIndex
 }
 
 // ReadBuffer reads data from a GPU buffer into the provided byte slice.

--- a/hal/metal/queue.go
+++ b/hal/metal/queue.go
@@ -24,6 +24,9 @@ type Queue struct {
 	device       *Device
 	commandQueue ID // id<MTLCommandQueue>
 
+	// submissionIndex is a monotonically increasing counter for tracking submissions.
+	submissionIndex uint64
+
 	// frameSemaphore limits CPU-ahead-of-GPU frames. Each Submit consumes a
 	// slot from the buffered channel; the GPU's addCompletedHandler callback
 	// returns the slot when the command buffer finishes execution.
@@ -32,13 +35,14 @@ type Queue struct {
 }
 
 // Submit submits command buffers to the GPU.
+// Returns a monotonically increasing submission index for tracking completion.
 //
 // Frame throttling: when frameSemaphore is initialized, Submit blocks until a
 // frame slot is available (at most maxFramesInFlight frames in-flight). A
 // completion handler on the last command buffer signals the semaphore when the
 // GPU finishes, releasing the slot for the next frame. This prevents unbounded
 // memory growth from queued command buffers and avoids drawable pool exhaustion.
-func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenceValue uint64) error {
+func (q *Queue) Submit(commandBuffers []hal.CommandBuffer) (uint64, error) {
 	// Acquire a frame slot — blocks if maxFramesInFlight frames are in-flight.
 	// This is the CPU-side throttle point.
 	if q.frameSemaphore != nil {
@@ -47,8 +51,10 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenc
 
 	hal.Logger().Debug("metal: Submit",
 		"buffers", len(commandBuffers),
-		"hasFence", fence != nil,
 	)
+
+	q.submissionIndex++
+	subIdx := q.submissionIndex
 
 	pool := NewAutoreleasePool()
 	defer pool.Drain()
@@ -58,16 +64,6 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenc
 		cb, ok := buf.(*CommandBuffer)
 		if !ok || cb == nil {
 			continue
-		}
-
-		// If fence provided, encode a signal on the shared event.
-		// MTLSharedEvent.signaledValue is updated by the GPU when the command
-		// buffer completes — we do NOT set the Go-side value here.
-		if fence != nil {
-			if mtlFence, ok := fence.(*Fence); ok && mtlFence != nil {
-				_ = MsgSend(cb.raw, Sel("encodeSignalEvent:value:"),
-					uintptr(mtlFence.event), uintptr(fenceValue))
-			}
 		}
 
 		// Schedule presentation BEFORE commit (Metal requirement)
@@ -93,7 +89,20 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenc
 		q.frameSemaphore <- struct{}{}
 	}
 
-	return nil
+	return subIdx, nil
+}
+
+// PollCompleted returns the highest submission index known to be completed by the GPU.
+// Metal tracks completion via completion handlers; this returns the last known completed index.
+func (q *Queue) PollCompleted() uint64 {
+	// Metal uses completion handlers for tracking. Since we don't have a shared
+	// event counter exposed here, we conservatively return the last submission
+	// minus frames-in-flight (or 0 if too early). The frame semaphore provides
+	// the actual throttling.
+	if q.submissionIndex <= maxFramesInFlight {
+		return 0
+	}
+	return q.submissionIndex - maxFramesInFlight
 }
 
 // registerFrameCompletionHandler attaches an addCompletedHandler: block to the

--- a/hal/noop/bench_test.go
+++ b/hal/noop/bench_test.go
@@ -50,7 +50,7 @@ func BenchmarkNoopSubmitEmpty(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := queue.Submit(nil, nil, 0)
+		_, err := queue.Submit(nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -71,30 +71,7 @@ func BenchmarkNoopSubmitSingle(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := queue.Submit(cmdBuffers, nil, 0)
-		if err != nil {
-			b.Fatal(err)
-		}
-	}
-	runtime.KeepAlive(cmdBuffers)
-}
-
-// BenchmarkNoopSubmitWithFence measures submit + fence signaling overhead.
-func BenchmarkNoopSubmitWithFence(b *testing.B) {
-	b.ReportAllocs()
-	device, queue, cleanup := setupNoopDevice(b)
-	defer cleanup()
-
-	encoder, _ := device.CreateCommandEncoder(&hal.CommandEncoderDescriptor{Label: "bench"})
-	_ = encoder.BeginEncoding("bench")
-	cmdBuffer, _ := encoder.EndEncoding()
-	cmdBuffers := []hal.CommandBuffer{cmdBuffer}
-	fence, _ := device.CreateFence()
-	defer device.DestroyFence(fence)
-
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		err := queue.Submit(cmdBuffers, fence, uint64(i+1))
+		_, err := queue.Submit(cmdBuffers)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -337,9 +314,6 @@ func BenchmarkNoopFullFrame(b *testing.B) {
 	})
 	defer device.DestroyRenderPipeline(pipeline)
 
-	fence, _ := device.CreateFence()
-	defer device.DestroyFence(fence)
-
 	rpDesc := &hal.RenderPassDescriptor{
 		ColorAttachments: []hal.RenderPassColorAttachment{
 			{
@@ -366,7 +340,7 @@ func BenchmarkNoopFullFrame(b *testing.B) {
 		cmdBuffer, _ := encoder.EndEncoding()
 
 		// Submit
-		_ = queue.Submit([]hal.CommandBuffer{cmdBuffer}, fence, uint64(i+1))
+		_, _ = queue.Submit([]hal.CommandBuffer{cmdBuffer})
 	}
 }
 

--- a/hal/noop/noop_test.go
+++ b/hal/noop/noop_test.go
@@ -554,25 +554,19 @@ func TestNoopQueueSubmit(t *testing.T) {
 	_ = encoder.BeginEncoding("test")
 	cmdBuffer, _ := encoder.EndEncoding()
 
-	// Submit without fence
-	err := queue.Submit([]hal.CommandBuffer{cmdBuffer}, nil, 0)
+	// Submit
+	subIdx, err := queue.Submit([]hal.CommandBuffer{cmdBuffer})
 	if err != nil {
 		t.Fatalf("Submit failed: %v", err)
 	}
-
-	// Submit with fence
-	fence, _ := device.CreateFence()
-	defer device.DestroyFence(fence)
-
-	err = queue.Submit([]hal.CommandBuffer{cmdBuffer}, fence, 1)
-	if err != nil {
-		t.Fatalf("Submit with fence failed: %v", err)
+	if subIdx == 0 {
+		t.Error("expected non-zero submission index")
 	}
 
-	// Verify fence was signaled
-	ok, _ := device.Wait(fence, 1, 100*time.Millisecond)
-	if !ok {
-		t.Error("expected fence to be signaled after submit")
+	// Poll completed — noop is synchronous, should be immediately complete
+	completed := queue.PollCompleted()
+	if completed < subIdx {
+		t.Errorf("expected completed >= %d, got %d", subIdx, completed)
 	}
 }
 
@@ -850,25 +844,12 @@ func TestNoopComputeE2E(t *testing.T) {
 		t.Fatalf("EndEncoding failed: %v", err)
 	}
 
-	// 8. Submit with fence
-	fence, err := device.CreateFence()
-	if err != nil {
-		t.Fatalf("CreateFence failed: %v", err)
-	}
-	defer device.DestroyFence(fence)
-
-	if err := queue.Submit([]hal.CommandBuffer{cmdBuffer}, fence, 1); err != nil {
+	// 8. Submit
+	if _, err := queue.Submit([]hal.CommandBuffer{cmdBuffer}); err != nil {
 		t.Fatalf("Submit failed: %v", err)
 	}
 
-	// 9. Wait for completion
-	ok, err := device.Wait(fence, 1, time.Second)
-	if err != nil {
-		t.Fatalf("Wait failed: %v", err)
-	}
-	if !ok {
-		t.Fatal("fence not signaled after submit")
-	}
+	// 9. Noop is synchronous — submission is immediately complete.
 
 	// 10. Read back results
 	result := make([]byte, bufferSize)
@@ -1204,21 +1185,9 @@ func TestNoopFullLifecycle(t *testing.T) {
 	cmdBuffer, _ := encoder.EndEncoding()
 
 	// Submit
-	fence, _ := device.CreateFence()
-	defer device.DestroyFence(fence)
-
-	err = queue.Submit([]hal.CommandBuffer{cmdBuffer}, fence, 1)
+	_, err = queue.Submit([]hal.CommandBuffer{cmdBuffer})
 	if err != nil {
 		t.Fatalf("Submit failed: %v", err)
-	}
-
-	// Wait
-	ok, err := device.Wait(fence, 1, time.Second)
-	if err != nil {
-		t.Fatalf("Wait failed: %v", err)
-	}
-	if !ok {
-		t.Error("expected fence to be signaled")
 	}
 }
 
@@ -1253,7 +1222,7 @@ func TestNoopConcurrentAccess(t *testing.T) {
 				encoder, _ := device.CreateCommandEncoder(&hal.CommandEncoderDescriptor{})
 				_ = encoder.BeginEncoding("test")
 				cmdBuffer, _ := encoder.EndEncoding()
-				_ = queue.Submit([]hal.CommandBuffer{cmdBuffer}, nil, 0)
+				_, _ = queue.Submit([]hal.CommandBuffer{cmdBuffer})
 			}
 		}()
 	}

--- a/hal/noop/queue.go
+++ b/hal/noop/queue.go
@@ -7,17 +7,21 @@ import (
 )
 
 // Queue implements hal.Queue for the noop backend.
-type Queue struct{}
+type Queue struct {
+	submissionIndex uint64
+}
 
 // Submit simulates command buffer submission.
-// If a fence is provided, it is signaled with the given value.
-func (q *Queue) Submit(_ []hal.CommandBuffer, fence hal.Fence, fenceValue uint64) error {
-	if fence != nil {
-		if f, ok := fence.(*Fence); ok {
-			f.value.Store(fenceValue)
-		}
-	}
-	return nil
+// Returns a monotonically increasing submission index.
+func (q *Queue) Submit(_ []hal.CommandBuffer) (uint64, error) {
+	q.submissionIndex++
+	return q.submissionIndex, nil
+}
+
+// PollCompleted returns the highest submission index known to be completed.
+// Noop backend is synchronous — all submissions are immediately complete.
+func (q *Queue) PollCompleted() uint64 {
+	return q.submissionIndex
 }
 
 // ReadBuffer reads data from a buffer.

--- a/hal/software/queue.go
+++ b/hal/software/queue.go
@@ -7,17 +7,21 @@ import (
 )
 
 // Queue implements hal.Queue for the software backend.
-type Queue struct{}
+type Queue struct {
+	submissionIndex uint64
+}
 
 // Submit simulates command buffer submission.
-// If a fence is provided, it is signaled with the given value.
-func (q *Queue) Submit(_ []hal.CommandBuffer, fence hal.Fence, fenceValue uint64) error {
-	if fence != nil {
-		if f, ok := fence.(*Fence); ok {
-			f.value.Store(fenceValue)
-		}
-	}
-	return nil
+// Software backend is synchronous — work is complete immediately.
+func (q *Queue) Submit(_ []hal.CommandBuffer) (uint64, error) {
+	q.submissionIndex++
+	return q.submissionIndex, nil
+}
+
+// PollCompleted returns the highest submission index known to be completed.
+// Software backend is synchronous — all submissions are immediately complete.
+func (q *Queue) PollCompleted() uint64 {
+	return q.submissionIndex
 }
 
 // ReadBuffer reads data from a buffer.

--- a/hal/vulkan/bench_hot_path_test.go
+++ b/hal/vulkan/bench_hot_path_test.go
@@ -78,7 +78,7 @@ func BenchmarkVulkanSubmitEmpty(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := queue.Submit(nil, nil, 0)
+		_, err := queue.Submit(nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -133,7 +133,7 @@ func BenchmarkVulkanSubmitSingle(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := queue.Submit(cmdBuffers, nil, 0)
+		_, err := queue.Submit(cmdBuffers)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -186,7 +186,7 @@ func BenchmarkVulkanEncodeSubmitCycle(b *testing.B) {
 		_ = encoder.BeginEncoding("frame")
 		cb, _ := encoder.EndEncoding()
 
-		_ = queue.Submit([]hal.CommandBuffer{cb}, nil, 0)
+		_, _ = queue.Submit([]hal.CommandBuffer{cb})
 		_ = device.WaitIdle()
 	}
 }
@@ -224,7 +224,7 @@ func BenchmarkVulkanSubmitMultiple(b *testing.B) {
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_ = queue.Submit(cmdBuffers, nil, 0)
+				_, _ = queue.Submit(cmdBuffers)
 				_ = device.WaitIdle()
 			}
 		})

--- a/hal/vulkan/compute_integration_test.go
+++ b/hal/vulkan/compute_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/binary"
 	"math"
 	"testing"
-	"time"
 
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/hal"
@@ -285,21 +284,16 @@ func TestComputeSDFIntegration(t *testing.T) {
 		t.Fatalf("EndEncoding failed: %v", err)
 	}
 
-	// Step 10: Submit with fence and wait
-	fence, err := device.CreateFence()
+	// Step 10: Submit and wait for completion
+	subIdx, err := queue.Submit([]hal.CommandBuffer{cmdBuffer})
 	if err != nil {
-		t.Fatalf("CreateFence failed: %v", err)
-	}
-	defer device.DestroyFence(fence)
-
-	if err := queue.Submit([]hal.CommandBuffer{cmdBuffer}, fence, 1); err != nil {
 		t.Fatalf("Submit failed: %v", err)
 	}
 
-	ok, err := device.Wait(fence, 1, 5*time.Second)
-	if err != nil {
-		t.Fatalf("Wait failed: %v", err)
-	}
+	// Wait for GPU to complete by polling (or use WaitIdle for tests).
+	_ = device.WaitIdle()
+	completed := queue.PollCompleted()
+	ok := completed >= subIdx
 	if !ok {
 		t.Fatal("fence not signaled after 5s timeout")
 	}

--- a/hal/vulkan/queue.go
+++ b/hal/vulkan/queue.go
@@ -35,12 +35,14 @@ type Queue struct {
 }
 
 // Submit submits command buffers to the GPU.
-func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenceValue uint64) error {
+// Returns a monotonically increasing submission index for tracking completion.
+// The HAL internally manages fence/timeline semaphore synchronization.
+func (q *Queue) Submit(commandBuffers []hal.CommandBuffer) (uint64, error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
 	if len(commandBuffers) == 0 {
-		return nil
+		return 0, nil
 	}
 
 	// Convert command buffers to Vulkan handles.
@@ -52,7 +54,7 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenc
 		if !ok {
 			*pooledSlice = vkCmdBuffers
 			cmdBufferPool.Put(pooledSlice)
-			return fmt.Errorf("vulkan: command buffer is not a Vulkan command buffer")
+			return 0, fmt.Errorf("vulkan: command buffer is not a Vulkan command buffer")
 		}
 		vkCmdBuffers = append(vkCmdBuffers, vkCB.handle)
 	}
@@ -73,7 +75,6 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenc
 	// - Signal presentSemaphores: ONLY on first submit (waited on by present)
 	// Subsequent submits in the same frame run without semaphore synchronization.
 	waitStage := vk.PipelineStageFlags(vk.PipelineStageColorAttachmentOutputBit)
-	var submitFence vk.Fence
 	consumedAcquire := false // tracks whether THIS submit consumes the acquire semaphore
 	if q.activeSwapchain != nil && !q.acquireUsed {
 		acquireSem := q.activeSwapchain.currentAcquireSem
@@ -87,19 +88,12 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenc
 		consumedAcquire = true
 	}
 
-	// Use user-provided fence if available
-	if fence != nil {
-		if vkF, ok := fence.(*Fence); ok {
-			submitFence = vkF.handle
-		}
-	}
+	signalValue := q.device.timelineFence.nextSignalValue()
 
 	// Timeline path (VK-IMPL-001): Attach timeline semaphore signal to the real submit.
 	// This enables waitForGPU to track the latest submission.
 	var timelineSubmitInfo vk.TimelineSemaphoreSubmitInfo
 	if q.device.timelineFence.isTimeline { //nolint:nestif // timeline PNext chaining requires conditional semaphore setup
-		signalValue := q.device.timelineFence.nextSignalValue()
-
 		// VK-IMPL-004: Record which submission consumed this acquire semaphore.
 		// Pre-acquire wait in acquireNextImage() uses this to ensure the GPU
 		// has finished before reusing the semaphore.
@@ -144,18 +138,18 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenc
 			timelineSubmitInfo.PWaitSemaphoreValues = &waitValue
 		}
 
-		result := vkQueueSubmit(q, 1, &submitInfo, submitFence)
+		result := vkQueueSubmit(q, 1, &submitInfo, vk.Fence(0))
 		if result != vk.Success {
-			return fmt.Errorf("vulkan: vkQueueSubmit failed: %d", result)
+			return 0, fmt.Errorf("vulkan: vkQueueSubmit failed: %d", result)
 		}
-		return nil
+		return signalValue, nil
 	}
 
 	// Binary path (VK-IMPL-003): Get a fence from the pool to track this submission.
-	// The fencePool replaces the old transferFence with per-submission tracking,
-	// enabling waitForGPU to wait for specific or latest submissions.
+	// BUG-GOGPU-004 FIX: Always use pool fence directly — single vkQueueSubmit per frame.
+	// Previously, user-provided fences caused a double submit (real + empty for pool tracking).
+	// Now the HAL manages fences internally, eliminating the double submit entirely.
 	pool := q.device.timelineFence.pool
-	signalValue := q.device.timelineFence.nextSignalValue()
 
 	// VK-IMPL-004: Record fence value for pre-acquire wait (binary path).
 	if consumedAcquire {
@@ -163,31 +157,41 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer, fence hal.Fence, fenc
 	}
 	poolFence, err := pool.signal(q.device.cmds, q.device.handle, signalValue)
 	if err != nil {
-		return fmt.Errorf("vulkan: Submit fencePool signal: %w", err)
+		return 0, fmt.Errorf("vulkan: Submit fencePool signal: %w", err)
 	}
 
-	// If user provided their own fence, we submit with the user fence and
-	// signal the pool fence via a separate empty submit for tracking.
-	if submitFence != 0 {
-		result := vkQueueSubmit(q, 1, &submitInfo, submitFence)
-		if result != vk.Success {
-			return fmt.Errorf("vulkan: vkQueueSubmit failed: %d", result)
-		}
-		// Empty submit to signal the pool fence for waitForGPU tracking.
-		emptySubmit := vk.SubmitInfo{SType: vk.StructureTypeSubmitInfo}
-		result = vkQueueSubmit(q, 1, &emptySubmit, poolFence)
-		if result != vk.Success {
-			return fmt.Errorf("vulkan: vkQueueSubmit (pool fence) failed: %d", result)
-		}
-		return nil
-	}
-
-	// Common case: no user fence, submit with pool fence directly.
+	// Single vkQueueSubmit with pool fence — no more double submit.
 	result := vkQueueSubmit(q, 1, &submitInfo, poolFence)
 	if result != vk.Success {
-		return fmt.Errorf("vulkan: vkQueueSubmit failed: %d", result)
+		return 0, fmt.Errorf("vulkan: vkQueueSubmit failed: %d", result)
 	}
-	return nil
+	return signalValue, nil
+}
+
+// PollCompleted returns the highest submission index known to be completed by the GPU.
+// Non-blocking.
+func (q *Queue) PollCompleted() uint64 {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if q.device.timelineFence.isTimeline {
+		// Timeline path: query the semaphore counter value.
+		var value uint64
+		result := q.device.cmds.GetSemaphoreCounterValue(q.device.handle, q.device.timelineFence.timelineSemaphore, &value)
+		if result == vk.Success {
+			if value > q.device.timelineFence.lastCompleted {
+				q.device.timelineFence.lastCompleted = value
+			}
+			return value
+		}
+		return q.device.timelineFence.lastCompleted
+	}
+
+	// Binary path: poll fences in the pool.
+	pool := q.device.timelineFence.pool
+	pool.maintain(q.device.cmds, q.device.handle)
+	q.device.timelineFence.lastCompleted = pool.lastCompleted
+	return pool.lastCompleted
 }
 
 // SubmitForPresent submits command buffers with swapchain synchronization.
@@ -475,13 +479,6 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 		return fmt.Errorf("vulkan: WriteTexture: EndEncoding failed: %w", err)
 	}
 
-	// Submit and wait
-	fence, err := q.device.CreateFence()
-	if err != nil {
-		return fmt.Errorf("vulkan: WriteTexture: CreateFence failed: %w", err)
-	}
-	defer q.device.DestroyFence(fence)
-
 	// VK-004: Staging uploads must NOT consume swapchain semaphores.
 	// When WriteTexture is called between BeginFrame/EndFrame (e.g., in onDraw),
 	// the activeSwapchain acquire semaphore must be preserved for the render pass
@@ -499,12 +496,18 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 		q.mu.Unlock()
 	}()
 
-	if err := q.Submit([]hal.CommandBuffer{cmdBuffer}, fence, 0); err != nil {
+	// Submit and wait for completion — WriteTexture must block because
+	// the staging buffer data must be fully uploaded before return.
+	subIdx, err := q.Submit([]hal.CommandBuffer{cmdBuffer})
+	if err != nil {
 		return fmt.Errorf("vulkan: WriteTexture: Submit failed: %w", err)
 	}
 
-	// Wait for completion (60 second timeout)
-	_, _ = q.device.Wait(fence, 0, 60*time.Second)
+	// Wait for the submission to complete (60 second timeout).
+	timeoutNs := uint64(60 * time.Second)
+	if waitErr := q.device.timelineFence.waitForValue(q.device.cmds, q.device.handle, subIdx, timeoutNs); waitErr != nil {
+		hal.Logger().Warn("vulkan: WriteTexture: wait failed", "err", waitErr)
+	}
 
 	// Free command buffer back to pool after GPU finishes
 	q.device.FreeCommandBuffer(cmdBuffer)

--- a/integration_test.go
+++ b/integration_test.go
@@ -555,7 +555,7 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
 		t.Fatalf("Finish: %v", err)
 	}
 
-	err = device.Queue().Submit(cmdBuf)
+	_, err = device.Queue().Submit(cmdBuf)
 	if err != nil {
 		t.Fatalf("Submit: %v", err)
 	}

--- a/queue.go
+++ b/queue.go
@@ -2,93 +2,48 @@ package wgpu
 
 import (
 	"fmt"
-	"sync/atomic"
-	"time"
 
 	"github.com/gogpu/wgpu/hal"
 )
 
-// defaultSubmitTimeout is the maximum time to wait for GPU work to complete
-// after submitting command buffers. 30 seconds accommodates heavy compute workloads.
-const defaultSubmitTimeout = 30 * time.Second
-
 // Queue handles command submission and data transfers.
 type Queue struct {
-	hal        hal.Queue
-	halDevice  hal.Device
-	fence      hal.Fence
-	fenceValue atomic.Uint64
-	device     *Device
+	hal       hal.Queue
+	halDevice hal.Device
+	device    *Device
 }
 
-// Submit submits command buffers for execution.
-// This is a synchronous operation - it blocks until the GPU has completed all submitted work.
-func (q *Queue) Submit(commandBuffers ...*CommandBuffer) error {
+// Submit submits command buffers for execution. Non-blocking.
+// Returns a submission index that can be used with Poll() to track completion.
+// Command buffers are owned by the caller — free them after Poll confirms completion.
+func (q *Queue) Submit(commandBuffers ...*CommandBuffer) (uint64, error) {
 	if q.hal == nil {
-		return fmt.Errorf("wgpu: queue not available")
+		return 0, fmt.Errorf("wgpu: queue not available")
 	}
 
 	halBuffers := make([]hal.CommandBuffer, len(commandBuffers))
 	for i, cb := range commandBuffers {
 		if cb == nil {
-			return fmt.Errorf("wgpu: command buffer at index %d is nil", i)
+			return 0, fmt.Errorf("wgpu: command buffer at index %d is nil", i)
 		}
 		halBuffers[i] = cb.halBuffer()
 	}
 
-	nextValue := q.fenceValue.Add(1)
-	err := q.hal.Submit(halBuffers, q.fence, nextValue)
+	subIdx, err := q.hal.Submit(halBuffers)
 	if err != nil {
-		return fmt.Errorf("wgpu: submit failed: %w", err)
+		return 0, fmt.Errorf("wgpu: submit failed: %w", err)
 	}
 
-	_, err = q.halDevice.Wait(q.fence, nextValue, defaultSubmitTimeout)
-	if err != nil {
-		return fmt.Errorf("wgpu: wait failed: %w", err)
-	}
-
-	for _, cb := range commandBuffers {
-		raw := cb.halBuffer()
-		if raw != nil {
-			q.halDevice.FreeCommandBuffer(raw)
-		}
-	}
-
-	return nil
+	return subIdx, nil
 }
 
-// SubmitWithFence submits command buffers for execution with fence-based tracking.
-// Unlike Submit, this method does NOT block until GPU completion. Instead, it
-// signals the provided fence with submissionIndex when the work completes.
-// The caller is responsible for polling or waiting on the fence.
-//
-// If fence is nil, the submission proceeds without fence signaling.
-// Command buffers must be freed by the caller after the fence signals
-// (use Device.FreeCommandBuffer).
-func (q *Queue) SubmitWithFence(commandBuffers []*CommandBuffer, fence *Fence, submissionIndex uint64) error {
+// Poll returns the last completed submission index. Non-blocking.
+// All submissions with index <= the returned value have been completed by the GPU.
+func (q *Queue) Poll() uint64 {
 	if q.hal == nil {
-		return fmt.Errorf("wgpu: queue not available")
+		return 0
 	}
-
-	halBuffers := make([]hal.CommandBuffer, len(commandBuffers))
-	for i, cb := range commandBuffers {
-		if cb == nil {
-			return fmt.Errorf("wgpu: command buffer at index %d is nil", i)
-		}
-		halBuffers[i] = cb.halBuffer()
-	}
-
-	var halFence hal.Fence
-	if fence != nil {
-		halFence = fence.hal
-	}
-
-	err := q.hal.Submit(halBuffers, halFence, submissionIndex)
-	if err != nil {
-		return fmt.Errorf("wgpu: submit failed: %w", err)
-	}
-
-	return nil
+	return q.hal.PollCompleted()
 }
 
 // WriteBuffer writes data to a buffer.
@@ -145,8 +100,5 @@ func (q *Queue) WriteTexture(dst *ImageCopyTexture, data []byte, layout *ImageDa
 
 // release cleans up queue resources.
 func (q *Queue) release() {
-	if q.fence != nil && q.halDevice != nil {
-		q.halDevice.DestroyFence(q.fence)
-		q.fence = nil
-	}
+	// Queue no longer owns fences — HAL manages synchronization internally.
 }

--- a/wgpu_test.go
+++ b/wgpu_test.go
@@ -904,7 +904,7 @@ func TestQueueSubmitNilCommandBuffer(t *testing.T) {
 		t.Skip("no queue available")
 	}
 
-	err := q.Submit(nil)
+	_, err := q.Submit(nil)
 	if err == nil {
 		t.Fatal("Submit with nil command buffer should return error")
 	}

--- a/wrap.go
+++ b/wrap.go
@@ -2,7 +2,6 @@ package wgpu
 
 import (
 	"fmt"
-	"sync/atomic"
 
 	"github.com/gogpu/wgpu/core"
 	"github.com/gogpu/wgpu/hal"
@@ -39,18 +38,10 @@ func NewDeviceFromHAL(
 
 	coreDevice := core.NewDevice(halDevice, coreAdapter, features, limits, label)
 
-	fence, err := halDevice.CreateFence()
-	if err != nil {
-		coreDevice.Destroy()
-		return nil, fmt.Errorf("wgpu: failed to create queue fence: %w", err)
-	}
-
 	queue := &Queue{
 		hal:       halQueue,
 		halDevice: halDevice,
-		fence:     fence,
 	}
-	queue.fenceValue = atomic.Uint64{}
 
 	coreDevice.SetAssociatedQueue(&core.Queue{Label: label + " Queue"})
 


### PR DESCRIPTION
## Summary

Enterprise fence architecture: HAL owns all fences, `Queue.Submit()` returns `SubmissionIndex`.

### Breaking Changes

- `Queue.Submit()` signature changed: returns `(uint64, error)` (non-blocking)
- `Queue.SubmitWithFence()` removed
- HAL `Queue.Submit()` no longer accepts user fence parameter

### Added

- `Adapter.GetSurfaceCapabilities(surface)` — query supported formats, present modes, alpha modes
- `Queue.Poll()` — non-blocking GPU completion query

### Changed

- All 6 HAL backends updated (Vulkan, DX12, Metal, GLES, Software, Noop)
- Vulkan binary fence path: single `vkQueueSubmit` per frame (was double)
- deps: naga v0.14.8 → v0.15.0 (full Rust parity, all 5 shader backends 100%)

### Why

5 enterprise engines analyzed (Rust wgpu, Dawn, Godot, DXVK, vkd3d-proton) — all use single submit with HAL-owned fences. Our double submit on binary fence path caused first-frame loss on llvmpipe Vulkan 1.0.2 (ui#66).

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Lint clean (`golangci-lint run` — 0 issues)
- [x] Triangle, texture, particles examples verified on Vulkan (Intel Iris Xe)
- [x] gg integration, ui hello examples verified
- [x] Cross-compile Linux verified
