### PR TITLE
v0.25.1: Linux X11 software backend presentation (BUG-SW-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.1] - 2026-04-21
+
+### Added
+
+- **Software backend: Linux X11 windowed presentation** — `blitFramebufferToWindow` via
+  `XPutImage` (Skia enterprise pattern). Lazy-loads libX11.so via goffi on first blit.
+  Constructs XImage on stack pointing to BGRA framebuffer — no pixel format conversion
+  needed (BGRA = X11 ZPixmap LSBFirst on little-endian). Graceful fallback: if libX11 is
+  unavailable (headless CI), blit silently no-ops.
+
+### Changed
+
+- **Software Surface: store display handle** — `CreateSurface(display, window)` now stores
+  both handles. Required for X11 `XPutImage` which needs Display* in addition to Window ID.
+
 ## [0.25.0] - 2026-04-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -327,10 +327,10 @@ import _ "github.com/gogpu/wgpu/hal/software"
 - 6-plane frustum clipping (Sutherland-Hodgman)
 - 8x8 tile-based parallel rendering
 
-**Windows Presentation:**
-- DWM-safe `CreateDIBSection` + `BitBlt` (SDL3/Qt6 pattern)
-- Zero-copy: render pipeline writes directly into GDI bitmap pixels
-- Correct display during and after window resize
+**Windowed Presentation:**
+- **Windows:** DWM-safe `CreateDIBSection` + `BitBlt` (SDL3/Qt6 pattern), zero-copy into GDI bitmap
+- **Linux X11:** `XPutImage` via goffi (Skia pattern), BGRA = X11 ZPixmap native format
+- **macOS:** Planned (CGImage + CALayer)
 
 ---
 

--- a/hal/software/api.go
+++ b/hal/software/api.go
@@ -24,10 +24,14 @@ type Instance struct{}
 
 // CreateSurface creates a software rendering surface.
 // If a valid window handle is provided, Present() will automatically blit
-// the framebuffer to the window via platform-native APIs (GDI on Windows).
+// the framebuffer to the window via platform-native APIs (GDI on Windows,
+// XPutImage on Linux X11).
 // If window is 0 (headless mode), Present() is a no-op.
