### PR TITLE
v0.25.2: gputypes v0.5.0 (PrimitiveState zero defaults)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.2] - 2026-04-21
+
+### Dependencies
+
+- **gputypes** v0.4.0 → **v0.5.0** — PrimitiveState zero value = WebGPU spec default (breaking
+  enum renumber in gputypes). Go zero-init now produces correct defaults without explicit field
+  assignment. Aligns with gpucontext v0.13.0.
+
 ## [0.25.1] - 2026-04-21
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-webgpu/goffi v0.5.0
-	github.com/gogpu/gputypes v0.4.0
+	github.com/gogpu/gputypes v0.5.0
 	github.com/gogpu/naga v0.17.4
 	golang.org/x/sys v0.43.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE=
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/gogpu/gputypes v0.4.0 h1:nPFn77na71K4gkyObbXgpYywy9lIKz/U1x/2+4EAZ3Y=
-github.com/gogpu/gputypes v0.4.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
+github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
+github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.4 h1:37U/6PP7F+fiyXqJzEAOJUzxZPC5lyyOKxCOnCQIw6k=
 github.com/gogpu/naga v0.17.4/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=


### PR DESCRIPTION
## Summary

- **gputypes** v0.4.0 → v0.5.0 — PrimitiveState zero value = WebGPU spec default
- Aligns with gpucontext v0.13.0 dependency chain

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `gofmt -l .` — clean
- [ ] CI