### PR TITLE
v0.25.3: fix SIGSEGV on large WriteBuffer (#142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.3] - 2026-04-23
+
+### Fixed
+
+- **SIGSEGV on large Queue.WriteBuffer** (#142) — `copyToMappedMemory` crashed when writing
+  data larger than `maxMemoryAllocationSize` (e.g., 544MB on Lavapipe with 256MB limit).
+  Root cause: `vkAllocateMemory` silently fails on oversized requests; the staging belt then
+  wrote past the valid mapped region. Four fixes applied:
+  1. **Query and enforce `maxMemoryAllocationSize`** (Vulkan 1.1 core) — allocator rejects
+     allocations exceeding the driver limit with `ErrAllocationTooLarge`
+  2. **Chunk large writes** — staging belt caps individual staging buffers at 64MB (Rust wgpu
+     parity: `1 << 26`), automatically splits larger writes into multiple CopyBufferToBuffer
+  3. **MappedPtr null check** — `ensureMemoryMapped` returns error if `vkMapMemory` returns null
+  4. **MappedSize bounds check** — `WriteBuffer` verifies `offset + len(data) <= MappedSize`
+     before `copyToMappedMemory`, turning SIGSEGV into a clear error message
+
+### Added
+
+- `hal.MaxStagingBufferSizer` optional interface — backends can advertise their maximum
+  staging buffer size. Vulkan returns `min(64MB, maxMemoryAllocationSize)`. Non-implementing
+  backends default to 64MB.
+- `memory.ErrAllocationTooLarge` sentinel error for allocations exceeding device limits.
+- `MemoryBlock.MappedSize` field for bounds checking mapped memory access.
+
 ## [0.25.2] - 2026-04-21
 
 ### Dependencies

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.25.0
+## Current State: v0.25.3
 
 ✅ **All 5 HAL backends complete** (~127K LOC)
 ✅ **Three-layer WebGPU stack** — wgpu API → wgpu/core → wgpu/hal
@@ -40,6 +40,9 @@
 ✅ **GLES Y-flip fix** — swapchain offscreen FBO + Present blit (Rust wgpu-hal parity)
 ✅ **Encoder pool** — per-Device shared pool (Rust CommandAllocator pattern)
 ✅ **Software DWM-safe presentation** — CreateDIBSection+BitBlt (SDL3/Qt6 pattern)
+✅ **Software Linux X11 presentation** — XPutImage via goffi (Skia pattern)
+✅ **Vulkan maxMemoryAllocationSize enforcement** — prevents SIGSEGV on large writes
+✅ **Staging belt auto-chunking** — writes >64MB automatically split (Rust wgpu parity)
 
 ### Remaining validation (planned)
 - Late buffer binding size (SPIR-V reflection → min binding size)
@@ -50,7 +53,7 @@
 | Metal | macOS | ✅ Stable — naga MSL 91/91 |
 | DX12 | Windows | ✅ Stable — TDR fixed, PendingWrites, deferred destruction |
 | GLES | Windows, Linux | ✅ Stable — text rendering, SamplerBindMap, texture completeness |
-| Software | All | ✅ Partial (SW-002) |
+| Software | Windows, Linux | ✅ Stable — windowed presentation (GDI/X11), macOS planned |
 
 → **See [CHANGELOG.md](CHANGELOG.md) for detailed per-version notes**
 
@@ -124,6 +127,9 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.25.3** | 2026-04 | Fix SIGSEGV on large WriteBuffer (#142): maxMemoryAllocationSize enforcement, staging belt auto-chunking, MappedSize bounds checking |
+| **v0.25.2** | 2026-04 | gputypes v0.5.0 (PrimitiveState zero defaults) |
+| **v0.25.1** | 2026-04 | Linux X11 software presentation via XPutImage (Skia pattern) |
 | **v0.25.0** | 2026-04 | **WebGPU Buffer mapping API**, **DXIL full rendering** (naga v0.17.4), GLES Y-flip fix, sampler heap plumbing, pipeline error logging. Breaking: `Queue.ReadBuffer` removed. |
 | **v0.24.7** | 2026-04 | DWM-safe software presentation (CreateDIBSection+BitBlt), rendering optimizations |
 | **v0.23.8** | 2026-04 | Metal vertex buffer fix, GLES per-type binding counters, StagingBelt alignment |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -91,7 +91,7 @@ Key interfaces (defined in `hal/api.go`):
 Pure Go Vulkan 1.0+ implementation using `cgo_import_dynamic` for function loading.
 
 - `vk/` — Low-level Vulkan bindings (generated types, function signatures, loader)
-- `memory/` — GPU memory allocator (buddy allocation)
+- `memory/` — GPU memory allocator (buddy allocation, `maxMemoryAllocationSize` enforcement)
 - Platform surface: VkWin32, VkXlib, VkMetal
 
 ### `hal/metal/` — Metal Backend
@@ -187,7 +187,7 @@ Queue.Submit(userCmds)    │
 
 **Batching backends** (DX12, Vulkan, Metal): sub-allocate from StagingBelt chunks, record `CopyBufferToBuffer`/`CopyBufferToTexture` via command encoder. Encoder pool recycles allocators after GPU completion.
 
-**StagingBelt** (`staging_belt.go`): ring-buffer of reusable 256KB staging chunks with bump-pointer sub-allocation. Matches Rust wgpu `util::StagingBelt` (belt.rs). Zero heap allocations in steady state — chunks are pre-allocated and recycled after GPU completion. Oversized writes (> chunkSize) fall back to one-off buffers.
+**StagingBelt** (`staging_belt.go`): ring-buffer of reusable 256KB staging chunks with bump-pointer sub-allocation. Matches Rust wgpu `util::StagingBelt` (belt.rs). Zero heap allocations in steady state — chunks are pre-allocated and recycled after GPU completion. Oversized writes (> chunkSize) are automatically chunked into multiple staging buffers capped at 64MB (Rust wgpu parity: `1 << 26`), each followed by a `CopyBufferToBuffer` command. This prevents SIGSEGV when writes exceed `maxMemoryAllocationSize`.
 
 ```
 Chunk lifecycle:  free → active (sub-allocating) → closed (GPU in-flight) → free (recycled)

--- a/hal/api.go
+++ b/hal/api.go
@@ -289,3 +289,19 @@ type Queue interface {
 	// directly to the HAL without batching.
 	SupportsCommandBufferCopies() bool
 }
+
+// MaxStagingBufferSizer is an optional interface implemented by HAL devices
+// that can report the maximum safe staging buffer allocation size.
+//
+// For Vulkan, this returns min(64MB, maxMemoryAllocationSize) from
+// VkPhysicalDeviceMaintenance3Properties. Without this limit, staging belt
+// allocations can silently fail when they exceed the driver's maximum
+// allocation size, leading to SIGSEGV (BUG-VK-001).
+//
+// Backends that do not implement this interface default to 64MB
+// (stagingBeltMaxOversizedSize), which is safe for DX12, Metal, and GLES.
+type MaxStagingBufferSizer interface {
+	// MaxStagingBufferSize returns the maximum size in bytes for a single
+	// staging buffer allocation. Returns 0 to use the default (64MB).
+	MaxStagingBufferSize() uint64
+}

--- a/hal/vulkan/device.go
+++ b/hal/vulkan/device.go
@@ -121,8 +121,13 @@ func (d *Device) initAllocator() error {
 		}
 	}
 
+	// Query maxMemoryAllocationSize (Vulkan 1.1 core, BUG-VK-001).
+	// This prevents SIGSEGV from vkAllocateMemory silently failing
+	// when the requested size exceeds what the driver supports.
+	maxAllocSize := d.queryMaxMemoryAllocationSize()
+
 	// Create allocator with default config
-	allocator, err := memory.NewGpuAllocator(d.handle, d.cmds, props, memory.DefaultConfig())
+	allocator, err := memory.NewGpuAllocator(d.handle, d.cmds, props, maxAllocSize, memory.DefaultConfig())
 	if err != nil {
 		return fmt.Errorf("failed to create memory allocator: %w", err)
 	}
@@ -130,6 +135,55 @@ func (d *Device) initAllocator() error {
 	d.allocator = allocator
 
 	return nil
+}
+
+// queryMaxMemoryAllocationSize queries VkPhysicalDeviceMaintenance3Properties
+// to determine the maximum single VkDeviceMemory allocation size.
+// Returns 0 if the query is not available (pre-Vulkan 1.1), in which case
+// the allocator uses a safe fallback.
+func (d *Device) queryMaxMemoryAllocationSize() uint64 {
+	// vkGetPhysicalDeviceProperties2 is Vulkan 1.1 core.
+	// GetPhysicalDeviceProperties2 has an internal nil-check on its function pointer
+	// and returns silently if unavailable (pre-1.1 drivers).
+	// We rely on the SType being properly initialized for the pNext chain.
+
+	// Chain PhysicalDeviceMaintenance3Properties into PhysicalDeviceProperties2.
+	var maint3Props vk.PhysicalDeviceMaintenance3Properties
+	maint3Props.SType = vk.StructureTypePhysicalDeviceMaintenance3Properties
+
+	props2 := vk.PhysicalDeviceProperties2{
+		SType: vk.StructureTypePhysicalDeviceProperties2,
+		PNext: (*uintptr)(unsafe.Pointer(&maint3Props)),
+	}
+
+	d.instance.cmds.GetPhysicalDeviceProperties2(d.physicalDevice, &props2)
+
+	maxSize := uint64(maint3Props.MaxMemoryAllocationSize)
+	if maxSize > 0 {
+		hal.Logger().Info("vulkan: maxMemoryAllocationSize queried",
+			"maxSize", maxSize,
+			"maxSizeMB", maxSize/(1<<20),
+		)
+	}
+
+	return maxSize
+}
+
+// MaxStagingBufferSize returns the maximum safe staging buffer allocation size.
+// This is min(64MB, maxMemoryAllocationSize) from the Vulkan allocator.
+// Used by the staging belt to cap individual staging buffers, preventing
+// vkAllocateMemory from silently failing on oversized requests (BUG-VK-001).
+// Implements hal.MaxStagingBufferSizer.
+func (d *Device) MaxStagingBufferSize() uint64 {
+	if d.allocator == nil {
+		return 0
+	}
+	maxAlloc := d.allocator.MaxAllocationSize()
+	const defaultMax = 64 << 20 // 64 MB, matching Rust wgpu's 1 << 26
+	if maxAlloc > 0 && maxAlloc < defaultMax {
+		return maxAlloc
+	}
+	return defaultMax
 }
 
 // CreateBuffer creates a GPU buffer.
@@ -231,10 +285,14 @@ func (d *Device) ensureMemoryMapped(block *memory.MemoryBlock) error {
 		if result != vk.Success {
 			return fmt.Errorf("vulkan: vkMapMemory failed: %d", result)
 		}
+		if mappedPtr == 0 {
+			return fmt.Errorf("vulkan: vkMapMemory returned null pointer (BUG-VK-001)")
+		}
 		d.mappedMemory[block.Memory] = mappedPtr
 		basePtr = mappedPtr
 	}
 	block.MappedPtr = basePtr + uintptr(block.Offset)
+	block.MappedSize = block.Size // Valid mapped region = allocated block size (BUG-VK-001)
 	return nil
 }
 

--- a/hal/vulkan/memory/allocator.go
+++ b/hal/vulkan/memory/allocator.go
@@ -78,6 +78,12 @@ type GpuAllocator struct {
 	config   AllocatorConfig
 	selector *MemoryTypeSelector
 
+	// maxAllocationSize is the maximum single VkDeviceMemory allocation
+	// allowed by the driver (from VkPhysicalDeviceMaintenance3Properties).
+	// Allocations exceeding this size are rejected with ErrAllocationTooLarge.
+	// Vulkan 1.1 core — guaranteed available on all target devices (BUG-VK-001).
+	maxAllocationSize uint64
+
 	// pools contains per-memory-type pools.
 	// Index matches Vulkan memory type index.
 	pools []*MemoryPool
@@ -107,6 +113,11 @@ var (
 
 	// ErrInvalidBlock indicates an invalid memory block.
 	ErrInvalidBlock = errors.New("allocator: invalid memory block")
+
+	// ErrAllocationTooLarge indicates the requested allocation exceeds
+	// VkPhysicalDeviceMaintenance3Properties.maxMemoryAllocationSize.
+	// Callers should chunk large writes into smaller pieces (BUG-VK-001).
+	ErrAllocationTooLarge = errors.New("allocator: allocation exceeds maxMemoryAllocationSize")
 )
 
 // NewGpuAllocator creates a new GPU memory allocator.
@@ -115,8 +126,10 @@ var (
 //   - device: Vulkan device handle
 //   - cmds: Vulkan commands for memory operations
 //   - props: Device memory properties from vkGetPhysicalDeviceMemoryProperties
+//   - maxAllocationSize: VkPhysicalDeviceMaintenance3Properties.maxMemoryAllocationSize
+//     (Vulkan 1.1 core). Pass 0 to use a safe fallback (256MB).
 //   - config: Allocator configuration (use DefaultConfig() for defaults)
-func NewGpuAllocator(device vk.Device, cmds *vk.Commands, props DeviceMemoryProperties, config AllocatorConfig) (*GpuAllocator, error) {
+func NewGpuAllocator(device vk.Device, cmds *vk.Commands, props DeviceMemoryProperties, maxAllocationSize uint64, config AllocatorConfig) (*GpuAllocator, error) {
 	// Validate config
 	if !isPowerOfTwo(config.BlockSize) {
 		return nil, fmt.Errorf("BlockSize must be power of 2: %d", config.BlockSize)
@@ -129,6 +142,12 @@ func NewGpuAllocator(device vk.Device, cmds *vk.Commands, props DeviceMemoryProp
 	}
 
 	selector := NewMemoryTypeSelector(props)
+
+	// Safe fallback if maxAllocationSize is not available (pre-Vulkan 1.1
+	// or query failure). 256MB is conservative but safe for all GPUs.
+	if maxAllocationSize == 0 {
+		maxAllocationSize = 256 << 20 // 256 MB
+	}
 
 	// Create pools for each memory type
 	pools := make([]*MemoryPool, len(props.MemoryTypes))
@@ -143,12 +162,13 @@ func NewGpuAllocator(device vk.Device, cmds *vk.Commands, props DeviceMemoryProp
 	}
 
 	return &GpuAllocator{
-		device:    device,
-		cmds:      cmds,
-		config:    config,
-		selector:  selector,
-		pools:     pools,
-		dedicated: make(map[vk.DeviceMemory]*MemoryBlock),
+		device:            device,
+		cmds:              cmds,
+		config:            config,
+		selector:          selector,
+		maxAllocationSize: maxAllocationSize,
+		pools:             pools,
+		dedicated:         make(map[vk.DeviceMemory]*MemoryBlock),
 	}, nil
 }
 
@@ -395,7 +415,13 @@ func (a *GpuAllocator) Destroy() {
 }
 
 // vulkanAllocate wraps vkAllocateMemory.
+// Rejects allocations exceeding maxMemoryAllocationSize (BUG-VK-001).
 func (a *GpuAllocator) vulkanAllocate(size uint64, memTypeIndex uint32) (vk.DeviceMemory, error) {
+	if size > a.maxAllocationSize {
+		return 0, fmt.Errorf("%w: requested %d bytes, limit %d bytes",
+			ErrAllocationTooLarge, size, a.maxAllocationSize)
+	}
+
 	allocInfo := vk.MemoryAllocateInfo{
 		SType:           vk.StructureTypeMemoryAllocateInfo,
 		AllocationSize:  vk.DeviceSize(size),
@@ -409,6 +435,12 @@ func (a *GpuAllocator) vulkanAllocate(size uint64, memTypeIndex uint32) (vk.Devi
 	}
 
 	return memory, nil
+}
+
+// MaxAllocationSize returns the maximum single VkDeviceMemory allocation
+// size allowed by the driver.
+func (a *GpuAllocator) MaxAllocationSize() uint64 {
+	return a.maxAllocationSize
 }
 
 // vulkanFree wraps vkFreeMemory.

--- a/hal/vulkan/memory/types.go
+++ b/hal/vulkan/memory/types.go
@@ -72,6 +72,11 @@ type MemoryBlock struct {
 	// MappedPtr holds the mapped pointer if memory is mapped.
 	// Set by Map(), cleared by Unmap().
 	MappedPtr uintptr
+
+	// MappedSize is the size in bytes of the mapped region accessible
+	// through MappedPtr. Used for bounds checking before copyToMappedMemory
+	// to prevent SIGSEGV on partial/failed allocations (BUG-VK-001).
+	MappedSize uint64
 }
 
 // IsDedicated returns true if this is a dedicated allocation.

--- a/hal/vulkan/queue.go
+++ b/hal/vulkan/queue.go
@@ -308,6 +308,14 @@ func (q *Queue) WriteBuffer(buffer hal.Buffer, offset uint64, data []byte) error
 
 	// Map, copy, unmap
 	if vkBuffer.memory.MappedPtr != 0 {
+		// Bounds check: verify the write fits within the mapped region (BUG-VK-001).
+		// Without this, a partial/failed vkAllocateMemory that returned a too-small
+		// mapping would cause SIGSEGV in copyToMappedMemory.
+		if vkBuffer.memory.MappedSize > 0 && offset+uint64(len(data)) > vkBuffer.memory.MappedSize {
+			return fmt.Errorf("vulkan: WriteBuffer: write of %d bytes at offset %d exceeds mapped size %d (BUG-VK-001)",
+				len(data), offset, vkBuffer.memory.MappedSize)
+		}
+
 		// Already mapped - direct copy using Vulkan mapped memory from vkMapMemory
 		// Use copyToMappedMemory to avoid go vet false positive about unsafe.Pointer
 		copyToMappedMemory(vkBuffer.memory.MappedPtr, offset, data)

--- a/hal/vulkan/vk/const_ext.go
+++ b/hal/vulkan/vk/const_ext.go
@@ -19,6 +19,10 @@ const (
 	// StructureTypePhysicalDeviceProperties2 = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2
 	StructureTypePhysicalDeviceProperties2 StructureType = 1000059001
 
+	// StructureTypePhysicalDeviceMaintenance3Properties = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES
+	// Vulkan 1.1 core — used to query maxMemoryAllocationSize.
+	StructureTypePhysicalDeviceMaintenance3Properties StructureType = 1000168000
+
 	// === Vulkan 1.2 Core (promoted from VK_KHR_timeline_semaphore) ===
 
 	// StructureTypePhysicalDeviceTimelineSemaphoreFeatures = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES

--- a/pending_writes.go
+++ b/pending_writes.go
@@ -92,6 +92,11 @@ type inflightSubmission struct {
 // wgpu-core which uses a single device.command_allocator for both user command
 // encoders and internal PendingWrites (queue.rs:1373). pool may be nil for
 // non-batching backends (GLES/Software).
+//
+// The staging belt's maxStagingBufferSize is automatically queried from the HAL
+// device via the optional hal.MaxStagingBufferSizer interface (BUG-VK-001).
+// For Vulkan, this returns min(64MB, maxMemoryAllocationSize). For backends
+// that do not implement the interface, the default 64MB cap is used.
 func newPendingWrites(halDevice hal.Device, halQueue hal.Queue, pool *encoderPool) *pendingWrites {
 	pw := &pendingWrites{
 		halDevice:    halDevice,
@@ -102,7 +107,15 @@ func newPendingWrites(halDevice hal.Device, halQueue hal.Queue, pool *encoderPoo
 	}
 	if pw.usesBatching {
 		pw.pool = pool
-		pw.belt = newStagingBelt(halDevice, halQueue, 0, 0) // 0 = defaults (256KB chunks, 8-byte alignment)
+		// Query the device for its maximum staging buffer allocation size.
+		// Vulkan devices report min(64MB, maxMemoryAllocationSize) to prevent
+		// vkAllocateMemory from silently failing on oversized requests (BUG-VK-001).
+		// Other backends return 0 (use default 64MB), which is safe.
+		var maxStaging uint64
+		if sizer, ok := halDevice.(hal.MaxStagingBufferSizer); ok {
+			maxStaging = sizer.MaxStagingBufferSize()
+		}
+		pw.belt = newStagingBelt(halDevice, halQueue, 0, 0, maxStaging)
 	}
 	return pw
 }
@@ -142,14 +155,31 @@ func (pw *pendingWrites) writeBuffer(buffer hal.Buffer, usage gputypes.BufferUsa
 		return fmt.Errorf("wgpu: pending writes: activate encoder: %w", err)
 	}
 
-	// Record GPU copy from staging chunk to destination buffer.
-	// Stack-allocate copy region to avoid slice heap escape.
-	copyRegion := [1]hal.BufferCopy{{
-		SrcOffset: alloc.offset,
-		DstOffset: offset,
-		Size:      dataLen,
-	}}
-	enc.CopyBufferToBuffer(alloc.buffer, buffer, copyRegion[:])
+	// Check if the allocation was chunked (BUG-VK-001).
+	// For chunked writes, we issue one CopyBufferToBuffer per chunk at
+	// the correct destination offset. Each chunk has its own staging buffer.
+	if len(pw.belt.chunkedAllocs) > 1 {
+		dstOffset := offset
+		for _, chunk := range pw.belt.chunkedAllocs {
+			copyRegion := [1]hal.BufferCopy{{
+				SrcOffset: chunk.offset,
+				DstOffset: dstOffset,
+				Size:      chunk.size,
+			}}
+			enc.CopyBufferToBuffer(chunk.buffer, buffer, copyRegion[:])
+			dstOffset += chunk.size
+		}
+		pw.belt.chunkedAllocs = pw.belt.chunkedAllocs[:0]
+	} else {
+		// Normal (non-chunked) path: single CopyBufferToBuffer.
+		// Stack-allocate copy region to avoid slice heap escape.
+		copyRegion := [1]hal.BufferCopy{{
+			SrcOffset: alloc.offset,
+			DstOffset: offset,
+			Size:      dataLen,
+		}}
+		enc.CopyBufferToBuffer(alloc.buffer, buffer, copyRegion[:])
+	}
 
 	// Track destination buffer for barrier computation at flush time.
 	pw.dstBuffers[buffer] = usage

--- a/pending_writes_bench_test.go
+++ b/pending_writes_bench_test.go
@@ -147,7 +147,7 @@ func BenchmarkBufferReadUsage(b *testing.B) {
 func BenchmarkStagingBelt_AllocateSteadyState(b *testing.B) {
 	dev := &noop.Device{}
 	q := &noop.Queue{}
-	belt := newStagingBelt(dev, q, 0, 0)
+	belt := newStagingBelt(dev, q, 0, 0, 0)
 	defer belt.destroy()
 
 	data := make([]byte, 256)

--- a/pending_writes_test.go
+++ b/pending_writes_test.go
@@ -37,6 +37,17 @@ func (q *mockBatchingQueue) WriteTexture(dst *hal.ImageCopyTexture, data []byte,
 	return q.Queue.WriteTexture(dst, data, layout, size)
 }
 
+// mockStagingSizeDevice wraps noop.Device and implements hal.MaxStagingBufferSizer.
+// Used to verify that newPendingWrites queries the device for the max staging buffer size.
+type mockStagingSizeDevice struct {
+	noop.Device
+	maxStaging uint64
+}
+
+func (d *mockStagingSizeDevice) MaxStagingBufferSize() uint64 {
+	return d.maxStaging
+}
+
 // mockNonBatchingQueue wraps noop.Queue and tracks direct calls.
 type mockNonBatchingQueue struct {
 	noop.Queue
@@ -918,5 +929,46 @@ func TestPendingWrites_WriteBufferNonBatchingVerifiesData(t *testing.T) {
 		if b != data[i] {
 			t.Errorf("byte %d: got 0x%02x, want 0x%02x", i, b, data[i])
 		}
+	}
+}
+
+func TestPendingWrites_MaxStagingBufferSizerWiring(t *testing.T) {
+	// Verify that newPendingWrites queries the hal.MaxStagingBufferSizer
+	// interface from the device and propagates it to the staging belt.
+	// This is the core of BUG-VK-001: on Vulkan, maxMemoryAllocationSize
+	// must cap the staging belt to prevent oversized allocations.
+	dev := &mockStagingSizeDevice{maxStaging: 1 << 20} // 1MB
+	q := &mockBatchingQueue{}
+	pool := newEncoderPool(&dev.Device)
+	pw := newPendingWrites(dev, q, pool)
+	defer pw.destroy()
+	defer pool.destroy()
+
+	if pw.belt == nil {
+		t.Fatal("expected non-nil belt for batching backend")
+	}
+
+	if pw.belt.maxStagingBufferSize != 1<<20 {
+		t.Errorf("belt.maxStagingBufferSize = %d, want %d", pw.belt.maxStagingBufferSize, 1<<20)
+	}
+}
+
+func TestPendingWrites_MaxStagingBufferSizerDefaultWhenNotImplemented(t *testing.T) {
+	// Verify that when the device does NOT implement MaxStagingBufferSizer,
+	// the belt uses the default 64MB cap.
+	dev := &noop.Device{} // noop.Device does NOT implement MaxStagingBufferSizer
+	q := &mockBatchingQueue{}
+	pool := newEncoderPool(dev)
+	pw := newPendingWrites(dev, q, pool)
+	defer pw.destroy()
+	defer pool.destroy()
+
+	if pw.belt == nil {
+		t.Fatal("expected non-nil belt for batching backend")
+	}
+
+	if pw.belt.maxStagingBufferSize != stagingBeltMaxOversizedSize {
+		t.Errorf("belt.maxStagingBufferSize = %d, want default %d",
+			pw.belt.maxStagingBufferSize, stagingBeltMaxOversizedSize)
 	}
 }

--- a/staging_belt.go
+++ b/staging_belt.go
@@ -34,6 +34,12 @@ type stagingBelt struct {
 	chunkSize uint64 // size of each pre-allocated chunk
 	alignment uint64 // minimum sub-allocation alignment (power of two)
 
+	// maxStagingBufferSize caps the maximum size of a single staging buffer.
+	// Set to min(stagingBeltMaxOversizedSize, device maxMemoryAllocationSize).
+	// Writes larger than this are automatically chunked into multiple
+	// staging buffers + CopyBufferToBuffer commands (BUG-VK-001).
+	maxStagingBufferSize uint64
+
 	// activeChunks are being sub-allocated via bump pointer.
 	// Typically 1 chunk is active; more are activated when the current
 	// chunk's remaining space can't fit an allocation.
@@ -50,6 +56,12 @@ type stagingBelt struct {
 	// These are not recycled — destroyed after GPU completion (too large
 	// to keep in the pool without wasting memory).
 	oversized []hal.Buffer
+
+	// chunkedAllocs temporarily holds chunk allocations from allocateChunked.
+	// Consumed by pendingWrites.writeBuffer to issue CopyBufferToBuffer for
+	// each chunk. Reset at the start of each allocateChunked call.
+	// Only valid between allocateChunked and the next writeBuffer call.
+	chunkedAllocs []stagingChunkedAllocation
 }
 
 // stagingChunk is a large staging buffer with a bump-pointer allocator.
@@ -78,24 +90,36 @@ const stagingBeltDefaultChunkSize = 256 * 1024
 // cache performance. Configurable via newStagingBelt alignment parameter.
 const stagingBeltDefaultAlignment uint64 = 8
 
+// stagingBeltMaxOversizedSize caps individual staging buffer allocations at 64MB.
+// Rust wgpu caps staging buffers at 1 << 26 (64MB). This prevents
+// vkAllocateMemory from failing when size exceeds maxMemoryAllocationSize,
+// which causes SIGSEGV via null/partial mapped pointer (BUG-VK-001).
+// Writes larger than this are automatically chunked.
+const stagingBeltMaxOversizedSize uint64 = 64 << 20 // 64 MB
+
 // newStagingBelt creates a staging belt with the given chunk size and alignment.
 // If chunkSize is 0, uses the default (256KB).
 // If alignment is 0, uses the default (8 bytes, Rust wgpu parity).
+// If maxStagingBufferSize is 0, uses the default (64MB, Rust wgpu parity).
 // Alignment must be a power of two.
 // Matches Rust wgpu StagingBelt::allocate() where alignment is per-allocation;
 // we simplify to per-belt since the belt is internal to pendingWrites.
-func newStagingBelt(halDevice hal.Device, halQueue hal.Queue, chunkSize, alignment uint64) *stagingBelt { //nolint:unparam // alignment is configurable for future callers and testing
+func newStagingBelt(halDevice hal.Device, halQueue hal.Queue, chunkSize, alignment, maxStagingBufferSize uint64) *stagingBelt { //nolint:unparam // alignment and maxStagingBufferSize are configurable for testing and future callers
 	if chunkSize == 0 {
 		chunkSize = stagingBeltDefaultChunkSize
 	}
 	if alignment == 0 {
 		alignment = stagingBeltDefaultAlignment
 	}
+	if maxStagingBufferSize == 0 {
+		maxStagingBufferSize = stagingBeltMaxOversizedSize
+	}
 	return &stagingBelt{
-		halDevice: halDevice,
-		halQueue:  halQueue,
-		chunkSize: chunkSize,
-		alignment: alignment,
+		halDevice:            halDevice,
+		halQueue:             halQueue,
+		chunkSize:            chunkSize,
+		alignment:            alignment,
+		maxStagingBufferSize: maxStagingBufferSize,
 	}
 }
 
@@ -170,10 +194,34 @@ func (b *stagingBelt) allocate(size uint64, data []byte) (stagingAllocation, err
 	return alloc, nil
 }
 
-// allocateOversized creates a one-off staging buffer for writes larger
-// than chunkSize. The buffer is tracked separately and destroyed after
-// GPU completion (not recycled into the chunk pool).
+// allocateOversized creates one or more one-off staging buffers for writes
+// larger than chunkSize. Each staging buffer is capped at maxStagingBufferSize
+// (default 64MB, matching Rust wgpu's 1 << 26 cap). Writes larger than this
+// cap are split into multiple staging buffers.
+//
+// Returns the first staging allocation. If the write was split, additional
+// staging buffers are tracked in b.oversized but the caller only needs the
+// first allocation's buffer for the CopyBufferToBuffer source — the chunked
+// copies are handled internally by allocateChunked.
+//
+// Defense-in-depth: validates that CreateBuffer returns a usable mapped
+// pointer before writing data, preventing SIGSEGV (BUG-VK-001 Fix 3).
 func (b *stagingBelt) allocateOversized(size uint64, data []byte) (stagingAllocation, error) {
+	// If the write fits in a single staging buffer, use the simple path.
+	if size <= b.maxStagingBufferSize {
+		return b.allocateSingleOversized(size, data)
+	}
+
+	// Large write: chunk into multiple staging buffers.
+	// Each chunk gets its own staging buffer + is tracked as oversized.
+	// The caller (pendingWrites.writeBuffer) will issue CopyBufferToBuffer
+	// for each chunk separately via allocateChunked.
+	return b.allocateChunked(size, data)
+}
+
+// allocateSingleOversized creates a single one-off staging buffer.
+// Validates the mapped pointer before writing (BUG-VK-001 Fix 3).
+func (b *stagingBelt) allocateSingleOversized(size uint64, data []byte) (stagingAllocation, error) {
 	desc := hal.BufferDescriptor{
 		Label:            "(wgpu internal) staging oversized",
 		Size:             size,
@@ -182,7 +230,7 @@ func (b *stagingBelt) allocateOversized(size uint64, data []byte) (stagingAlloca
 	}
 	buf, err := b.halDevice.CreateBuffer(&desc)
 	if err != nil {
-		return stagingAllocation{}, fmt.Errorf("staging belt: create oversized buffer: %w", err)
+		return stagingAllocation{}, fmt.Errorf("staging belt: create oversized buffer (%d bytes): %w", size, err)
 	}
 	if err := b.halQueue.WriteBuffer(buf, 0, data); err != nil {
 		b.halDevice.DestroyBuffer(buf)
@@ -190,6 +238,61 @@ func (b *stagingBelt) allocateOversized(size uint64, data []byte) (stagingAlloca
 	}
 	b.oversized = append(b.oversized, buf)
 	return stagingAllocation{buffer: buf, offset: 0}, nil
+}
+
+// stagingChunkedAllocation holds one chunk of a multi-chunk oversized write.
+// Used by allocateChunked to return all chunks for CopyBufferToBuffer commands.
+type stagingChunkedAllocation struct {
+	buffer hal.Buffer // staging buffer for this chunk
+	offset uint64     // always 0 for oversized (dedicated buffer per chunk)
+	size   uint64     // bytes of data in this chunk
+}
+
+// allocateChunked splits a large write into multiple staging buffers, each
+// capped at maxStagingBufferSize. Returns the first chunk as the primary
+// allocation and stores all chunks in b.chunkedAllocs for the caller to
+// issue CopyBufferToBuffer commands.
+func (b *stagingBelt) allocateChunked(totalSize uint64, data []byte) (stagingAllocation, error) {
+	maxChunk := b.maxStagingBufferSize
+	remaining := totalSize
+	dataOffset := uint64(0)
+
+	b.chunkedAllocs = b.chunkedAllocs[:0]
+
+	for remaining > 0 {
+		chunkSize := remaining
+		if chunkSize > maxChunk {
+			chunkSize = maxChunk
+		}
+
+		chunkData := data[dataOffset : dataOffset+chunkSize]
+		alloc, err := b.allocateSingleOversized(chunkSize, chunkData)
+		if err != nil {
+			// Clean up any chunks we already allocated.
+			for _, ca := range b.chunkedAllocs {
+				b.halDevice.DestroyBuffer(ca.buffer)
+			}
+			b.chunkedAllocs = b.chunkedAllocs[:0]
+			return stagingAllocation{}, fmt.Errorf("staging belt: allocate chunk at offset %d: %w", dataOffset, err)
+		}
+
+		b.chunkedAllocs = append(b.chunkedAllocs, stagingChunkedAllocation{
+			buffer: alloc.buffer,
+			offset: alloc.offset,
+			size:   chunkSize,
+		})
+
+		dataOffset += chunkSize
+		remaining -= chunkSize
+	}
+
+	if len(b.chunkedAllocs) == 0 {
+		return stagingAllocation{}, nil
+	}
+
+	// Return the first chunk as the primary allocation.
+	first := b.chunkedAllocs[0]
+	return stagingAllocation{buffer: first.buffer, offset: first.offset}, nil
 }
 
 // finish moves all active chunks and oversized buffers to closed state.
@@ -316,6 +419,10 @@ func (b *stagingBelt) destroy() {
 		b.halDevice.DestroyBuffer(buf)
 	}
 	b.oversized = nil
+
+	// chunkedAllocs only holds references to buffers already in oversized —
+	// no extra DestroyBuffer needed, just nil the slice.
+	b.chunkedAllocs = nil
 }
 
 // beltStats holds belt statistics for diagnostics/logging.

--- a/staging_belt_test.go
+++ b/staging_belt_test.go
@@ -10,7 +10,7 @@ func createTestBelt(t *testing.T, chunkSize uint64) *stagingBelt {
 	t.Helper()
 	dev := &noop.Device{}
 	q := &mockBatchingQueue{}
-	return newStagingBelt(dev, q, chunkSize, 0)
+	return newStagingBelt(dev, q, chunkSize, 0, 0)
 }
 
 func TestStagingBelt_AllocateSubAllocates(t *testing.T) {
@@ -277,7 +277,7 @@ func TestStagingBelt_AlignUp64(t *testing.T) {
 func TestStagingBelt_DefaultChunkSize(t *testing.T) {
 	dev := &noop.Device{}
 	q := &mockBatchingQueue{}
-	belt := newStagingBelt(dev, q, 0, 0) // 0 = defaults
+	belt := newStagingBelt(dev, q, 0, 0, 0) // 0 = defaults
 	defer belt.destroy()
 
 	if belt.chunkSize != stagingBeltDefaultChunkSize {
@@ -312,5 +312,195 @@ func TestStagingBelt_FinishNoWork(t *testing.T) {
 	s := belt.stats()
 	if s.ClosedSubs != 0 {
 		t.Errorf("expected 0 closed submissions from empty finish, got %d", s.ClosedSubs)
+	}
+}
+
+func TestStagingBelt_ChunkedAllocation(t *testing.T) {
+	// Create a belt with maxStagingBufferSize = 100 bytes.
+	// An oversized write of 250 bytes should be split into 3 chunks:
+	// 100 + 100 + 50.
+	dev := &noop.Device{}
+	q := &mockBatchingQueue{}
+	belt := newStagingBelt(dev, q, 64, 0, 100) // chunkSize=64, maxStaging=100
+	defer belt.destroy()
+
+	data := make([]byte, 250)
+	for i := range data {
+		data[i] = byte(i % 256)
+	}
+
+	alloc, err := belt.allocate(250, data)
+	if err != nil {
+		t.Fatalf("allocate chunked: %v", err)
+	}
+
+	// First chunk should be returned as primary allocation.
+	if alloc.buffer == nil {
+		t.Fatal("expected non-nil buffer from chunked allocation")
+	}
+	if alloc.offset != 0 {
+		t.Errorf("expected offset=0 for chunked allocation, got %d", alloc.offset)
+	}
+
+	// Should have 3 chunks in chunkedAllocs.
+	if len(belt.chunkedAllocs) != 3 {
+		t.Fatalf("expected 3 chunked allocs, got %d", len(belt.chunkedAllocs))
+	}
+
+	// Verify chunk sizes.
+	expectedSizes := []uint64{100, 100, 50}
+	for i, ca := range belt.chunkedAllocs {
+		if ca.size != expectedSizes[i] {
+			t.Errorf("chunk %d: expected size %d, got %d", i, expectedSizes[i], ca.size)
+		}
+		if ca.buffer == nil {
+			t.Errorf("chunk %d: expected non-nil buffer", i)
+		}
+	}
+
+	// All chunks should be in oversized (not activeChunks).
+	if len(belt.oversized) != 3 {
+		t.Errorf("expected 3 oversized buffers, got %d", len(belt.oversized))
+	}
+	s := belt.stats()
+	if s.ActiveChunks != 0 {
+		t.Errorf("expected 0 active chunks, got %d", s.ActiveChunks)
+	}
+}
+
+func TestStagingBelt_ChunkedSingleChunk(t *testing.T) {
+	// When oversized write fits in maxStagingBufferSize, should NOT chunk.
+	dev := &noop.Device{}
+	q := &mockBatchingQueue{}
+	belt := newStagingBelt(dev, q, 64, 0, 200) // chunkSize=64, maxStaging=200
+	defer belt.destroy()
+
+	data := make([]byte, 150)
+	alloc, err := belt.allocate(150, data)
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+
+	if alloc.buffer == nil {
+		t.Fatal("expected non-nil buffer")
+	}
+
+	// Should NOT have chunked — single oversized buffer.
+	if len(belt.chunkedAllocs) != 0 {
+		t.Errorf("expected 0 chunked allocs (not chunked), got %d", len(belt.chunkedAllocs))
+	}
+	if len(belt.oversized) != 1 {
+		t.Errorf("expected 1 oversized buffer, got %d", len(belt.oversized))
+	}
+}
+
+func TestStagingBelt_ChunkedExactMultiple(t *testing.T) {
+	// Write is exact multiple of maxStagingBufferSize.
+	dev := &noop.Device{}
+	q := &mockBatchingQueue{}
+	belt := newStagingBelt(dev, q, 64, 0, 100) // chunkSize=64, maxStaging=100
+	defer belt.destroy()
+
+	data := make([]byte, 300)
+	_, err := belt.allocate(300, data)
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+
+	// Should have 3 chunks of 100 each.
+	if len(belt.chunkedAllocs) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(belt.chunkedAllocs))
+	}
+	for i, ca := range belt.chunkedAllocs {
+		if ca.size != 100 {
+			t.Errorf("chunk %d: expected size 100, got %d", i, ca.size)
+		}
+	}
+}
+
+func TestStagingBelt_MaxStagingBufferSizeDefault(t *testing.T) {
+	dev := &noop.Device{}
+	q := &mockBatchingQueue{}
+	belt := newStagingBelt(dev, q, 0, 0, 0) // all defaults
+	defer belt.destroy()
+
+	if belt.maxStagingBufferSize != stagingBeltMaxOversizedSize {
+		t.Errorf("expected default maxStagingBufferSize=%d, got %d",
+			stagingBeltMaxOversizedSize, belt.maxStagingBufferSize)
+	}
+}
+
+func TestStagingBelt_ChunkedDataIntegrity(t *testing.T) {
+	// Verify that chunked allocation splits data correctly across multiple
+	// staging buffers. This is the core of BUG-VK-001 Fix 2: writes larger
+	// than maxStagingBufferSize must be split, and each chunk must contain
+	// the correct slice of the source data.
+	dev := &noop.Device{}
+	q := &mockBatchingQueue{}
+	belt := newStagingBelt(dev, q, 32, 0, 80) // chunkSize=32, maxStaging=80
+	defer belt.destroy()
+
+	// Write 200 bytes of recognizable data (should produce 3 chunks: 80+80+40).
+	data := make([]byte, 200)
+	for i := range data {
+		data[i] = byte(i)
+	}
+
+	alloc, err := belt.allocate(200, data)
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+	if alloc.buffer == nil {
+		t.Fatal("expected non-nil buffer")
+	}
+
+	// Verify chunks.
+	if len(belt.chunkedAllocs) != 3 {
+		t.Fatalf("expected 3 chunks, got %d", len(belt.chunkedAllocs))
+	}
+
+	wantSizes := []uint64{80, 80, 40}
+	wantDstOffsets := []uint64{0, 80, 160} // cumulative offsets for CopyBufferToBuffer
+	dstOffset := uint64(0)
+	for i, ca := range belt.chunkedAllocs {
+		if ca.size != wantSizes[i] {
+			t.Errorf("chunk %d: size=%d, want %d", i, ca.size, wantSizes[i])
+		}
+		if dstOffset != wantDstOffsets[i] {
+			t.Errorf("chunk %d: dst offset=%d, want %d", i, dstOffset, wantDstOffsets[i])
+		}
+		dstOffset += ca.size
+	}
+
+	// Total data transferred must equal original size.
+	if dstOffset != 200 {
+		t.Errorf("total chunked size=%d, want 200", dstOffset)
+	}
+}
+
+func TestStagingBelt_SmallMaxStagingBufferSize(t *testing.T) {
+	// Simulate a device with very small maxMemoryAllocationSize (e.g., 16 bytes).
+	// This exercises the extreme case where even normal-sized writes must be chunked.
+	dev := &noop.Device{}
+	q := &mockBatchingQueue{}
+	belt := newStagingBelt(dev, q, 8, 0, 16) // chunkSize=8, maxStaging=16
+	defer belt.destroy()
+
+	// Write 50 bytes. Should produce ceil(50/16)=4 chunks: 16+16+16+2.
+	data := make([]byte, 50)
+	_, err := belt.allocate(50, data)
+	if err != nil {
+		t.Fatalf("allocate: %v", err)
+	}
+
+	if len(belt.chunkedAllocs) != 4 {
+		t.Fatalf("expected 4 chunks, got %d", len(belt.chunkedAllocs))
+	}
+
+	wantSizes := []uint64{16, 16, 16, 2}
+	for i, ca := range belt.chunkedAllocs {
+		if ca.size != wantSizes[i] {
+			t.Errorf("chunk %d: size=%d, want %d", i, ca.size, wantSizes[i])
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Fix SIGSEGV on large `Queue.WriteBuffer`** (#142) — crash when writing >maxMemoryAllocationSize (e.g., 544MB on Lavapipe 256MB limit)
- Query and enforce `VkPhysicalDeviceMaintenance3Properties.maxMemoryAllocationSize` (Vulkan 1.1 core)
- Staging belt auto-chunks writes >64MB (Rust wgpu parity: `1 << 26`)
- `MappedSize` bounds checking + null `MappedPtr` guard — SIGSEGV → clear error message
- `hal.MaxStagingBufferSizer` optional interface for backend-specific limits

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass (new: `TestStagingBelt_ChunkedDataIntegrity`, `TestStagingBelt_SmallMaxStagingBufferSize`)
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] Benchmarks: 0 allocs/op on all hot paths, no regression
- [x] `gofmt -l .` — clean
- [ ] CI