-func (i *Instance) CreateSurface(_, window uintptr) (hal.Surface, error) {
-	return &Surface{hwnd: window}, nil
+//
+// displayHandle is platform-specific: X11 Display* on Linux, 0 elsewhere.
+// windowHandle is the native window: HWND on Windows, X11 Window on Linux.
+func (i *Instance) CreateSurface(displayHandle, window uintptr) (hal.Surface, error) {
+	return &Surface{displayHandle: displayHandle, hwnd: window}, nil
 }
 
 // EnumerateAdapters returns a single default software adapter.

--- a/hal/software/blit_linux.go
+++ b/hal/software/blit_linux.go
@@ -1,0 +1,315 @@
+//go:build linux
+
+package software
+
+import (
+	"log/slog"
+	"sync"
+	"unsafe"
+
+	"github.com/go-webgpu/goffi/ffi"
+	"github.com/go-webgpu/goffi/types"
+)
+
+// X11 constants (from X.h / Xlib.h).
+const (
+	zPixmap  = 2 // ZPixmap format for XImage
+	lsbFirst = 0 // LSBFirst byte order (little-endian)
+)
+
+// ximage matches the C XImage struct layout on amd64 Linux (LP64).
+//
+// Reference: X11/Xlib.h _XImage struct.
+// Layout verified against Skia RasterWindowContext_unix.cpp and SDL3
+// SDL_x11framebuffer.c — both construct XImage on stack with these fields.
+//
+// The struct ends with a funcs sub-struct of 6 function pointers (48 bytes
+// on amd64) that XInitImage fills in. We include them as opaque padding so
+// XInitImage has room to write without corrupting adjacent memory.
+type ximage struct {
+	width          int32   // 0
+	height         int32   // 4
+	xoffset        int32   // 8
+	format         int32   // 12
+	data           uintptr // 16 (char*)
+	byteOrder      int32   // 24
+	bitmapUnit     int32   // 28
+	bitmapBitOrder int32   // 32
+	bitmapPad      int32   // 36
+	depth          int32   // 40
+	bytesPerLine   int32   // 44
+	bitsPerPixel   int32   // 48
+	_pad0          int32   // 52 (padding to align unsigned long)
+	redMask        uint64  // 56 (unsigned long on LP64)
+	greenMask      uint64  // 64
+	blueMask       uint64  // 72
+	obdata         uintptr // 80 (XPointer = char*)
+	// funcs: 6 function pointers filled by XInitImage
+	funcCreateImage  uintptr // 88
+	funcDestroyImage uintptr // 96
+	funcGetPixel     uintptr // 104
+	funcPutPixel     uintptr // 112
+	funcSubImage     uintptr // 120
+	funcAddPixel     uintptr // 128
+	// Total: 136 bytes
+}
+
+// x11State holds lazily-loaded libX11 symbols and call interfaces.
+// Initialized once on first blit; subsequent blits reuse the state.
+var (
+	x11Once  sync.Once
+	x11Ready bool // true if libX11 loaded successfully
+
+	x11Lib unsafe.Pointer
+
+	symXCreateGC  unsafe.Pointer
+	symXFreeGC    unsafe.Pointer
+	symXPutImage  unsafe.Pointer
+	symXFlush     unsafe.Pointer
+	symXInitImage unsafe.Pointer
+
+	// XCreateGC(Display*, Drawable, unsigned long valuemask, XGCValues*) -> GC
+	cifXCreateGC types.CallInterface
+	// XFreeGC(Display*, GC) -> int
+	cifXFreeGC types.CallInterface
+	// XPutImage(Display*, Drawable, GC, XImage*, int, int, int, int, uint, uint) -> int
+	cifXPutImage types.CallInterface
+	// XFlush(Display*) -> int
+	cifXFlush types.CallInterface
+	// XInitImage(XImage*) -> Status (int)
+	cifXInitImage types.CallInterface
+)
+
+// initX11 loads libX11.so and prepares call interfaces.
+// Called once via sync.Once; sets x11Ready on success.
+func initX11() {
+	var err error
+
+	// Load library: try .so.6 first (standard versioned SONAME), then unversioned.
+	x11Lib, err = ffi.LoadLibrary("libX11.so.6")
+	if err != nil {
+		x11Lib, err = ffi.LoadLibrary("libX11.so")
+		if err != nil {
+			slog.Debug("software: X11 blit unavailable — could not load libX11", "error", err)
+			return
+		}
+	}
+
+	// Load symbols.
+	symXCreateGC, err = ffi.GetSymbol(x11Lib, "XCreateGC")
+	if err != nil {
+		return
+	}
+	symXFreeGC, err = ffi.GetSymbol(x11Lib, "XFreeGC")
+	if err != nil {
+		return
+	}
+	symXPutImage, err = ffi.GetSymbol(x11Lib, "XPutImage")
+	if err != nil {
+		return
+	}
+	symXFlush, err = ffi.GetSymbol(x11Lib, "XFlush")
+	if err != nil {
+		return
+	}
+	symXInitImage, err = ffi.GetSymbol(x11Lib, "XInitImage")
+	if err != nil {
+		return
+	}
+
+	// Prepare call interfaces.
+
+	// GC XCreateGC(Display *display, Drawable d, unsigned long valuemask, XGCValues *values)
+	// On LP64: Drawable = unsigned long (8 bytes), valuemask = unsigned long (8 bytes)
+	// GC = pointer. Using Pointer for Drawable since it's XID (unsigned long = pointer-sized on LP64).
+	err = ffi.PrepareCallInterface(&cifXCreateGC, types.DefaultCall,
+		types.PointerTypeDescriptor, // return: GC (pointer)
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor, // Display*
+			types.PointerTypeDescriptor, // Drawable (unsigned long = pointer-sized)
+			types.PointerTypeDescriptor, // unsigned long valuemask (pointer-sized on LP64)
+			types.PointerTypeDescriptor, // XGCValues*
+		})
+	if err != nil {
+		return
+	}
+
+	// int XFreeGC(Display *display, GC gc)
+	err = ffi.PrepareCallInterface(&cifXFreeGC, types.DefaultCall,
+		types.SInt32TypeDescriptor, // return: int
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor, // Display*
+			types.PointerTypeDescriptor, // GC
+		})
+	if err != nil {
+		return
+	}
+
+	// int XPutImage(Display*, Drawable, GC, XImage*, int, int, int, int, unsigned int, unsigned int)
+	err = ffi.PrepareCallInterface(&cifXPutImage, types.DefaultCall,
+		types.SInt32TypeDescriptor, // return: int
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor, // Display*
+			types.PointerTypeDescriptor, // Drawable (unsigned long)
+			types.PointerTypeDescriptor, // GC
+			types.PointerTypeDescriptor, // XImage*
+			types.SInt32TypeDescriptor,  // src_x
+			types.SInt32TypeDescriptor,  // src_y
+			types.SInt32TypeDescriptor,  // dest_x
+			types.SInt32TypeDescriptor,  // dest_y
+			types.UInt32TypeDescriptor,  // width
+			types.UInt32TypeDescriptor,  // height
+		})
+	if err != nil {
+		return
+	}
+
+	// int XFlush(Display *display)
+	err = ffi.PrepareCallInterface(&cifXFlush, types.DefaultCall,
+		types.SInt32TypeDescriptor, // return: int
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor, // Display*
+		})
+	if err != nil {
+		return
+	}
+
+	// Status XInitImage(XImage *image)
+	err = ffi.PrepareCallInterface(&cifXInitImage, types.DefaultCall,
+		types.SInt32TypeDescriptor, // return: Status (int)
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor, // XImage*
+		})
+	if err != nil {
+		return
+	}
+
+	x11Ready = true
+	slog.Debug("software: X11 blit initialized — XPutImage path available")
+}
+
+// platformBlit holds X11 GC for blit operations.
+// Embedded in Surface via build tags.
+type platformBlit struct {
+	gc uintptr // X11 GC (Graphics Context), lazy-initialized on first blit
+}
+
+// createPlatformFramebuffer returns nil on Linux — we use Go heap memory
+// and blit via XPutImage (unlike Windows which uses kernel-allocated DIB section).
+func (s *Surface) createPlatformFramebuffer(_, _ int32) []byte { return nil }
+
+// destroyPlatformFramebuffer releases the X11 GC if one was created.
+func (s *Surface) destroyPlatformFramebuffer() {
+	if s.gc == 0 || s.displayHandle == 0 {
+		return
+	}
+
+	x11Once.Do(initX11)
+	if !x11Ready {
+		s.gc = 0
+		return
+	}
+
+	display := s.displayHandle
+	gc := s.gc
+	args := [2]unsafe.Pointer{
+		unsafe.Pointer(&display),
+		unsafe.Pointer(&gc),
+	}
+	_ = ffi.CallFunction(&cifXFreeGC, symXFreeGC, nil, args[:])
+	s.gc = 0
+}
+
+// blitFramebufferToWindow copies the framebuffer to the X11 window via XPutImage.
+//
+// Follows the Skia enterprise pattern (RasterWindowContext_unix.cpp):
+// construct XImage on stack pointing to our BGRA pixel buffer, call XInitImage
+// to fill function pointers, then XPutImage to send pixels to the X server.
+//
+// No pixel format conversion is needed: our framebuffer stores BGRA (the software
+// rasterizer's executeFullscreenBlit does RGBA→BGRA swizzle), which matches X11's
+// 32bpp ZPixmap LSBFirst format on little-endian systems. This is the same reason
+// Skia and SDL3 set byte_order=LSBFirst and depth=24 with bits_per_pixel=32.
+func (s *Surface) blitFramebufferToWindow(data []byte, width, height int32) {
+	if s.hwnd == 0 || s.displayHandle == 0 || width <= 0 || height <= 0 || len(data) == 0 {
+		return
+	}
+
+	// Lazy-load libX11 on first blit.
+	x11Once.Do(initX11)
+	if !x11Ready {
+		return
+	}
+
+	display := s.displayHandle
+	window := s.hwnd
+
+	// Lazy-create GC on first blit (same pattern as SDL3: XCreateGC in CreateWindowFramebuffer).
+	if s.gc == 0 {
+		var valuemask uintptr // 0 = no special GC values
+		var values uintptr    // NULL = default values
+		var gc uintptr
+		args := [4]unsafe.Pointer{
+			unsafe.Pointer(&display),
+			unsafe.Pointer(&window),
+			unsafe.Pointer(&valuemask),
+			unsafe.Pointer(&values),
+		}
+		_ = ffi.CallFunction(&cifXCreateGC, symXCreateGC, unsafe.Pointer(&gc), args[:])
+		if gc == 0 {
+			slog.Warn("software: XCreateGC failed — blit skipped")
+			return
+		}
+		s.gc = gc
+	}
+
+	// Construct XImage on stack pointing to our pixel buffer.
+	// Fields follow Skia RasterWindowContext_unix.cpp exactly.
+	var image ximage
+	image.width = width
+	image.height = height
+	image.format = zPixmap
+	image.data = uintptr(unsafe.Pointer(&data[0]))
+	image.byteOrder = lsbFirst
+	image.bitmapUnit = 32
+	image.bitmapBitOrder = lsbFirst
+	image.bitmapPad = 32
+	image.depth = 24
+	image.bytesPerLine = 0 // XInitImage calculates this
+	image.bitsPerPixel = 32
+
+	// XInitImage fills the function pointer struct at the end of XImage.
+	// Without this call, XPutImage would crash dereferencing nil func ptrs.
+	imagePtr := uintptr(unsafe.Pointer(&image))
+	var status int32
+	initArgs := [1]unsafe.Pointer{unsafe.Pointer(&imagePtr)}
+	_ = ffi.CallFunction(&cifXInitImage, symXInitImage, unsafe.Pointer(&status), initArgs[:])
+	if status == 0 {
+		slog.Warn("software: XInitImage failed — blit skipped")
+		return
+	}
+
+	// XPutImage: copy pixel data to the X server.
+	gc := s.gc
+	var srcX, srcY, dstX, dstY int32
+	w := uint32(width)
+	h := uint32(height)
+	putArgs := [10]unsafe.Pointer{
+		unsafe.Pointer(&display),
+		unsafe.Pointer(&window),
+		unsafe.Pointer(&gc),
+		unsafe.Pointer(&imagePtr),
+		unsafe.Pointer(&srcX),
+		unsafe.Pointer(&srcY),
+		unsafe.Pointer(&dstX),
+		unsafe.Pointer(&dstY),
+		unsafe.Pointer(&w),
+		unsafe.Pointer(&h),
+	}
+	_ = ffi.CallFunction(&cifXPutImage, symXPutImage, nil, putArgs[:])
+
+	// XFlush ensures the X server processes the put request immediately.
+	// Without this, pixels may not appear until the next X event.
+	flushArgs := [1]unsafe.Pointer{unsafe.Pointer(&display)}
+	_ = ffi.CallFunction(&cifXFlush, symXFlush, nil, flushArgs[:])
+}

