### PR TITLE
feat(software): enterprise Present + windowed rendering (v0.24.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,34 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.24.4] - 2026-04-07
+## [0.24.4] - 2026-04-08
 
 ### Added
 
-- **Software backend windowed rendering** — `Present()` now auto-blits CPU
-  framebuffer to Win32 window via GDI `StretchDIBits`. gogpu calls `Present()`
-  identically for all backends — no backend-specific knowledge needed. Headless
-  (hwnd=0) remains no-op. RGBA→BGRA conversion with reusable buffer.
-  Platform files: `blit_windows.go` (GDI), `blit_other.go` (stub Linux/macOS).
+#### Software Backend — Enterprise Windowed Rendering
+
+- **Present() auto-blits framebuffer via GDI** — Same pattern as `vkQueuePresentKHR`
+  (Vulkan), `presentDrawable` (Metal), `swapChain.Present` (DX12). Framebuffer is
+  BGRA after `executeFullscreenBlit` swizzle — passed directly to GDI `StretchDIBits`,
+  zero conversion needed. Headless (hwnd=0) remains no-op. gogpu calls `Present()`
+  identically for all backends — no backend-specific knowledge required.
+
+- **Core routing for software surface** — `ensureHALSurface` auto-swaps HAL surface
+  when device backend differs from initially created one. `halInstanceMap` for
+  backend-to-instance lookup. `FilterBackendsByMask` includes software as fallback
+  for all masks; `RequestAdapter` prefers GPU, software only if no GPU or
+  `ForceFallbackAdapter` set.
+
+- **allbackends registers software** instead of noop — software backend is production
+  fallback, noop is testing-only.
+
+- **GetFramebuffer BGRA→RGBA normalization** — callers always receive RGBA for
+  consistent readback API regardless of surface format.
 
 - **Software triangle example** — `cmd/sw-triangle` renders red triangle on blue
-  background using only CPU rasterizer + GDI blit. ~30 FPS at 800×600. Proves
-  software backend works end-to-end with windowed output.
+  background using CPU rasterizer + GDI blit. ~30 FPS at 800×600.
 
-- **Software backend headless test** — `cmd/sw-test` validates instance, adapter,
-  device, shader compilation, pipeline creation on CPU adapter.
+- **Float32x3 vertex color support** — `hasVertexColors` recognizes RGB (Float32x3)
+  in addition to RGBA. Vertex attributes padded to 4 components (alpha=1.0).
 
-- **Software rasterizer Float32x3 vertex color** — `hasVertexColors` now recognizes
-  RGB (Float32x3) in addition to RGBA (Float32x4). Vertex attributes padded to 4
-  components (alpha=1.0) for interpolated color rendering.
-
-- **Adapter selection logging** — `RequestAdapter` now logs which adapter was
-  selected with name, backend, and device type via slog. Helps diagnose fallback
-  issues — previously no indication which backend was chosen.
-
-- **Software backend test** — `cmd/sw-test` validates software rasterizer:
-  instance, CPU adapter, device, shader compilation, render pipeline creation.
-  Headless (no window needed).
+- **Adapter selection logging** — `RequestAdapter` logs selected adapter name,
+  backend, and device type via slog.
 
 ### Fixed
 
@@ -43,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the closed X11 → SIGSEGV in `eglInitialize` on Linux. `DisplayOwner` now stored in
   `Context` and closed after `eglTerminate` in `Destroy()`. Matches Rust wgpu-hal
   where `DisplayOwner` lives in Instance, `XCloseDisplay` only in `Drop`.
-  Fixes SIGSEGV on Linux GLES (ui#66, gogpu#155). (BUG-GLES-001)
+  (BUG-GLES-001)
 
 ## [0.24.2] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.24.3] - 2026-04-07
+## [0.24.4] - 2026-04-07
 
 ### Added
+
+- **Software backend windowed rendering** — `Present()` now auto-blits CPU
+  framebuffer to Win32 window via GDI `StretchDIBits`. gogpu calls `Present()`
+  identically for all backends — no backend-specific knowledge needed. Headless
+  (hwnd=0) remains no-op. RGBA→BGRA conversion with reusable buffer.
+  Platform files: `blit_windows.go` (GDI), `blit_other.go` (stub Linux/macOS).
+
+- **Software triangle example** — `cmd/sw-triangle` renders red triangle on blue
+  background using only CPU rasterizer + GDI blit. ~30 FPS at 800×600. Proves
+  software backend works end-to-end with windowed output.
+
+- **Software backend headless test** — `cmd/sw-test` validates instance, adapter,
+  device, shader compilation, pipeline creation on CPU adapter.
+
+- **Software rasterizer Float32x3 vertex color** — `hasVertexColors` now recognizes
+  RGB (Float32x3) in addition to RGBA (Float32x4). Vertex attributes padded to 4
+  components (alpha=1.0) for interpolated color rendering.
 
 - **Adapter selection logging** — `RequestAdapter` now logs which adapter was
   selected with name, backend, and device type via slog. Helps diagnose fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.24.3] - 2026-04-07
 
+### Added
+
+- **Adapter selection logging** — `RequestAdapter` now logs which adapter was
+  selected with name, backend, and device type via slog. Helps diagnose fallback
+  issues — previously no indication which backend was chosen.
+
+- **Software backend test** — `cmd/sw-test` validates software rasterizer:
+  instance, CPU adapter, device, shader compilation, render pipeline creation.
+  Headless (no window needed).
+
 ### Fixed
 
 #### GLES

--- a/cmd/sw-test/main.go
+++ b/cmd/sw-test/main.go
@@ -1,0 +1,112 @@
+// Command sw-test validates the software rasterizer backend.
+// Headless — no window needed. Creates instance, adapter, device,
+// compiles a shader, and creates a render pipeline to verify the
+// software backend is functional.
+package main
+
+import (
+	"fmt"
+	"log"
+	"log/slog"
+	"os"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+	"github.com/gogpu/wgpu/hal"
+	_ "github.com/gogpu/wgpu/hal/software"
+)
+
+const wgslShader = `
+@vertex
+fn vs_main(@builtin(vertex_index) idx: u32) -> @builtin(position) vec4<f32> {
+    var pos = array<vec2<f32>, 3>(
+        vec2<f32>( 0.0, -0.5),
+        vec2<f32>( 0.5,  0.5),
+        vec2<f32>(-0.5,  0.5),
+    );
+    return vec4<f32>(pos[idx], 0.0, 1.0);
+}
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+}
+`
+
+func main() {
+	hal.SetLogger(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: %v\n", err)
+		os.Exit(1)
+	}
+	log.Println("sw-test: PASS")
+}
+
+func run() error {
+	log.Println("=== Software Backend Test ===")
+
+	instance, err := wgpu.CreateInstance(nil)
+	if err != nil {
+		return fmt.Errorf("instance: %w", err)
+	}
+	defer instance.Release()
+
+	adapter, err := instance.RequestAdapter(&wgpu.RequestAdapterOptions{
+		ForceFallbackAdapter: true,
+	})
+	if err != nil {
+		return fmt.Errorf("adapter: %w", err)
+	}
+	defer adapter.Release()
+
+	info := adapter.Info()
+	log.Printf("Adapter: %s (type=%v, backend=%v)", info.Name, info.DeviceType, info.Backend)
+
+	if info.DeviceType != gputypes.DeviceTypeCPU {
+		return fmt.Errorf("expected CPU adapter, got %v — is software backend imported?", info.DeviceType)
+	}
+	log.Println("OK: CPU adapter found")
+
+	device, err := adapter.RequestDevice(nil)
+	if err != nil {
+		return fmt.Errorf("device: %w", err)
+	}
+	defer device.Release()
+	log.Println("OK: device created")
+
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "sw-test shader",
+		WGSL:  wgslShader,
+	})
+	if err != nil {
+		return fmt.Errorf("shader: %w", err)
+	}
+	defer shader.Release()
+	log.Println("OK: shader compiled")
+
+	pipeline, err := device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
+		Label: "sw-test pipeline",
+		Vertex: wgpu.VertexState{
+			Module:     shader,
+			EntryPoint: "vs_main",
+		},
+		Fragment: &wgpu.FragmentState{
+			Module:     shader,
+			EntryPoint: "fs_main",
+			Targets: []wgpu.ColorTargetState{{
+				Format: gputypes.TextureFormatRGBA8Unorm,
+			}},
+		},
+		Primitive: gputypes.PrimitiveState{
+			Topology: gputypes.PrimitiveTopologyTriangleList,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("pipeline: %w", err)
+	}
+	defer pipeline.Release()
+	log.Println("OK: render pipeline created")
+
+	return nil
+}

