### PR TITLE
fix(dx12,gles): text/texture rendering on all non-Vulkan backends (v0.23.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.1] - 2026-03-31
+
+### Fixed
+
+- **DX12: vertex input semantic mismatch** — Changed input layout semantic from
+  `TEXCOORD{N}` to `LOC{N}` to match naga HLSL output. DX12 validates exact
+  semantic name match between shader and input layout. Previous mismatch caused
+  `CreateGraphicsPipelineState` to fail with `E_INVALIDARG` on all render pipelines.
+
+- **GLES: texture sampling broken — BindingMap not passed to GLSL compiler** —
+  Without BindingMap, naga GLSL emitted default `layout(binding=0)` for all
+  samplers. Runtime bound textures at `group*16+binding` (unit 1+). Shader
+  sampled unit 0 (empty) → invisible text and textures on all GLES backends.
+
+- **GLES (Linux): WriteTexture used wrong internalFormat** — Linux path discarded
+  `internalFormat` from `textureFormatToGL()` and passed `GL_TEXTURE_2D` (0x0DE1)
+  as internal format to `glTexImage2D`. Texture upload silently failed.
+
+- **GLES: missing GL_UNPACK_ALIGNMENT for R8 textures** — Added
+  `glPixelStorei(GL_UNPACK_ALIGNMENT, 1)` before R8 uploads to prevent corrupted
+  font glyphs on non-power-of-2 widths.
+
+- **DX12: direct sampler binding** — naga HLSL now generates direct `register(sN, spaceG)`
+  for samplers when BindingMap is provided (instead of sampler heap indirection).
+  DX12 HAL builds BindingMap from IR module, matching root signature layout.
+  Fixes invisible text/textures on DX12.
+
+### Known Issues
+
+- **DX12: rendering noticeably slower than Vulkan/GLES** — Needs profiling.
+  Possible causes: HLSL compilation overhead, descriptor heap allocation, sync.
+  Tracked in PERF-DX12-001.
+
 ## [0.23.0] - 2026-03-30
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.5.0
 	github.com/gogpu/gputypes v0.3.0
-	github.com/gogpu/naga v0.15.0
+	github.com/gogpu/naga v0.15.1
 	golang.org/x/sys v0.42.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.3.0 h1:gcwxsBrcoCX19GqqqiV55wLv2iFwaybiOluKCb0hVrs=
 github.com/gogpu/gputypes v0.3.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.15.0 h1:vjVjdZPZyvLB/yzT3tDxccR+HJWXyPtKcqAdRTjvi4k=
-github.com/gogpu/naga v0.15.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.15.1 h1:G2oSyFWbzXT294NNj3qB9/ey5ok8vhEaXfOKI0ch39k=
+github.com/gogpu/naga v0.15.1/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/hal/dx12/device.go
+++ b/hal/dx12/device.go
@@ -1593,19 +1593,50 @@ func (d *Device) compileWGSLModule(wgslSource string, module *ShaderModule) erro
 		return fmt.Errorf("WGSL lower: %w", err)
 	}
 
-	// Step 3: Generate HLSL (all entry points)
-	hlslSource, info, err := hlsl.Compile(irModule, hlsl.DefaultOptions())
+	// Step 3: Build BindingMap from IR global variables.
+	// This maps each (group, binding) pair to an explicit HLSL register target,
+	// matching the root signature layout where register=binding and space=group.
+	// Without this, naga generates sampler heap indirection (nagaSamplerHeap[...])
+	// which requires a global sampler pool and index buffers that our HAL doesn't
+	// implement. With explicit BindingMap entries and no SamplerBufferBindingMap,
+	// naga emits direct register bindings for samplers (register(sN, spaceG)),
+	// matching our per-group sampler descriptor tables.
+	bindingMap := make(map[hlsl.ResourceBinding]hlsl.BindTarget, len(irModule.GlobalVariables))
+	for i := range irModule.GlobalVariables {
+		gv := &irModule.GlobalVariables[i]
+		if gv.Binding == nil {
+			continue
+		}
+		bindingMap[hlsl.ResourceBinding{
+			Group:   gv.Binding.Group,
+			Binding: gv.Binding.Binding,
+		}] = hlsl.BindTarget{
+			Space:    uint8(gv.Binding.Group),
+			Register: gv.Binding.Binding,
+		}
+	}
+
+	opts := hlsl.DefaultOptions()
+	opts.BindingMap = bindingMap
+	opts.FakeMissingBindings = false
+	// NOTE: SamplerBufferBindingMap is intentionally left nil.
+	// This tells naga to emit direct sampler register bindings instead of
+	// sampler heap indirection, which matches our root signature layout.
+	opts.SamplerBufferBindingMap = nil
+
+	// Step 4: Generate HLSL (all entry points)
+	hlslSource, info, err := hlsl.Compile(irModule, opts)
 	if err != nil {
 		return fmt.Errorf("HLSL generation: %w", err)
 	}
 
-	// Step 4: Load d3dcompiler_47.dll
+	// Step 5: Load d3dcompiler_47.dll
 	compiler, err := d3dcompile.Load()
 	if err != nil {
 		return fmt.Errorf("load d3dcompiler: %w", err)
 	}
 