--- a/hal/software/blit_other.go
+++ b/hal/software/blit_other.go
@@ -1,17 +1,17 @@
-//go:build !windows
+//go:build !windows && !linux
 
 package software
 
-// platformBlit is a no-op on non-Windows platforms.
-// On Windows this struct has real GDI fields (memDC, bitmap, oldBmp).
+// platformBlit is a no-op on platforms without native blit support.
+// Windows has GDI (blit_windows.go), Linux has X11 (blit_linux.go).
 type platformBlit struct{}
 
-// createPlatformFramebuffer returns nil on non-Windows — use Go memory.
+// createPlatformFramebuffer returns nil — use Go heap memory.
 func (s *Surface) createPlatformFramebuffer(_, _ int32) []byte { return nil }
 
-// destroyPlatformFramebuffer is a no-op on non-Windows.
+// destroyPlatformFramebuffer is a no-op.
 func (s *Surface) destroyPlatformFramebuffer() {}
 
-// blitFramebufferToWindow is a no-op on non-Windows platforms.
-// TODO: implement XPutImage for Linux X11, CGContextDrawImage for macOS.
+// blitFramebufferToWindow is a no-op on unsupported platforms.
+// TODO: implement CGImage+CALayer blit for macOS (Phase 2).
 func (s *Surface) blitFramebufferToWindow(_ []byte, _, _ int32) {}