--- a/cmd/sw-triangle/main.go
+++ b/cmd/sw-triangle/main.go
@@ -1,0 +1,298 @@
+//go:build windows
+
+// Command sw-triangle renders a red triangle on a blue background using
+// ONLY the software rasterizer backend. The rendered framebuffer is displayed
+// in a Win32 window via GDI SetDIBitsToDevice — no GPU required.
+package main
+
+import (
+	"fmt"
+	"log"
+	"math"
+	"os"
+	"runtime"
+	"time"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+	"github.com/gogpu/wgpu/hal/software"
+)
+
+func init() {
+	runtime.LockOSThread()
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// surfaceConfig returns the standard surface configuration for the given dimensions.
+func surfaceConfig(w, h uint32) *wgpu.SurfaceConfiguration {
+	return &wgpu.SurfaceConfiguration{
+		Format:      gputypes.TextureFormatRGBA8Unorm,
+		Usage:       gputypes.TextureUsageRenderAttachment,
+		Width:       w,
+		Height:      h,
+		PresentMode: gputypes.PresentModeFifo,
+		AlphaMode:   gputypes.CompositeAlphaModeOpaque,
+	}
+}
+
+// renderFrame renders one frame: clear to blue, draw triangle, present, GDI blit.
+// Returns false if the frame was skipped due to a recoverable error.
+func renderFrame(
+	window *Window,
+	surface *wgpu.Surface,
+	device *wgpu.Device,
+	pipeline *wgpu.RenderPipeline,
+	vertexBuffer *wgpu.Buffer,
+	swSurface *software.Surface,
+) bool {
+	surfaceTex, _, err := surface.GetCurrentTexture()
+	if err != nil {
+		return false
+	}
+	view, err := surfaceTex.CreateView(nil)
+	if err != nil {
+		surface.DiscardTexture()
+		return false
+	}
+	defer view.Release()
+
+	encoder, err := device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{Label: "Frame"})
+	if err != nil {
+		return false
+	}
+	renderPass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
+		ColorAttachments: []wgpu.RenderPassColorAttachment{{
+			View:       view,
+			LoadOp:     gputypes.LoadOpClear,
+			StoreOp:    gputypes.StoreOpStore,
+			ClearValue: gputypes.Color{R: 0, G: 0, B: 0.5, A: 1}, // Blue background
+		}},
+	})
+	if err != nil {
+		return false
+	}
+	renderPass.SetPipeline(pipeline)
+	renderPass.SetVertexBuffer(0, vertexBuffer, 0)
+	renderPass.Draw(3, 1, 0, 0)
+	_ = renderPass.End()
+	commands, _ := encoder.Finish()
+	_, _ = device.Queue().Submit(commands)
+	_ = surface.Present(surfaceTex)
+
+	// Blit the software framebuffer to the Win32 window via GDI.
+	fb := swSurface.GetFramebuffer()
+	cw, ch := window.Size()
+
+	if len(fb) > 0 && cw > 0 && ch > 0 {
+		window.BlitFramebuffer(fb, cw, ch)
+	}
+	return true
+}
+
+//nolint:funlen,gocyclo,cyclop // example code — sequential setup is intentionally verbose
+func run() error {
+	log.Println("=== Software Triangle (GDI Blit) ===")
+
+	window, err := NewWindow("Software Triangle", 800, 600)
+	if err != nil {
+		return fmt.Errorf("window: %w", err)
+	}
+	defer window.Destroy()
+
+	instance, err := wgpu.CreateInstance(nil)
+	if err != nil {
+		return fmt.Errorf("instance: %w", err)
+	}
+	defer instance.Release()
+
+	surface, err := instance.CreateSurface(0, window.Handle())
+	if err != nil {
+		return fmt.Errorf("surface: %w", err)
+	}
+	defer surface.Release()
+
+	adapter, err := instance.RequestAdapter(&wgpu.RequestAdapterOptions{
+		ForceFallbackAdapter: true,
+	})
+	if err != nil {
+		return fmt.Errorf("adapter: %w", err)
+	}
+	defer adapter.Release()
+
+	info := adapter.Info()
+	log.Printf("Adapter: %s (type=%v)", info.Name, info.DeviceType)
+	if info.DeviceType != gputypes.DeviceTypeCPU {
+		return fmt.Errorf("expected CPU adapter, got %v — software backend not loaded?", info.DeviceType)
+	}
+
+	device, err := adapter.RequestDevice(nil)
+	if err != nil {
+		return fmt.Errorf("device: %w", err)
+	}
+	defer device.Release()
+
+	w, h := window.Size()
+	if err = surface.Configure(device, surfaceConfig(safeUint32(w), safeUint32(h))); err != nil {
+		return fmt.Errorf("configure: %w", err)
+	}
+
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "Triangle",
+		WGSL:  triangleShaderWGSL,
+	})
+	if err != nil {
+		return fmt.Errorf("shader: %w", err)
+	}
+	defer shader.Release()
+
+	// Create vertex buffer with explicit positions + colors.
+	// Software backend doesn't interpret shaders — it needs vertex data
+	// in buffers (no @builtin(vertex_index) support in fixed-function rasterizer).
+	vertices := []float32{
+		// x, y, r, g, b
+		0.0, 0.5, 1.0, 0.0, 0.0, // top — red
+		-0.5, -0.5, 1.0, 0.0, 0.0, // bottom-left — red
+		0.5, -0.5, 1.0, 0.0, 0.0, // bottom-right — red
+	}
+	vertexData := float32SliceToBytes(vertices)
+
+	vertexBuffer, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "Vertices",
+		Size:             uint64(len(vertexData)),
+		Usage:            gputypes.BufferUsageVertex | gputypes.BufferUsageCopyDst,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		return fmt.Errorf("vertex buffer: %w", err)
+	}
+	defer vertexBuffer.Release()
+
+	if err = device.Queue().WriteBuffer(vertexBuffer, 0, vertexData); err != nil {
+		return fmt.Errorf("write vertices: %w", err)
+	}
+
+	pipelineLayout, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{Label: "Layout"})
+	if err != nil {
+		return fmt.Errorf("layout: %w", err)
+	}
+	defer pipelineLayout.Release()
+
+	pipeline, err := device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
+		Label:  "Triangle",
+		Layout: pipelineLayout,
+		Vertex: wgpu.VertexState{
+			Module:     shader,
+			EntryPoint: "vs_main",
+			Buffers: []gputypes.VertexBufferLayout{{
+				ArrayStride: 5 * 4, // 5 floats per vertex
+				StepMode:    gputypes.VertexStepModeVertex,
+				Attributes: []gputypes.VertexAttribute{
+					{Format: gputypes.VertexFormatFloat32x2, Offset: 0, ShaderLocation: 0},     // position
+					{Format: gputypes.VertexFormatFloat32x3, Offset: 2 * 4, ShaderLocation: 1}, // color
+				},
+			}},
+		},
+		Fragment: &wgpu.FragmentState{
+			Module: shader, EntryPoint: "fs_main",
+			Targets: []wgpu.ColorTargetState{{
+				Format:    gputypes.TextureFormatRGBA8Unorm,
+				WriteMask: gputypes.ColorWriteMaskAll,
+			}},
+		},
+		Primitive: gputypes.PrimitiveState{
+			Topology: gputypes.PrimitiveTopologyTriangleList,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("pipeline: %w", err)
+	}
+	defer pipeline.Release()
+
+	// Get the software HAL surface for framebuffer access.
+	swSurface, ok := surface.HAL().(*software.Surface)
+	if !ok {
+		return fmt.Errorf("HAL surface is not software.Surface — wrong backend?")
+	}
+
+	log.Println("Render loop started")
+	frameCount := 0
+	startTime := time.Now()
+
+	for window.PollEvents() {
+		// Handle window resize.
+		if window.NeedsResize() {
+			rw, rh := window.Size()
+			if rw > 0 && rh > 0 {
+				if err = surface.Configure(device, surfaceConfig(safeUint32(rw), safeUint32(rh))); err != nil {
+					log.Printf("reconfigure: %v", err)
+					continue
+				}
+			}
+		}
+
+		if !renderFrame(window, surface, device, pipeline, vertexBuffer, swSurface) {
+			continue
+		}
+
+		frameCount++
+		if frameCount%60 == 0 {
+			fps := float64(frameCount) / time.Since(startTime).Seconds()
+			log.Printf("Frame %d (%.1f FPS)", frameCount, fps)
+		}
+	}
+
+	log.Printf("Done. %d frames", frameCount)
+	return nil
+}
+
+// Shader uses explicit vertex attributes (not @builtin(vertex_index)) because
+// the software rasterizer uses fixed-function vertex fetch from bound buffers.
+const triangleShaderWGSL = `
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+    @location(1) color: vec3<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec3<f32>,
+}
+
+@vertex
+fn vs_main(in: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+    out.position = vec4<f32>(in.position, 0.0, 1.0);
+    out.color = in.color;
+    return out;
+}
+
+@fragment
+fn fs_main(@location(0) color: vec3<f32>) -> @location(0) vec4<f32> {
+    return vec4<f32>(color, 1.0);
+}
+`
+
+func float32SliceToBytes(data []float32) []byte {
+	buf := make([]byte, len(data)*4)
+	for i, v := range data {
+		bits := math.Float32bits(v)
+		buf[i*4+0] = byte(bits)       //nolint:gosec // deliberate truncation for little-endian encoding
+		buf[i*4+1] = byte(bits >> 8)  //nolint:gosec // deliberate truncation
+		buf[i*4+2] = byte(bits >> 16) //nolint:gosec // deliberate truncation
+		buf[i*4+3] = byte(bits >> 24)
+	}
+	return buf
+}
+
+func safeUint32(v int32) uint32 {
+	if v < 0 {
+		return 0
+	}
+	return uint32(v)
+}

