### PR TITLE
chore(deps): naga v0.17.1 + Metal depth textures (v0.24.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.6] - 2026-04-08
+
+### Added
+
+- **Metal: depth texture support in render pass** — `DepthStencil` descriptor now applied on Metal:
+  depth attachment pixel format, `MTLDepthStencilState` with compare function and write enable,
+  depth bias parameters. Set on render encoder via `setDepthStencilState:` / `setDepthBias:slopeScale:clamp:`.
+  (PR #136 by @jdbann)
+
+### Changed
+
+- **naga** v0.17.0 → **v0.17.1** — SPIR-V Workgroup ArrayStride fix (text invisible on Adreno Vulkan)
+
 ## [0.24.5] - 2026-04-08
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.5.0
 	github.com/gogpu/gputypes v0.4.0
-	github.com/gogpu/naga v0.17.0
+	github.com/gogpu/naga v0.17.1
 	golang.org/x/sys v0.42.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.4.0 h1:nPFn77na71K4gkyObbXgpYywy9lIKz/U1x/2+4EAZ3Y=
 github.com/gogpu/gputypes v0.4.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.17.0 h1:lr3oQbcxNzu7dEv34+VXKFEVth4RzSkx+KF2pvJHtVM=
-github.com/gogpu/naga v0.17.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.17.1 h1:Y2QaFbYoGqTdRz0vRec67xGn1+dcQOwTSYHIdtQIsXw=
+github.com/gogpu/naga v0.17.1/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## Summary

- **naga** v0.17.0 → v0.17.1 — SPIR-V Workgroup ArrayStride fix (text invisible on Adreno Vulkan, gogpu/wgpu#134)
- **Metal depth textures** — PR #136 by @jdbann (already merged)

## Test plan

- [x] Build + tests pass locally
- [x] naga v0.17.1 spirv-val: 164/164 pass
- [ ] @SideFx confirms text on Adreno Vulkan (post-release)