### PR TITLE
feat(metal): set cull mode and front face winding

### DIFF
--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -658,7 +658,13 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 	if pl, ok := desc.Layout.(*PipelineLayout); ok {
 		pipeLayout = pl
 	}
-	return &RenderPipeline{raw: pipelineState, device: d, layout: pipeLayout}, nil
+	return &RenderPipeline{
+		raw:       pipelineState,
+		device:    d,
+		layout:    pipeLayout,
+		cullMode:  cullModeToMTL(desc.Primitive.CullMode),
+		frontFace: frontFaceToMTL(desc.Primitive.FrontFace),
+	}, nil
 }
 
 // buildVertexDescriptor creates an MTLVertexDescriptor from WebGPU vertex buffer layouts.

--- a/hal/metal/encoder.go
+++ b/hal/metal/encoder.go
@@ -418,6 +418,8 @@ func (e *RenderPassEncoder) SetPipeline(pipeline hal.RenderPipeline) {
 	e.pipeline = p
 	e.currentLayout = p.layout // store for SetBindGroup slot offset lookup
 	_ = MsgSend(e.raw, Sel("setRenderPipelineState:"), uintptr(p.raw))
+	_ = MsgSend(e.raw, Sel("setCullMode:"), uintptr(p.cullMode))
+	_ = MsgSend(e.raw, Sel("setFrontFacingWinding:"), uintptr(p.frontFace))
 }
 
 // bindSlotAssignment holds the computed per-type Metal slot index for a bind group entry.

--- a/hal/metal/resource.go
+++ b/hal/metal/resource.go
@@ -188,9 +188,11 @@ func (l *PipelineLayout) Destroy() {
 
 // RenderPipeline implements hal.RenderPipeline for Metal.
 type RenderPipeline struct {
-	raw    ID // id<MTLRenderPipelineState>
-	device *Device
-	layout *PipelineLayout // for SetBindGroup slot offset lookup
+	raw       ID // id<MTLRenderPipelineState>
+	device    *Device
+	layout    *PipelineLayout // for SetBindGroup slot offset lookup
+	cullMode  MTLCullMode
+	frontFace MTLWinding
 }
 
 // Destroy releases the render pipeline.


### PR DESCRIPTION
For Metal, cull mode and front face winding are set on the render pass rather than the render pipeline. Store the raw values when creating RenderPipeline and set the state as part of SetPipeline.