--- a/cmd/sw-triangle/main.go
+++ b/cmd/sw-triangle/main.go
@@ -15,7 +15,8 @@ import (
 
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu"
-	"github.com/gogpu/wgpu/hal/software"
+
+	_ "github.com/gogpu/wgpu/hal/allbackends" // register all backends
 )
 
 func init() {
@@ -41,15 +42,13 @@ func surfaceConfig(w, h uint32) *wgpu.SurfaceConfiguration {
 	}
 }
 
-// renderFrame renders one frame: clear to blue, draw triangle, present, GDI blit.
+// renderFrame renders one frame: clear to blue, draw triangle, present.
 // Returns false if the frame was skipped due to a recoverable error.
 func renderFrame(
-	window *Window,
 	surface *wgpu.Surface,
 	device *wgpu.Device,
 	pipeline *wgpu.RenderPipeline,
 	vertexBuffer *wgpu.Buffer,
-	swSurface *software.Surface,
 ) bool {
 	surfaceTex, _, err := surface.GetCurrentTexture()
 	if err != nil {
@@ -83,19 +82,16 @@ func renderFrame(
 	_ = renderPass.End()
 	commands, _ := encoder.Finish()
 	_, _ = device.Queue().Submit(commands)
-	_ = surface.Present(surfaceTex)
-
-	// Blit the software framebuffer to the Win32 window via GDI.
-	fb := swSurface.GetFramebuffer()
-	cw, ch := window.Size()
-
-	if len(fb) > 0 && cw > 0 && ch > 0 {
-		window.BlitFramebuffer(fb, cw, ch)
+	// Present() auto-blits framebuffer to window via GDI (hal/software/queue.go).
+	// Same API as GPU backends — no manual framebuffer access needed.
+	if presentErr := surface.Present(surfaceTex); presentErr != nil {
+		log.Printf("Present: %v", presentErr)
+		return false
 	}
 	return true
 }
 
-//nolint:funlen,gocyclo,cyclop // example code — sequential setup is intentionally verbose
+//nolint:funlen // example code — sequential setup is intentionally verbose
 func run() error {
 	log.Println("=== Software Triangle (GDI Blit) ===")
 
@@ -105,7 +101,12 @@ func run() error {
 	}
 	defer window.Destroy()
 
-	instance, err := wgpu.CreateInstance(nil)
+	// Use software-only backend mask. Creating Vulkan/DX12 instances (even without
+	// surfaces) loads GPU drivers that interfere with GDI StretchDIBits on some
+	// systems (Intel Iris Xe). 1 << BackendEmpty filters to software only.
+	instance, err := wgpu.CreateInstance(&wgpu.InstanceDescriptor{
+		Backends: wgpu.Backends(1 << gputypes.BackendEmpty),
+	})
 	if err != nil {
 		return fmt.Errorf("instance: %w", err)
 	}
@@ -214,12 +215,6 @@ func run() error {
 	}
 	defer pipeline.Release()
 
-	// Get the software HAL surface for framebuffer access.
-	swSurface, ok := surface.HAL().(*software.Surface)
-	if !ok {
-		return fmt.Errorf("HAL surface is not software.Surface — wrong backend?")
-	}
-
 	log.Println("Render loop started")
 	frameCount := 0
 	startTime := time.Now()
@@ -236,7 +231,7 @@ func run() error {
 			}
 		}
 
-		if !renderFrame(window, surface, device, pipeline, vertexBuffer, swSurface) {
+		if !renderFrame(surface, device, pipeline, vertexBuffer) {
 			continue
 		}
 

--- a/cmd/sw-triangle/window_windows.go
+++ b/cmd/sw-triangle/window_windows.go
@@ -1,0 +1,399 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"sync/atomic"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	user32   = windows.NewLazySystemDLL("user32.dll")
+	gdi32    = windows.NewLazySystemDLL("gdi32.dll")
+	kernel32 = windows.NewLazySystemDLL("kernel32.dll")
+
+	procRegisterClassExW   = user32.NewProc("RegisterClassExW")
+	procCreateWindowExW    = user32.NewProc("CreateWindowExW")
+	procDefWindowProcW     = user32.NewProc("DefWindowProcW")
+	procDestroyWindow      = user32.NewProc("DestroyWindow")
+	procShowWindow         = user32.NewProc("ShowWindow")
+	procUpdateWindow       = user32.NewProc("UpdateWindow")
+	procPeekMessageW       = user32.NewProc("PeekMessageW")
+	procTranslateMessage   = user32.NewProc("TranslateMessage")
+	procDispatchMessageW   = user32.NewProc("DispatchMessageW")
+	procGetModuleHandleW   = kernel32.NewProc("GetModuleHandleW")
+	procPostQuitMessage    = user32.NewProc("PostQuitMessage")
+	procGetClientRect      = user32.NewProc("GetClientRect")
+	procAdjustWindowRectEx = user32.NewProc("AdjustWindowRectEx")
+	procSetWindowLongPtrW  = user32.NewProc("SetWindowLongPtrW")
+	procLoadCursorW        = user32.NewProc("LoadCursorW")
+	procSetCursor          = user32.NewProc("SetCursor")
+	procGetDC              = user32.NewProc("GetDC")
+	procReleaseDC          = user32.NewProc("ReleaseDC")
+	procStretchDIBits      = gdi32.NewProc("StretchDIBits")
+)
+
+const (
+	csOwnDC = 0x0020
+
+	// Window styles
+	wsOverlappedWindow = 0x00CF0000
+	wsVisible          = 0x10000000
+
+	swShow = 5
+
+	// Window messages
+	wmDestroy       = 0x0002
+	wmSize          = 0x0005
+	wmPaint         = 0x000F
+	wmClose         = 0x0010
+	wmQuit          = 0x0012
+	wmSetCursor     = 0x0020
+	wmEnterSizeMove = 0x0231
+	wmExitSizeMove  = 0x0232
+
+	pmRemove = 0x0001
+
+	// Cursor constants
+	idcArrow = 32512
+
+	// WM_SETCURSOR hit test codes
+	htClient = 1
+
+	// DIB constants
+	dibRGBColors = 0
+	srcCopy      = 0x00CC0020
+	biRGB        = 0
+)
+
+type wndClassExW struct {
+	Size       uint32
+	Style      uint32
+	WndProc    uintptr
+	ClsExtra   int32
+	WndExtra   int32
+	Instance   uintptr
+	Icon       uintptr
+	Cursor     uintptr
+	Background uintptr
+	MenuName   *uint16
+	ClassName  *uint16
+	IconSm     uintptr
+}
+
+type msg struct {
+	Hwnd    uintptr
+	Message uint32
+	WParam  uintptr
+	LParam  uintptr
+	Time    uint32
+	Pt      point
+}
+
+type point struct {
+	X int32
+	Y int32
+}
+
+type rect struct {
+	Left   int32
+	Top    int32
+	Right  int32
+	Bottom int32
+}
+
+// bitmapInfoHeader is the BITMAPINFOHEADER structure for GDI blitting.
+type bitmapInfoHeader struct {
+	Size          uint32
+	Width         int32
+	Height        int32
+	Planes        uint16
+	BitCount      uint16
+	Compression   uint32
+	SizeImage     uint32
+	XPelsPerMeter int32
+	YPelsPerMeter int32
+	ClrUsed       uint32
+	ClrImportant  uint32
+}
+
+// Window represents a platform window with GDI blit support for software rendering.
+type Window struct {
+	hwnd      uintptr
+	hInstance uintptr
+	cursor    uintptr
+	width     int32
+	height    int32
+	running   bool
+
+	// Resize handling
+	inSizeMove  atomic.Bool
+	needsResize atomic.Bool
+	pendingW    atomic.Int32
+	pendingH    atomic.Int32
+
+	animating atomic.Bool
+
+	// GDI blit framebuffer (BGRA format, kept between frames for WM_PAINT)
+	blitBuf    []byte
+	blitWidth  int32
+	blitHeight int32
+}
+
+// Global window pointer for wndProc callback.
+var globalWindow *Window
+
+// NewWindow creates a new window with the given title and size.
+func NewWindow(title string, width, height int32) (*Window, error) {
+	hInstance, _, _ := procGetModuleHandleW.Call(0)
+
+	className, err := windows.UTF16PtrFromString("SwTriangleWindow")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create class name: %w", err)
+	}
+	windowTitle, err := windows.UTF16PtrFromString(title)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create window title: %w", err)
+	}
+
+	cursor, _, _ := procLoadCursorW.Call(0, uintptr(idcArrow))
+
+	wc := wndClassExW{
+		Size:      uint32(unsafe.Sizeof(wndClassExW{})),
+		Style:     csOwnDC,
+		WndProc:   windows.NewCallback(wndProc),
+		Instance:  hInstance,
+		Cursor:    cursor,
+		ClassName: className,
+	}
+
+	ret, _, callErr := procRegisterClassExW.Call(uintptr(unsafe.Pointer(&wc))) //nolint:gosec // G103: Win32 API
+	if ret == 0 {
+		return nil, fmt.Errorf("RegisterClassExW failed: %w", callErr)
+	}
+
+	style := uint32(wsOverlappedWindow)
+
+	var rc rect
+	rc.Right = width
+	rc.Bottom = height
+	procAdjustWindowRectEx.Call( //nolint:errcheck,gosec // G103: Win32 API
+		uintptr(unsafe.Pointer(&rc)), //nolint:gosec // G103: Win32 API
+		uintptr(style),
+		0,
+		0,
+	)
+
+	hwnd, _, callErr := procCreateWindowExW.Call(
+		0,
+		uintptr(unsafe.Pointer(className)),   //nolint:gosec // G103: Win32 API
+		uintptr(unsafe.Pointer(windowTitle)), //nolint:gosec // G103: Win32 API
+		uintptr(style),
+		100, 100,
+		uintptr(rc.Right-rc.Left), //nolint:gosec // G115: window dimensions always positive
+		uintptr(rc.Bottom-rc.Top), //nolint:gosec // G115: window dimensions always positive
+		0, 0, hInstance, 0,
+	)
+	if hwnd == 0 {
+		return nil, fmt.Errorf("CreateWindowExW failed: %w", callErr)
+	}
+
+	w := &Window{
+		hwnd:      hwnd,
+		hInstance: hInstance,
+		cursor:    cursor,
+		width:     width,
+		height:    height,
+		running:   true,
+	}
+	w.animating.Store(true)
+
+	globalWindow = w
+	procSetWindowLongPtrW.Call(hwnd, ^uintptr(20), uintptr(unsafe.Pointer(w))) //nolint:errcheck,gosec
+
+	procShowWindow.Call(hwnd, uintptr(swShow)) //nolint:errcheck,gosec
+	procUpdateWindow.Call(hwnd)                //nolint:errcheck,gosec
+
+	return w, nil
+}
+
+// Destroy destroys the window.
+func (w *Window) Destroy() {
+	if w.hwnd != 0 {
+		_, _, _ = procDestroyWindow.Call(w.hwnd)
+		w.hwnd = 0
+	}
+	if globalWindow == w {
+		globalWindow = nil
+	}
+}
+
+// Handle returns the native window handle (HWND).
+func (w *Window) Handle() uintptr {
+	return w.hwnd
+}
+
+// Size returns the client area size of the window.
+func (w *Window) Size() (width, height int32) {
+	var rc rect
+	procGetClientRect.Call(w.hwnd, uintptr(unsafe.Pointer(&rc))) //nolint:errcheck,gosec // Win32 API
+	return rc.Right - rc.Left, rc.Bottom - rc.Top
+}
+
+// NeedsResize returns true if a resize event occurred and clears the flag.
+func (w *Window) NeedsResize() bool {
+	return w.needsResize.Swap(false)
+}
+
+// PollEvents processes pending window events.
+// Returns false when the window should close.
+func (w *Window) PollEvents() bool {
+	var m msg
+
+	for {
+		ret, _, _ := procPeekMessageW.Call(
+			uintptr(unsafe.Pointer(&m)), //nolint:gosec // G103: Win32 API
+			0, 0, 0,
+			uintptr(pmRemove),
+		)
+		if ret == 0 {
+			break
+		}
+
+		if m.Message == wmQuit {
+			w.running = false
+			return false
+		}
+
+		_, _, _ = procTranslateMessage.Call(uintptr(unsafe.Pointer(&m))) //nolint:gosec // G103: Win32 API
+		_, _, _ = procDispatchMessageW.Call(uintptr(unsafe.Pointer(&m))) //nolint:gosec // G103: Win32 API
+	}
+
+	return w.running
+}
+
+// BlitFramebuffer copies an RGBA framebuffer to the window using GDI SetDIBitsToDevice.
+// The RGBA bytes are converted to BGRA in-place for GDI compatibility.
+func (w *Window) BlitFramebuffer(rgba []byte, width, height int32) {
+	if len(rgba) == 0 || width <= 0 || height <= 0 {
+		return
+	}
+
+	// Convert RGBA -> BGRA for GDI (swap R and B channels).
+	// Keep a reusable buffer to avoid allocation each frame.
+	needed := int(width) * int(height) * 4
+	if len(w.blitBuf) < needed {
+		w.blitBuf = make([]byte, needed)
+	}
+	for i := 0; i < needed; i += 4 {
+		w.blitBuf[i+0] = rgba[i+2] // B
+		w.blitBuf[i+1] = rgba[i+1] // G
+		w.blitBuf[i+2] = rgba[i+0] // R
+		w.blitBuf[i+3] = rgba[i+3] // A
+	}
+	w.blitWidth = width
+	w.blitHeight = height
+
+	w.blitToWindow()
+}
+
+// blitToWindow performs the actual GDI blit of w.blitBuf to the window.
+func (w *Window) blitToWindow() {
+	if len(w.blitBuf) == 0 || w.blitWidth <= 0 || w.blitHeight <= 0 {
+		return
+	}
+
+	hdc, _, _ := procGetDC.Call(w.hwnd)
+	if hdc == 0 {
+		return
+	}
+	defer procReleaseDC.Call(w.hwnd, hdc) //nolint:errcheck
+
+	bmi := bitmapInfoHeader{
+		Size:        uint32(unsafe.Sizeof(bitmapInfoHeader{})),
+		Width:       w.blitWidth,
+		Height:      -w.blitHeight, // negative = top-down DIB
+		Planes:      1,
+		BitCount:    32,
+		Compression: biRGB,
+	}
+
+	ret, _, _ := procStretchDIBits.Call(
+		hdc,
+		0, 0, // dest x, y
+		uintptr(w.blitWidth),
+		uintptr(w.blitHeight),
+		0, 0, // src x, y
+		uintptr(w.blitWidth),
+		uintptr(w.blitHeight),
+		uintptr(unsafe.Pointer(&w.blitBuf[0])), //nolint:gosec // G103: GDI needs raw pointer
+		uintptr(unsafe.Pointer(&bmi)),          //nolint:gosec // G103: GDI needs raw pointer
+		uintptr(dibRGBColors),
+		uintptr(srcCopy),
+	)
+	_ = ret
+}
+
+// wndProc is the window procedure callback.
+func wndProc(hwnd, message, wParam, lParam uintptr) uintptr {
+	w := globalWindow
+	if w == nil || w.hwnd != hwnd {
+		ret, _, _ := procDefWindowProcW.Call(hwnd, message, wParam, lParam)
+		return ret
+	}
+
+	switch message {
+	case wmDestroy, wmClose:
+		_, _, _ = procPostQuitMessage.Call(0)
+		return 0
+
+	case wmPaint:
+		// Re-blit the last rendered frame on WM_PAINT (window exposed/restored).
+		w.blitToWindow()
+		ret, _, _ := procDefWindowProcW.Call(hwnd, message, wParam, lParam)
+		return ret
+
+	case wmEnterSizeMove:
+		w.inSizeMove.Store(true)
+		return 0
+
+	case wmExitSizeMove:
+		w.inSizeMove.Store(false)
+		if w.pendingW.Load() > 0 && w.pendingH.Load() > 0 {
+			w.needsResize.Store(true)
+		}
+		return 0
+
+	case wmSize:
+		width := int32(lParam & 0xFFFF)
+		height := int32((lParam >> 16) & 0xFFFF)
+
+		if width > 0 && height > 0 {
+			w.width = width
+			w.height = height
+			w.pendingW.Store(width)
+			w.pendingH.Store(height)
+
+			if !w.inSizeMove.Load() {
+				w.needsResize.Store(true)
+			}
+		}
+		return 0
+
+	case wmSetCursor:
+		hitTest := lParam & 0xFFFF
+		if hitTest == htClient {
+			_, _, _ = procSetCursor.Call(w.cursor)
+			return 1
+		}
+		ret, _, _ := procDefWindowProcW.Call(hwnd, message, wParam, lParam)
+		return ret
+
+	default:
+		ret, _, _ := procDefWindowProcW.Call(hwnd, message, wParam, lParam)
+		return ret
+	}
+}

--- a/cmd/sw-triangle/window_windows.go
+++ b/cmd/sw-triangle/window_windows.go
@@ -12,7 +12,6 @@ import (
 
 var (
 	user32   = windows.NewLazySystemDLL("user32.dll")
-	gdi32    = windows.NewLazySystemDLL("gdi32.dll")
 	kernel32 = windows.NewLazySystemDLL("kernel32.dll")
 
 	procRegisterClassExW   = user32.NewProc("RegisterClassExW")
@@ -31,9 +30,8 @@ var (
 	procSetWindowLongPtrW  = user32.NewProc("SetWindowLongPtrW")
 	procLoadCursorW        = user32.NewProc("LoadCursorW")
 	procSetCursor          = user32.NewProc("SetCursor")
-	procGetDC              = user32.NewProc("GetDC")
-	procReleaseDC          = user32.NewProc("ReleaseDC")
-	procStretchDIBits      = gdi32.NewProc("StretchDIBits")
+	procBeginPaint         = user32.NewProc("BeginPaint")
+	procEndPaint           = user32.NewProc("EndPaint")
 )
 
 const (
@@ -62,11 +60,6 @@ const (
 
 	// WM_SETCURSOR hit test codes
 	htClient = 1
-
-	// DIB constants
-	dibRGBColors = 0
-	srcCopy      = 0x00CC0020
-	biRGB        = 0
 )
 
 type wndClassExW struct {
@@ -105,22 +98,20 @@ type rect struct {
 	Bottom int32
 }
 
-// bitmapInfoHeader is the BITMAPINFOHEADER structure for GDI blitting.
-type bitmapInfoHeader struct {
-	Size          uint32
-	Width         int32
-	Height        int32
-	Planes        uint16
-	BitCount      uint16
-	Compression   uint32
-	SizeImage     uint32
-	XPelsPerMeter int32
-	YPelsPerMeter int32
-	ClrUsed       uint32
-	ClrImportant  uint32
+// paintStruct is the Windows PAINTSTRUCT.
+type paintStruct struct {
+	HDC         uintptr
+	FErase      int32
+	RcPaintL    int32
+	RcPaintT    int32
+	RcPaintR    int32
+	RcPaintB    int32
+	FRestore    int32
+	FIncUpdate  int32
+	RGBReserved [32]byte
 }
 
-// Window represents a platform window with GDI blit support for software rendering.
+// Window represents a platform window for software rendering.
 type Window struct {
 	hwnd      uintptr
 	hInstance uintptr
@@ -136,11 +127,6 @@ type Window struct {
 	pendingH    atomic.Int32
 
 	animating atomic.Bool
-
-	// GDI blit framebuffer (BGRA format, kept between frames for WM_PAINT)
-	blitBuf    []byte
-	blitWidth  int32
-	blitHeight int32
 }
 
 // Global window pointer for wndProc callback.
@@ -275,68 +261,6 @@ func (w *Window) PollEvents() bool {
 	return w.running
 }
 
-// BlitFramebuffer copies an RGBA framebuffer to the window using GDI SetDIBitsToDevice.
-// The RGBA bytes are converted to BGRA in-place for GDI compatibility.
-func (w *Window) BlitFramebuffer(rgba []byte, width, height int32) {
-	if len(rgba) == 0 || width <= 0 || height <= 0 {
-		return
-	}
-
-	// Convert RGBA -> BGRA for GDI (swap R and B channels).
-	// Keep a reusable buffer to avoid allocation each frame.
-	needed := int(width) * int(height) * 4
-	if len(w.blitBuf) < needed {
-		w.blitBuf = make([]byte, needed)
-	}
-	for i := 0; i < needed; i += 4 {
-		w.blitBuf[i+0] = rgba[i+2] // B
-		w.blitBuf[i+1] = rgba[i+1] // G
-		w.blitBuf[i+2] = rgba[i+0] // R
-		w.blitBuf[i+3] = rgba[i+3] // A
-	}
-	w.blitWidth = width
-	w.blitHeight = height
-
-	w.blitToWindow()
-}
-
-// blitToWindow performs the actual GDI blit of w.blitBuf to the window.
-func (w *Window) blitToWindow() {
-	if len(w.blitBuf) == 0 || w.blitWidth <= 0 || w.blitHeight <= 0 {
-		return
-	}
-
-	hdc, _, _ := procGetDC.Call(w.hwnd)
-	if hdc == 0 {
-		return
-	}
-	defer procReleaseDC.Call(w.hwnd, hdc) //nolint:errcheck
-
-	bmi := bitmapInfoHeader{
-		Size:        uint32(unsafe.Sizeof(bitmapInfoHeader{})),
-		Width:       w.blitWidth,
-		Height:      -w.blitHeight, // negative = top-down DIB
-		Planes:      1,
-		BitCount:    32,
-		Compression: biRGB,
-	}
-
-	ret, _, _ := procStretchDIBits.Call(
-		hdc,
-		0, 0, // dest x, y
-		uintptr(w.blitWidth),
-		uintptr(w.blitHeight),
-		0, 0, // src x, y
-		uintptr(w.blitWidth),
-		uintptr(w.blitHeight),
-		uintptr(unsafe.Pointer(&w.blitBuf[0])), //nolint:gosec // G103: GDI needs raw pointer
-		uintptr(unsafe.Pointer(&bmi)),          //nolint:gosec // G103: GDI needs raw pointer
-		uintptr(dibRGBColors),
-		uintptr(srcCopy),
-	)
-	_ = ret
-}
-
 // wndProc is the window procedure callback.
 func wndProc(hwnd, message, wParam, lParam uintptr) uintptr {
 	w := globalWindow
@@ -351,10 +275,13 @@ func wndProc(hwnd, message, wParam, lParam uintptr) uintptr {
 		return 0
 
 	case wmPaint:
-		// Re-blit the last rendered frame on WM_PAINT (window exposed/restored).
-		w.blitToWindow()
-		ret, _, _ := procDefWindowProcW.Call(hwnd, message, wParam, lParam)
-		return ret
+		// Validate the region to prevent continuous WM_PAINT.
+		// Software backend renders via direct GetDC blit in Present(),
+		// so WM_PAINT just needs to validate without erasing.
+		var ps paintStruct
+		procBeginPaint.Call(hwnd, uintptr(unsafe.Pointer(&ps))) //nolint:errcheck,gosec
+		procEndPaint.Call(hwnd, uintptr(unsafe.Pointer(&ps)))   //nolint:errcheck,gosec
+		return 0
 
 	case wmEnterSizeMove:
 		w.inSizeMove.Store(true)

--- a/core/backend.go
+++ b/core/backend.go
@@ -180,7 +180,9 @@ func FilterBackendsByMask(mask gputypes.Backends) []BackendProvider {
 				result = append(result, p)
 			}
 		case gputypes.BackendEmpty:
-			// Empty/noop backend is always available as fallback
+			// Software/noop backend included as fallback for all masks.
+			// Adapter selection (RequestAdapter) prefers GPU adapters over CPU;
+			// software only wins if ForceFallbackAdapter is set or no GPU available.
 			result = append(result, p)
 		default:
 			// Unknown backend types pass through if Primary is set

--- a/core/backend_test.go
+++ b/core/backend_test.go
@@ -271,7 +271,7 @@ func TestFilterBackendsByMask(t *testing.T) {
 		{
 			name:    "Vulkan only",
 			mask:    gputypes.BackendsVulkan,
-			wantLen: 2, // Vulkan + Empty (always included)
+			wantLen: 2, // Vulkan + Empty (always included as fallback)
 			wantHas: []gputypes.Backend{gputypes.BackendVulkan, gputypes.BackendEmpty},
 			wantNot: []gputypes.Backend{gputypes.BackendMetal, gputypes.BackendDX12},
 		},

--- a/core/instance.go
+++ b/core/instance.go
@@ -29,6 +29,12 @@ type Instance struct {
 	// These are destroyed when the Instance is destroyed.
 	halInstances []hal.Instance
 
+	// halInstanceMap maps backend type to its HAL instance for backend-specific
+	// surface creation. When a device uses a different backend than the initially
+	// selected one (e.g., software adapter with ForceFallbackAdapter), the surface
+	// must be re-created on the correct backend's HAL instance.
+	halInstanceMap map[gputypes.Backend]hal.Instance
+
 	// deferredGLES holds GLES HAL instances whose adapter enumeration is deferred
 	// until a surface is available. OpenGL requires a GL context (obtained from a
 	// surface) to query adapter capabilities. These are enumerated lazily on the
@@ -56,11 +62,12 @@ func NewInstance(desc *gputypes.InstanceDescriptor) *Instance {
 	}
 
 	i := &Instance{
-		backends:     desc.Backends,
-		flags:        desc.Flags,
-		adapters:     []AdapterID{},
-		halInstances: []hal.Instance{},
-		useMock:      false,
+		backends:       desc.Backends,
+		flags:          desc.Flags,
+		adapters:       []AdapterID{},
+		halInstances:   []hal.Instance{},
+		halInstanceMap: make(map[gputypes.Backend]hal.Instance),
+		useMock:        false,
 	}
 
 	// Try to enumerate real adapters via HAL backends
@@ -85,11 +92,12 @@ func NewInstanceWithMock(desc *gputypes.InstanceDescriptor) *Instance {
 	}
 
 	i := &Instance{
-		backends:     desc.Backends,
-		flags:        desc.Flags,
-		adapters:     []AdapterID{},
-		halInstances: []hal.Instance{},
-		useMock:      true,
+		backends:       desc.Backends,
+		flags:          desc.Flags,
+		adapters:       []AdapterID{},
+		halInstances:   []hal.Instance{},
+		halInstanceMap: make(map[gputypes.Backend]hal.Instance),
+		useMock:        true,
 	}
 
 	i.createMockAdapter()
@@ -151,12 +159,14 @@ func (i *Instance) enumerateRealAdapters(desc *gputypes.InstanceDescriptor) bool
 		// a placeholder adapter with nil glCtx that crashes on use.
 		if provider.Variant() == gputypes.BackendGL {
 			i.halInstances = append(i.halInstances, halInstance)
+			i.halInstanceMap[provider.Variant()] = halInstance
 			i.deferredGLES = append(i.deferredGLES, halInstance)
 			continue
 		}
 
 		// Track HAL instance for cleanup
 		i.halInstances = append(i.halInstances, halInstance)
+		i.halInstanceMap[provider.Variant()] = halInstance
 
 		// Enumerate adapters from this backend
 		exposedAdapters := halInstance.EnumerateAdapters(nil)
@@ -476,6 +486,24 @@ func (i *Instance) HALInstance() hal.Instance {
 		return i.halInstances[0]
 	}
 	return nil
+}
+
+// HALInstanceForBackend returns the HAL instance for a specific backend type.
+// Returns nil if no instance exists for the given backend.
+// Used to re-create surfaces when the device's backend differs from the
+// initially selected one (e.g., software adapter via ForceFallbackAdapter).
+func (i *Instance) HALInstanceForBackend(backend gputypes.Backend) hal.Instance {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.halInstanceMap[backend]
+}
+
+// HALInstanceMap returns the backend-to-instance mapping.
+// Used to determine which backend a given HAL instance belongs to.
+func (i *Instance) HALInstanceMap() map[gputypes.Backend]hal.Instance {
+	i.mu.RLock()
+	defer i.mu.RUnlock()
+	return i.halInstanceMap
 }
 
 // Destroy releases all resources associated with this instance.

--- a/core/resource.go
+++ b/core/resource.go
@@ -117,6 +117,14 @@ type Device struct {
 	errorScopeManager *ErrorScopeManager
 }
 
+// Backend returns the backend type of the device's adapter.
+func (d *Device) Backend() gputypes.Backend {
+	if d.adapter != nil {
+		return d.adapter.Backend
+	}
+	return gputypes.BackendEmpty
+}
+
 // NewDevice creates a new Device wrapping a HAL device.
 //
 // This is the constructor for devices with full HAL integration.
@@ -1524,4 +1532,12 @@ func NewSurface(
 // RawSurface returns the underlying HAL surface.
 func (s *Surface) RawSurface() hal.Surface {
 	return s.raw
+}
+
+// SetRawSurface replaces the underlying HAL surface.
+// Used when the surface needs to be re-created on a different backend's HAL
+// instance (e.g., switching from Vulkan surface to software surface during
+// Configure when the device's backend differs from the original surface).
+func (s *Surface) SetRawSurface(raw hal.Surface) {
+	s.raw = raw
 }

--- a/hal/allbackends/register.go
+++ b/hal/allbackends/register.go
@@ -7,6 +7,9 @@ import (
 	// Import all HAL backends for side-effect registration.
 	// Each backend's init() function registers it with hal.RegisterBackend().
 
-	// No-op backend - always available, useful for testing.
-	_ "github.com/gogpu/wgpu/hal/noop"
+	// Software backend - CPU-based renderer, always available as fallback.
+	// Note: noop backend is NOT included here — it's for testing only and
+	// should be imported explicitly when needed. Both noop and software
+	// register as BackendEmpty, so only one can be active at a time.
+	_ "github.com/gogpu/wgpu/hal/software"
 )

--- a/hal/software/api.go
+++ b/hal/software/api.go
@@ -23,9 +23,11 @@ func (API) CreateInstance(_ *hal.InstanceDescriptor) (hal.Instance, error) {
 type Instance struct{}
 
 // CreateSurface creates a software rendering surface.
-// Always succeeds regardless of display/window handles.
-func (i *Instance) CreateSurface(_, _ uintptr) (hal.Surface, error) {
-	return &Surface{}, nil
+// If a valid window handle is provided, Present() will automatically blit
+// the framebuffer to the window via platform-native APIs (GDI on Windows).
+// If window is 0 (headless mode), Present() is a no-op.
+func (i *Instance) CreateSurface(_, window uintptr) (hal.Surface, error) {
+	return &Surface{hwnd: window}, nil
 }
 
 // EnumerateAdapters returns a single default software adapter.

--- a/hal/software/blit_other.go
+++ b/hal/software/blit_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package software
+
+// blitFramebufferToWindow is a no-op on non-Windows platforms.
+// TODO: Implement X11 XPutImage for Linux, CoreGraphics for macOS.
+func blitFramebufferToWindow(_ uintptr, _ []byte, _, _ int32) {}

--- a/hal/software/blit_other.go
+++ b/hal/software/blit_other.go
@@ -3,5 +3,5 @@
 package software
 
 // blitFramebufferToWindow is a no-op on non-Windows platforms.
-// TODO: Implement X11 XPutImage for Linux, CoreGraphics for macOS.
+// TODO: implement XPutImage for Linux X11, CoreGraphics for macOS.
 func blitFramebufferToWindow(_ uintptr, _ []byte, _, _ int32) {}

--- a/hal/software/blit_windows.go
+++ b/hal/software/blit_windows.go
@@ -3,43 +3,40 @@
 package software
 
 import (
+	"syscall"
 	"unsafe"
-
-	"golang.org/x/sys/windows"
 )
 
 var (
-	user32Blit = windows.NewLazySystemDLL("user32.dll")
-	gdi32Blit  = windows.NewLazySystemDLL("gdi32.dll")
+	user32DLL = syscall.MustLoadDLL("user32.dll")
+	gdi32DLL  = syscall.MustLoadDLL("gdi32.dll")
 
-	procGetDC         = user32Blit.NewProc("GetDC")
-	procReleaseDC     = user32Blit.NewProc("ReleaseDC")
-	procStretchDIBits = gdi32Blit.NewProc("StretchDIBits")
+	procGetDC         = user32DLL.MustFindProc("GetDC")
+	procReleaseDC     = user32DLL.MustFindProc("ReleaseDC")
+	procStretchDIBits = gdi32DLL.MustFindProc("StretchDIBits")
 )
 
 const (
+	srccopy      = 0x00CC0020
 	dibRGBColors = 0
-	srcCopy      = 0x00CC0020
-	biRGB        = 0
 )
 
-// bitmapInfoHeader is the Windows BITMAPINFOHEADER structure.
 type bitmapInfoHeader struct {
-	Size          uint32
-	Width         int32
-	Height        int32
-	Planes        uint16
-	BitCount      uint16
-	Compression   uint32
-	SizeImage     uint32
-	XPelsPerMeter int32
-	YPelsPerMeter int32
-	ClrUsed       uint32
-	ClrImportant  uint32
+	biSize          uint32
+	biWidth         int32
+	biHeight        int32
+	biPlanes        uint16
+	biBitCount      uint16
+	biCompression   uint32
+	biSizeImage     uint32
+	biXPelsPerMeter int32
+	biYPelsPerMeter int32
+	biClrUsed       uint32
+	biClrImportant  uint32
 }
 
-// blitFramebufferToWindow blits a BGRA framebuffer to the window using GDI StretchDIBits.
-// The caller must provide pre-converted BGRA data (not RGBA).
+// blitFramebufferToWindow blits BGRA framebuffer to window via GDI StretchDIBits.
+// GDI BI_RGB 32-bit expects BGRA byte order — no conversion needed.
 func blitFramebufferToWindow(hwnd uintptr, bgra []byte, width, height int32) {
 	if len(bgra) == 0 || width <= 0 || height <= 0 {
 		return
@@ -52,25 +49,20 @@ func blitFramebufferToWindow(hwnd uintptr, bgra []byte, width, height int32) {
 	defer procReleaseDC.Call(hwnd, hdc) //nolint:errcheck
 
 	bmi := bitmapInfoHeader{
-		Size:        uint32(unsafe.Sizeof(bitmapInfoHeader{})),
-		Width:       width,
-		Height:      -height, // negative = top-down DIB
-		Planes:      1,
-		BitCount:    32,
-		Compression: biRGB,
+		biSize:     uint32(unsafe.Sizeof(bitmapInfoHeader{})),
+		biWidth:    width,
+		biHeight:   -height, // negative = top-down DIB
+		biPlanes:   1,
+		biBitCount: 32,
 	}
 
 	procStretchDIBits.Call( //nolint:errcheck
 		hdc,
-		0, 0, // dest x, y
-		uintptr(width),
-		uintptr(height),
-		0, 0, // src x, y
-		uintptr(width),
-		uintptr(height),
+		0, 0, uintptr(width), uintptr(height),
+		0, 0, uintptr(width), uintptr(height),
 		uintptr(unsafe.Pointer(&bgra[0])),
 		uintptr(unsafe.Pointer(&bmi)),
 		uintptr(dibRGBColors),
-		uintptr(srcCopy),
+		uintptr(srccopy),
 	)
 }

--- a/hal/software/blit_windows.go
+++ b/hal/software/blit_windows.go
@@ -1,0 +1,76 @@
+//go:build windows
+
+package software
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	user32Blit = windows.NewLazySystemDLL("user32.dll")
+	gdi32Blit  = windows.NewLazySystemDLL("gdi32.dll")
+
+	procGetDC         = user32Blit.NewProc("GetDC")
+	procReleaseDC     = user32Blit.NewProc("ReleaseDC")
+	procStretchDIBits = gdi32Blit.NewProc("StretchDIBits")
+)
+
+const (
+	dibRGBColors = 0
+	srcCopy      = 0x00CC0020
+	biRGB        = 0
+)
+
+// bitmapInfoHeader is the Windows BITMAPINFOHEADER structure.
+type bitmapInfoHeader struct {
+	Size          uint32
+	Width         int32
+	Height        int32
+	Planes        uint16
+	BitCount      uint16
+	Compression   uint32
+	SizeImage     uint32
+	XPelsPerMeter int32
+	YPelsPerMeter int32
+	ClrUsed       uint32
+	ClrImportant  uint32
+}
+
+// blitFramebufferToWindow blits a BGRA framebuffer to the window using GDI StretchDIBits.
+// The caller must provide pre-converted BGRA data (not RGBA).
+func blitFramebufferToWindow(hwnd uintptr, bgra []byte, width, height int32) {
+	if len(bgra) == 0 || width <= 0 || height <= 0 {
+		return
+	}
+
+	hdc, _, _ := procGetDC.Call(hwnd)
+	if hdc == 0 {
+		return
+	}
+	defer procReleaseDC.Call(hwnd, hdc) //nolint:errcheck
+
+	bmi := bitmapInfoHeader{
+		Size:        uint32(unsafe.Sizeof(bitmapInfoHeader{})),
+		Width:       width,
+		Height:      -height, // negative = top-down DIB
+		Planes:      1,
+		BitCount:    32,
+		Compression: biRGB,
+	}
+
+	procStretchDIBits.Call( //nolint:errcheck
+		hdc,
+		0, 0, // dest x, y
+		uintptr(width),
+		uintptr(height),
+		0, 0, // src x, y
+		uintptr(width),
+		uintptr(height),
+		uintptr(unsafe.Pointer(&bgra[0])),
+		uintptr(unsafe.Pointer(&bmi)),
+		uintptr(dibRGBColors),
+		uintptr(srcCopy),
+	)
+}

--- a/hal/software/draw.go
+++ b/hal/software/draw.go
@@ -257,6 +257,12 @@ func (r *RenderPassEncoder) fetchTriangles(
 			sv.Attributes = append(sv.Attributes, vals...)
 		}
 
+		// Ensure at least 4 attribute components (RGBA) for interpolated color.
+		// RGB vertex colors (Float32x3) need alpha=1.0 padding.
+		for len(sv.Attributes) < 4 {
+			sv.Attributes = append(sv.Attributes, 1.0)
+		}
+
 		vertices = append(vertices, sv)
 	}
 
@@ -349,9 +355,9 @@ func (r *RenderPassEncoder) hasVertexColors(layouts []gputypes.VertexBufferLayou
 		if attr.ShaderLocation == 0 {
 			continue
 		}
-		// 4-component attribute is likely RGBA color.
+		// 3 or 4-component attribute is likely RGB/RGBA color.
 		switch attr.Format {
-		case gputypes.VertexFormatFloat32x4, gputypes.VertexFormatUnorm8x4:
+		case gputypes.VertexFormatFloat32x3, gputypes.VertexFormatFloat32x4, gputypes.VertexFormatUnorm8x4:
 			return true
 		}
 	}

--- a/hal/software/queue.go
+++ b/hal/software/queue.go
@@ -54,11 +54,40 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 	return nil
 }
 
-// Present simulates surface presentation.
-// In software backend, this is essentially a no-op since framebuffer is already updated.
-func (q *Queue) Present(_ hal.Surface, _ hal.SurfaceTexture) error {
-	// In software backend, the framebuffer is already updated by render operations
-	// Present just marks the frame as complete
+// Present presents the rendered framebuffer to the window.
+// If the surface has a valid window handle, it blits the framebuffer via
+// platform-native APIs (GDI StretchDIBits on Windows).
+// In headless mode (hwnd == 0), this is a no-op.
+func (q *Queue) Present(surface hal.Surface, _ hal.SurfaceTexture) error {
+	s, ok := surface.(*Surface)
+	if !ok || s.hwnd == 0 {
+		return nil // headless mode — no window to blit to
+	}
+
+	s.mu.RLock()
+	fb := s.framebuffer
+	width := int32(s.width)
+	height := int32(s.height)
+	s.mu.RUnlock()
+
+	if len(fb) == 0 || width <= 0 || height <= 0 {
+		return nil
+	}
+
+	// Convert RGBA -> BGRA and blit to window.
+	// Reuse blitBuf on Surface to avoid per-frame allocation.
+	needed := int(width) * int(height) * 4
+	if len(s.blitBuf) < needed {
+		s.blitBuf = make([]byte, needed)
+	}
+	for i := 0; i < needed; i += 4 {
+		s.blitBuf[i+0] = fb[i+2] // B
+		s.blitBuf[i+1] = fb[i+1] // G
+		s.blitBuf[i+2] = fb[i+0] // R
+		s.blitBuf[i+3] = fb[i+3] // A
+	}
+
+	blitFramebufferToWindow(s.hwnd, s.blitBuf[:needed], width, height)
 	return nil
 }
 

--- a/hal/software/queue.go
+++ b/hal/software/queue.go
@@ -54,40 +54,29 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 	return nil
 }
 
-// Present presents the rendered framebuffer to the window.
-// If the surface has a valid window handle, it blits the framebuffer via
-// platform-native APIs (GDI StretchDIBits on Windows).
+// Present blits the software-rendered framebuffer to the window.
+// The framebuffer is in BGRA byte order (matching the surface format) after
+// executeFullscreenBlit's RGBA→BGRA swizzle. GDI BI_RGB 32-bit expects BGRA,
+// so no additional conversion is needed — the framebuffer is passed directly.
 // In headless mode (hwnd == 0), this is a no-op.
 func (q *Queue) Present(surface hal.Surface, _ hal.SurfaceTexture) error {
 	s, ok := surface.(*Surface)
 	if !ok || s.hwnd == 0 {
-		return nil // headless mode — no window to blit to
+		return nil
 	}
 
 	s.mu.RLock()
 	fb := s.framebuffer
-	width := int32(s.width)
-	height := int32(s.height)
+	w := s.width
+	h := s.height
 	s.mu.RUnlock()
 
-	if len(fb) == 0 || width <= 0 || height <= 0 {
+	if len(fb) == 0 || w == 0 || h == 0 {
 		return nil
 	}
 
-	// Convert RGBA -> BGRA and blit to window.
-	// Reuse blitBuf on Surface to avoid per-frame allocation.
-	needed := int(width) * int(height) * 4
-	if len(s.blitBuf) < needed {
-		s.blitBuf = make([]byte, needed)
-	}
-	for i := 0; i < needed; i += 4 {
-		s.blitBuf[i+0] = fb[i+2] // B
-		s.blitBuf[i+1] = fb[i+1] // G
-		s.blitBuf[i+2] = fb[i+0] // R
-		s.blitBuf[i+3] = fb[i+3] // A
-	}
-
-	blitFramebufferToWindow(s.hwnd, s.blitBuf[:needed], width, height)
+	// Framebuffer is BGRA — pass directly to GDI, no swap needed.
+	blitFramebufferToWindow(s.hwnd, fb, int32(w), int32(h))
 	return nil
 }
 

--- a/hal/software/resource.go
+++ b/hal/software/resource.go
@@ -135,6 +135,8 @@ type Surface struct {
 	mu          sync.RWMutex // Protects framebuffer access
 	presentMode hal.PresentMode
 	alphaMode   hal.CompositeAlphaMode
+	hwnd        uintptr // window handle for platform blit (0 = headless)
+	blitBuf     []byte  // reusable BGRA buffer to avoid per-frame allocation
 }
 
 // Configure configures the surface with the given settings.

--- a/hal/software/resource.go
+++ b/hal/software/resource.go
@@ -99,7 +99,8 @@ func (t *Texture) Clear(color gputypes.Color) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	// Simple RGBA8 clear (4 bytes per pixel)
+	// Software backend always stores RGBA byte order internally.
+	// Format conversion (RGBA→BGRA for GDI) is done at blit time.
 	r := uint8(color.R * 255)
 	g := uint8(color.G * 255)
 	b := uint8(color.B * 255)
@@ -136,7 +137,6 @@ type Surface struct {
 	presentMode hal.PresentMode
 	alphaMode   hal.CompositeAlphaMode
 	hwnd        uintptr // window handle for platform blit (0 = headless)
-	blitBuf     []byte  // reusable BGRA buffer to avoid per-frame allocation
 }
 
 // Configure configures the surface with the given settings.
@@ -201,8 +201,10 @@ func (s *Surface) AcquireTexture(_ hal.Fence) (*hal.AcquiredSurfaceTexture, erro
 // DiscardTexture is a no-op (framebuffer stays allocated).
 func (s *Surface) DiscardTexture(_ hal.SurfaceTexture) {}
 
-// GetFramebuffer returns a copy of the current framebuffer data (thread-safe).
-// This is the key method for reading rendered results in software backend.
+// GetFramebuffer returns a copy of the current framebuffer data in RGBA byte
+// order (thread-safe). If the surface format is BGRA, R and B channels are
+// swapped so callers always receive consistent RGBA data. This allows
+// platform blit code to do a single RGBA→BGRA conversion for GDI/X11.
 func (s *Surface) GetFramebuffer() []byte {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -213,6 +215,16 @@ func (s *Surface) GetFramebuffer() []byte {
 
 	result := make([]byte, len(s.framebuffer))
 	copy(result, s.framebuffer)
+
+	// If surface format is BGRA, the framebuffer stores BGRA bytes.
+	// Swap R↔B so the returned data is always RGBA.
+	if s.format == gputypes.TextureFormatBGRA8Unorm ||
+		s.format == gputypes.TextureFormatBGRA8UnormSrgb {
+		for i := 0; i < len(result)-3; i += 4 {
+			result[i+0], result[i+2] = result[i+2], result[i+0]
+		}
+	}
+
 	return result
 }
 

--- a/instance.go
+++ b/instance.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/core"
+	"github.com/gogpu/wgpu/hal"
 )
 
 // InstanceDescriptor configures instance creation.
@@ -87,6 +88,12 @@ func (i *Instance) RequestAdapter(opts *RequestAdapterOptions) (*Adapter, error)
 	if err != nil {
 		return nil, fmt.Errorf("wgpu: failed to get adapter limits: %w", err)
 	}
+
+	hal.Logger().Info("wgpu: adapter selected",
+		"name", info.Name,
+		"backend", info.Backend,
+		"type", info.DeviceType,
+	)
 
 	hub := core.GetGlobal().Hub()
 	coreAdapter, err := hub.GetAdapter(adapterID)

--- a/surface.go
+++ b/surface.go
@@ -3,6 +3,7 @@ package wgpu
 import (
 	"fmt"
 
+	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/core"
 	"github.com/gogpu/wgpu/hal"
 )
@@ -16,6 +17,15 @@ type Surface struct {
 	instance *Instance
 	device   *Device
 	released bool
+
+	// displayHandle and windowHandle are stored for deferred HAL surface
+	// re-creation when the device's backend differs from the initially
+	// selected one (e.g., software adapter via ForceFallbackAdapter when
+	// the initial surface was created on Vulkan/DX12).
+	displayHandle  uintptr
+	windowHandle   uintptr
+	currentBackend gputypes.Backend // backend type of the current HAL surface
+	surfaceCreated bool             // true after first ensureHALSurface
 }
 
 // CreateSurface creates a rendering surface from platform-specific handles.
@@ -39,10 +49,23 @@ func (i *Instance) CreateSurface(displayHandle, windowHandle uintptr) (*Surface,
 		return nil, fmt.Errorf("wgpu: failed to create surface: %w", err)
 	}
 
+	// Determine the backend of the initial HAL instance.
+	var initialBackend gputypes.Backend
+	for b, inst := range i.core.HALInstanceMap() {
+		if inst == halInstance {
+			initialBackend = b
+			break
+		}
+	}
+
 	coreSurface := core.NewSurface(halSurface, "")
 	return &Surface{
-		core:     coreSurface,
-		instance: i,
+		core:           coreSurface,
+		instance:       i,
+		displayHandle:  displayHandle,
+		windowHandle:   windowHandle,
+		currentBackend: initialBackend,
+		surfaceCreated: true,
 	}, nil
 }
 
@@ -66,6 +89,14 @@ func (s *Surface) Configure(device *Device, config *SurfaceConfiguration) error 
 		Usage:       config.Usage,
 		PresentMode: config.PresentMode,
 		AlphaMode:   config.AlphaMode,
+	}
+
+	// Create or re-create the HAL surface on the correct backend's HAL instance.
+	// Surface creation is deferred from CreateSurface() to here because we need
+	// to know the device's backend. Creating a Vulkan surface then destroying it
+	// (when device is software) corrupts GDI state on some drivers.
+	if err := s.ensureHALSurface(device.core.Backend()); err != nil {
+		return err
 	}
 
 	s.device = device
@@ -144,6 +175,28 @@ func (s *Surface) DiscardTexture() {
 		return
 	}
 	s.core.DiscardTexture()
+}
+
+// ensureHALSurface creates or re-creates the HAL surface for the given backend.
+func (s *Surface) ensureHALSurface(backend gputypes.Backend) error {
+	if s.surfaceCreated && s.currentBackend == backend {
+		return nil
+	}
+	targetInstance := s.instance.core.HALInstanceForBackend(backend)
+	if targetInstance == nil {
+		return fmt.Errorf("wgpu: no HAL instance for backend %v", backend)
+	}
+	if s.core.RawSurface() != nil {
+		s.core.RawSurface().Destroy()
+	}
+	halSurface, err := targetInstance.CreateSurface(s.displayHandle, s.windowHandle)
+	if err != nil {
+		return fmt.Errorf("wgpu: failed to create surface for backend %v: %w", backend, err)
+	}
+	s.core.SetRawSurface(halSurface)
+	s.currentBackend = backend
+	s.surfaceCreated = true
+	return nil
 }
 
 // HAL returns the underlying HAL surface for backward compatibility.


### PR DESCRIPTION
## Summary

- **Software Present()** auto-blits BGRA framebuffer via GDI StretchDIBits. Same pattern as Vulkan/Metal/DX12 — gogpu calls Present() identically for all backends.
- **Core routing**: ensureHALSurface auto-swaps surface when device backend differs. halInstanceMap for lookup.
- **allbackends**: software instead of noop (production fallback).
- **GetFramebuffer** BGRA→RGBA normalization for consistent readback API.
- **Adapter logging**: name, backend, device type via slog.
- **sw-triangle example**: CPU rasterizer + GDI blit demo.
- **GLES fix**: X11 display use-after-close (BUG-GLES-001).

## Test plan

- [x] DX12: gg circles — pass
- [x] Vulkan: gg circles — pass
- [x] GLES: gg circles — pass
- [x] Software: gg circles — correct colors, ~64 FPS, no flicker
- [x] Lint: 0 issues
- [x] Build: all platforms