### PR TITLE
feat(metal): support depth textures in render pass

### DIFF
--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -624,6 +624,24 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 		}
 	}
 
+	var depthStencilState ID
+	var depthBias, depthSlopeScale, depthClamp float32
+	if desc.DepthStencil != nil {
+		// Set depth attachment format
+		_ = MsgSend(pipelineDesc, Sel("setDepthAttachmentPixelFormat:"), uintptr(d.adapter.mapTextureFormat(desc.DepthStencil.Format)))
+
+		// Create depth stencil state
+		depthStencilDesc := MsgSend(ID(GetClass("MTLDepthStencilDescriptor")), Sel("new"))
+		_ = MsgSend(depthStencilDesc, Sel("setDepthCompareFunction:"), uintptr(compareFunctionToMTL(desc.DepthStencil.DepthCompare)))
+		msgSendVoid(depthStencilDesc, Sel("setDepthWriteEnabled:"), argBool(desc.DepthStencil.DepthWriteEnabled))
+		depthStencilState = MsgSend(d.raw, Sel("newDepthStencilStateWithDescriptor:"), uintptr(depthStencilDesc))
+
+		// Record bias values to set in render pass
+		depthBias = float32(desc.DepthStencil.DepthBias)
+		depthSlopeScale = desc.DepthStencil.DepthBiasSlopeScale
+		depthClamp = desc.DepthStencil.DepthBiasClamp
+	}
+
 	// Set sample count
 	sampleCount := desc.Multisample.Count
 	if sampleCount == 0 {
@@ -664,6 +682,11 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 		layout:    pipeLayout,
 		cullMode:  cullModeToMTL(desc.Primitive.CullMode),
 		frontFace: frontFaceToMTL(desc.Primitive.FrontFace),
+
+		depthStencil:    depthStencilState,
+		depthBias:       depthBias,
+		depthSlopeScale: depthSlopeScale,
+		depthClamp:      depthClamp,
 	}, nil
 }
 

--- a/hal/metal/encoder.go
+++ b/hal/metal/encoder.go
@@ -420,6 +420,10 @@ func (e *RenderPassEncoder) SetPipeline(pipeline hal.RenderPipeline) {
 	_ = MsgSend(e.raw, Sel("setRenderPipelineState:"), uintptr(p.raw))
 	_ = MsgSend(e.raw, Sel("setCullMode:"), uintptr(p.cullMode))
 	_ = MsgSend(e.raw, Sel("setFrontFacingWinding:"), uintptr(p.frontFace))
+	if p.depthStencil != 0 {
+		_ = MsgSend(e.raw, Sel("setDepthStencilState:"), uintptr(p.depthStencil))
+		_ = MsgSend(e.raw, Sel("setDepthBias:slopeScale:clamp:"), uintptr(p.depthBias), uintptr(p.depthSlopeScale), uintptr(p.depthClamp))
+	}
 }
 
 // bindSlotAssignment holds the computed per-type Metal slot index for a bind group entry.

--- a/hal/metal/resource.go
+++ b/hal/metal/resource.go
@@ -193,6 +193,11 @@ type RenderPipeline struct {
 	layout    *PipelineLayout // for SetBindGroup slot offset lookup
 	cullMode  MTLCullMode
 	frontFace MTLWinding
+
+	depthStencil    ID // id<MTLDepthStencilState>
+	depthBias       float32
+	depthSlopeScale float32
+	depthClamp      float32
 }
 
 // Destroy releases the render pipeline.


### PR DESCRIPTION
In `hal/metal/encoder.go`, `BeginRenderPass` correctly handles depth attachments. `MTLRenderCommandEncoder` does not get depth stencil state from the render pipeline - instead it is set on the encoder directly via `setDepthStencilState(_:)` and `setDepthBias(_:slopeScale:clamp:)`.

To enable this, `MTLDepthStencilState` and bias values are stored on `RenderPipeline` when created and set as part of `SetPipeline`.

I have verified basic depth texture use locally but I'm not familiar enough with the depth bias values to know how to verify their behaviour. Stencil support is not included here for the same reason.