-	// Step 5: Compile each entry point separately
+	// Step 6: Compile each entry point separately
 	for i := range irModule.EntryPoints {
 		ep := &irModule.EntryPoints[i]
 		target := shaderStageToTarget(ep.Stage)

--- a/hal/dx12/pipeline.go
+++ b/hal/dx12/pipeline.go
@@ -551,8 +551,9 @@ func buildInputLayout(buffers []gputypes.VertexBufferLayout) ([]d3d12.D3D12_INPU
 
 	for slotIdx, buffer := range buffers {
 		for _, attr := range buffer.Attributes {
-			// Create semantic name "TEXCOORD" with semantic index = shader location
-			semanticName := []byte("TEXCOORD\x00")
+			// Create semantic name "LOC" with semantic index = shader location.
+			// Must match naga HLSL output which uses LOC{N} for @location(N).
+			semanticName := []byte("LOC\x00")
 			semanticNames = append(semanticNames, semanticName)
 
 			element := d3d12.D3D12_INPUT_ELEMENT_DESC{

--- a/hal/gles/queue.go
+++ b/hal/gles/queue.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/hal"
 	"github.com/gogpu/wgpu/hal/gles/gl"
 	"github.com/gogpu/wgpu/hal/gles/wgl"
@@ -130,9 +131,18 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 	q.glCtx.BindTexture(tex.target, tex.id)
 
 	if tex.target == gl.TEXTURE_2D {
+		// Set alignment to 1 for single-channel formats (R8) whose row stride
+		// may not be a multiple of the default 4-byte GL_UNPACK_ALIGNMENT.
+		if tex.format == gputypes.TextureFormatR8Unorm {
+			q.glCtx.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
+		}
 		q.glCtx.TexImage2D(tex.target, int32(dst.MipLevel), int32(internalFormat),
 			int32(size.Width), int32(size.Height), 0, format, dataType,
 			unsafe.Pointer(&data[0]))
+		// Restore default alignment after upload.
+		if tex.format == gputypes.TextureFormatR8Unorm {
+			q.glCtx.PixelStorei(gl.UNPACK_ALIGNMENT, 4)
+		}
 	}
 
 	q.glCtx.BindTexture(tex.target, 0)

--- a/hal/gles/queue_linux.go
+++ b/hal/gles/queue_linux.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"unsafe"
 
+	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/hal"
 	"github.com/gogpu/wgpu/hal/gles/egl"
 	"github.com/gogpu/wgpu/hal/gles/gl"
@@ -125,14 +126,23 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 		return fmt.Errorf("gles: invalid texture type for WriteTexture")
 	}
 
-	_, format, dataType := textureFormatToGL(tex.format)
+	internalFormat, format, dataType := textureFormatToGL(tex.format)
 
 	q.glCtx.BindTexture(tex.target, tex.id)
 
 	if tex.target == gl.TEXTURE_2D {
-		q.glCtx.TexImage2D(tex.target, int32(dst.MipLevel), int32(tex.target),
+		// Set alignment to 1 for single-channel formats (R8) whose row stride
+		// may not be a multiple of the default 4-byte GL_UNPACK_ALIGNMENT.
+		if tex.format == gputypes.TextureFormatR8Unorm {
+			q.glCtx.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
+		}
+		q.glCtx.TexImage2D(tex.target, int32(dst.MipLevel), int32(internalFormat),
 			int32(size.Width), int32(size.Height), 0, format, dataType,
 			uintptr(unsafe.Pointer(&data[0])))
+		// Restore default alignment after upload.
+		if tex.format == gputypes.TextureFormatR8Unorm {
+			q.glCtx.PixelStorei(gl.UNPACK_ALIGNMENT, 4)
+		}
 	}
 
 	q.glCtx.BindTexture(tex.target, 0)

--- a/hal/gles/shader.go
+++ b/hal/gles/shader.go
@@ -34,6 +34,24 @@ func compileWGSLToGLSL(source hal.ShaderSource, entryPoint string) (string, erro
 		return "", fmt.Errorf("gles: WGSL lower error: %w", err)
 	}
 
+	// Build a BindingMap that maps (group, binding) to flat GL texture unit indices.
+	// The formula group*16 + binding must match SetBindGroupCommand.Execute in command.go,
+	// which uses the same maxBindingsPerGroup=16 constant to compute glBinding.
+	// Without this map, naga emits layout(binding=N) using the raw WGSL binding number,
+	// which does not match the texture units that SetBindGroupCommand activates.
+	const maxBindingsPerGroup = 16
+	bindingMap := make(map[glsl.BindingMapKey]uint8, len(module.GlobalVariables))
+	for _, gv := range module.GlobalVariables {
+		if gv.Binding == nil {
+			continue
+		}
+		flatBinding := gv.Binding.Group*maxBindingsPerGroup + gv.Binding.Binding
+		bindingMap[glsl.BindingMapKey{
+			Group:   gv.Binding.Group,
+			Binding: gv.Binding.Binding,
+		}] = uint8(flatBinding)
+	}
+
 	// Compile IR to GLSL 4.30 core.
 	// Version 4.30 is needed for layout(binding=N) resource binding qualifiers
 	// and compute shader support (local_size_x/y/z).
@@ -41,6 +59,7 @@ func compileWGSLToGLSL(source hal.ShaderSource, entryPoint string) (string, erro
 		LangVersion:        glsl.Version430,
 		EntryPoint:         entryPoint,
 		ForceHighPrecision: true,
+		BindingMap:         bindingMap,
 		// NOTE: Do NOT use WriterFlagAdjustCoordinateSpace here.
 		// Our gg shaders already flip Y in the vertex shader (Vulkan convention).
 		// Adding naga's flip would double-flip, producing upside-down output.


### PR DESCRIPTION
DX12: LOC semantic + BindingMap + direct sampler (naga v0.15.1). GLES: BindingMap + WriteTexture + UNPACK_ALIGNMENT. All 3 backends render text. deps: naga v0.15.1.