--- a/hal/software/resource.go
+++ b/hal/software/resource.go
@@ -135,16 +135,17 @@ func (v *TextureView) NativeHandle() uintptr { return uintptr(v.id) }
 // Surface implements hal.Surface for the software backend.
 type Surface struct {
 	Resource
-	configured   bool
-	width        uint32
-	height       uint32
-	format       gputypes.TextureFormat
-	framebuffer  []byte
-	mu           sync.RWMutex // Protects framebuffer access
-	presentMode  hal.PresentMode
-	alphaMode    hal.CompositeAlphaMode
-	hwnd         uintptr // window handle for platform blit (0 = headless)
-	platformBlit         // Windows: DIB section for DWM-friendly presentation
+	configured    bool
+	width         uint32
+	height        uint32
+	format        gputypes.TextureFormat
+	framebuffer   []byte
+	mu            sync.RWMutex // Protects framebuffer access
+	presentMode   hal.PresentMode
+	alphaMode     hal.CompositeAlphaMode
+	displayHandle uintptr // X11: Display*, macOS/Windows: 0
+	hwnd          uintptr // window handle for platform blit (0 = headless)
+	platformBlit          // platform-specific blit resources (Windows: DIB section, Linux: X11 GC)
 }
 
 // Configure configures the surface with the given settings.

--- a/hal/software/software_test.go
+++ b/hal/software/software_test.go
@@ -1073,6 +1073,26 @@ func TestSurfaceAcquireTexture(t *testing.T) {
 	surface.DiscardTexture(acquired.Texture)
 }
 
+func TestSurfaceStoresDisplayHandle(t *testing.T) {
+	backend := API{}
+	instance, _ := backend.CreateInstance(&hal.InstanceDescriptor{})
+	defer instance.Destroy()
+
+	surface, err := instance.CreateSurface(0xDEAD, 0xBEEF)
+	if err != nil {
+		t.Fatalf("CreateSurface failed: %v", err)
+	}
+	defer surface.Destroy()
+
+	s := surface.(*Surface)
+	if s.displayHandle != 0xDEAD {
+		t.Errorf("displayHandle = %#x, want 0xDEAD", s.displayHandle)
+	}
+	if s.hwnd != 0xBEEF {
+		t.Errorf("hwnd = %#x, want 0xBEEF", s.hwnd)
+	}
+}
+
 func TestSurfaceGetFramebufferNil(t *testing.T) {
 	s := &Surface{}
 	fb := s.GetFramebuffer()


### PR DESCRIPTION
## Summary

- **Linux X11 windowed presentation** for software backend via `XPutImage` (Skia enterprise pattern)
- Lazy-loads libX11.so via goffi on first blit — graceful no-op if unavailable (headless CI)
- No pixel format conversion — BGRA framebuffer matches X11 ZPixmap LSBFirst natively
- Store `displayHandle` in Surface (needed for X11 Display*)
- Test for displayHandle storage
- README updated: software presentation matrix (Windows + Linux + macOS planned)

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass (including new `TestSurfaceStoresDisplayHandle`)
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] `gofmt -l .` — clean
- [x] `GOGPU_GRAPHICS_API=software` gg example — Windows verified, no regression
- [ ] `GOGPU_GRAPHICS_API=software` — Linux X11 runtime (needs Linux machine)
- [ ] CI