### PR TITLE
v0.25.6: Vulkan command buffer free list (VK-CMD-001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.6] - 2026-04-24
+
+### Changed
+
+- **Vulkan: command buffer free list architecture** (VK-CMD-001) — replaced single-CB-per-encoder
+  with industry-standard free list pattern. Each `CommandEncoder` owns a pool of pre-allocated
+  command buffers (batch 16, matching Rust `ALLOCATION_GRANULARITY`). `BeginEncoding` pops from
+  free list, `EndEncoding` returns handle to caller, `ResetAll` recycles via `vkResetCommandPool`.
+  Fixes VUID-vkBeginCommandBuffer-commandBuffer-00049 (double begin on recording CB).
+  Enterprise parity: Khronos, NVIDIA, ARM, Mesa, Rust wgpu-hal.
+
 ## [0.25.5] - 2026-04-23
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.25.5
+## Current State: v0.25.6
 
 ✅ **All 5 HAL backends complete** (~127K LOC)
 ✅ **Three-layer WebGPU stack** — wgpu API → wgpu/core → wgpu/hal
@@ -46,6 +46,7 @@
 ✅ **Late buffer binding validation** — draw/dispatch-time MinBindingSize=0 checks (Rust parity)
 ✅ **Vulkan relay semaphores** — GPU-side submission ordering (Mesa ANV workaround)
 ✅ **WASM platform split** — root package _native.go/_browser.go, core/hal excluded from WASM build
+✅ **Vulkan command buffer free list** — batch alloc 16 CBs, pool reset (Khronos/NVIDIA/ARM/Mesa/Rust parity)
 
 ### Remaining validation (planned)
 - Late buffer binding size (SPIR-V reflection → min binding size)
@@ -130,6 +131,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.25.6** | 2026-04 | Vulkan command buffer free list (VK-CMD-001): batch alloc, pool reset, enterprise parity |
 | **v0.25.5** | 2026-04 | WASM platform split (Phase 0): _native.go/_browser.go file split, core/hal excluded from WASM |
 | **v0.25.4** | 2026-04 | Late buffer binding validation (VAL-006) + Vulkan relay semaphores (VK-SYNC-001) |
 | **v0.25.3** | 2026-04 | Fix SIGSEGV on large WriteBuffer (#142): maxMemoryAllocationSize enforcement, staging belt auto-chunking, MappedSize bounds checking |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -92,6 +92,7 @@ Pure Go Vulkan 1.0+ implementation using `cgo_import_dynamic` for function loadi
 
 - `vk/` — Low-level Vulkan bindings (generated types, function signatures, loader)
 - `memory/` — GPU memory allocator (buddy allocation, `maxMemoryAllocationSize` enforcement)
+- Command encoder: free list of pre-allocated VkCommandBuffers (batch 16), `vkResetCommandPool` for batch reset (Rust wgpu-hal parity)
 - Platform surface: VkWin32, VkXlib, VkMetal
 
 ### `hal/metal/` — Metal Backend

--- a/hal/vulkan/command.go
+++ b/hal/vulkan/command.go
@@ -33,84 +33,139 @@ func (c *CommandBuffer) Destroy() {
 	cmdBufferResultPool.Put(c)
 }
 
+// allocationGranularity is the number of VkCommandBuffers to batch-allocate
+// when the free list is empty. Matches Rust wgpu-hal ALLOCATION_GRANULARITY.
+// 16 amortizes the cost of vkAllocateCommandBuffers across many BeginEncoding
+// calls and aligns with NVIDIA/ARM best practices for command buffer pooling.
+const allocationGranularity = 16
+
 // CommandEncoder implements hal.CommandEncoder for Vulkan.
+//
+// Uses the free list pattern (Rust wgpu-hal parity): the encoder owns a
+// VkCommandPool and manages a pool of VkCommandBuffer handles internally.
+// BeginEncoding pops from the free list (batch-allocating if empty),
+// EndEncoding detaches the active handle, and ResetAll recycles completed
+// and discarded handles back to the free list with a single vkResetCommandPool.
 //
 // Two ownership modes:
 //   - Standalone (poolManaged=false): After EndEncoding, the encoder detaches its
-//     pool+cmdBuffer to the CommandBuffer result and returns itself to encoderPool
+//     pool to the CommandBuffer result and returns itself to encoderPool
 //     (sync.Pool for struct reuse). FreeCommandBuffer recycles the Vulkan resources.
 //     This is the default mode for user-created command encoders.
 //   - Pool-managed (poolManaged=true): After EndEncoding, the encoder retains
 //     ownership of its VkCommandPool. After GPU completion, ResetAll resets the
-//     pool (restoring the cmdBuffer to initial state) so the encoder can be
-//     reused via the wgpu-level encoder pool. Used by pendingWrites.
+//     pool so the encoder can be reused via the wgpu-level encoder pool.
+//     Used by pendingWrites.
 //
 // Pooled via encoderPool to avoid per-frame heap allocation (VK-PERF-003).
+//
+// Reference: Rust wgpu-hal vulkan/mod.rs:939-965 (struct),
+// vulkan/command.rs:7-192 (begin/end/discard/reset_all).
 type CommandEncoder struct {
-	device      *Device
-	pool        vk.CommandPool
-	cmdBuffer   vk.CommandBuffer
+	device *Device
+	pool   vk.CommandPool
+
+	// active is the current recording VkCommandBuffer. Zero means not recording.
+	// Replaces the old isRecording bool — matches Rust wgpu-hal's self.active
+	// null check pattern (vulkan/command.rs:153).
+	active vk.CommandBuffer
+
+	// free holds available VkCommandBuffers in Vulkan "initial" state.
+	// BeginEncoding pops from here; batch-allocates allocationGranularity
+	// handles via vkAllocateCommandBuffers when empty.
+	free []vk.CommandBuffer
+
+	// discarded holds used VkCommandBuffers that were abandoned via
+	// DiscardEncoding. They could be in any Vulkan state except "pending".
+	// ResetAll moves them back to free after vkResetCommandPool.
+	discarded []vk.CommandBuffer
+
 	label       string
-	isRecording bool
 	poolManaged bool // true when managed by wgpu-level encoder pool
 }
 
 // BeginEncoding begins command recording.
-// Returns an error if the command buffer handle is null (VK-001: prevents SIGSEGV
-// from null VkCommandBuffer dispatch table dereference).
+//
+// Pops a VkCommandBuffer from the free list. If the free list is empty,
+// batch-allocates allocationGranularity (16) command buffers from the pool.
+// This matches Rust wgpu-hal begin_encoding (vulkan/command.rs:122-151).
+//
+// Returns an error if the device is nil or if Vulkan allocation/begin fails.
 func (e *CommandEncoder) BeginEncoding(label string) error {
 	e.label = label
 
-	// VK-001: Validate command buffer handle before use.
-	// A null handle causes SIGSEGV at addr=0x10 when the ICD dereferences
-	// the dispatch table pointer (gogpu#119).
-	if e.cmdBuffer == 0 {
-		return fmt.Errorf("vulkan: BeginEncoding called with null command buffer handle")
-	}
 	if e.device == nil {
 		return fmt.Errorf("vulkan: BeginEncoding called with nil device")
 	}
 
-	// Begin command buffer
+	// Batch-allocate command buffers when free list is empty.
+	if len(e.free) == 0 {
+		allocInfo := vk.CommandBufferAllocateInfo{
+			SType:              vk.StructureTypeCommandBufferAllocateInfo,
+			CommandPool:        e.pool,
+			Level:              vk.CommandBufferLevelPrimary,
+			CommandBufferCount: allocationGranularity,
+		}
+		buffers := make([]vk.CommandBuffer, allocationGranularity)
+		result := e.device.cmds.AllocateCommandBuffers(e.device.handle, &allocInfo, &buffers[0])
+		if result != vk.Success {
+			return fmt.Errorf("vulkan: vkAllocateCommandBuffers failed: %d", result)
+		}
+		e.free = append(e.free, buffers...)
+	}
+
+	// Pop from free list.
+	raw := e.free[len(e.free)-1]
+	e.free = e.free[:len(e.free)-1]
+
+	// VK-001: Validate handle after allocation. goffi returns zeros on nil
+	// function pointer (no crash, no error), so vkAllocateCommandBuffers
+	// could "succeed" with a null handle (gogpu#119).
+	if raw == 0 {
+		return fmt.Errorf("vulkan: allocated command buffer has null handle")
+	}
+
+	// Begin command buffer with ONE_TIME_SUBMIT for per-frame recording.
 	beginInfo := vk.CommandBufferBeginInfo{
 		SType: vk.StructureTypeCommandBufferBeginInfo,
 		Flags: vk.CommandBufferUsageFlags(vk.CommandBufferUsageOneTimeSubmitBit),
 	}
 
-	result := vkBeginCommandBuffer(e.device.cmds, e.cmdBuffer, &beginInfo)
+	result := vkBeginCommandBuffer(e.device.cmds, raw, &beginInfo)
 	if result != vk.Success {
+		// Return the buffer to the free list on failure — it is still in
+		// initial state and can be reused.
+		e.free = append(e.free, raw)
 		return fmt.Errorf("vulkan: vkBeginCommandBuffer failed: %d", result)
 	}
 
-	e.isRecording = true
+	e.active = raw
 	return nil
 }
 
 // EndEncoding finishes command recording and returns a command buffer.
 // Uses sync.Pool for CommandBuffer struct reuse (VK-PERF-004).
 //
-// In standalone mode (default): detaches pool+cmdBuffer to the result and
+// In standalone mode (default): detaches pool to the result and
 // returns the encoder struct to encoderPool for reuse.
 // In pool-managed mode: the encoder retains ownership of its VkCommandPool.
 // After GPU completion, call ResetAll to prepare for the next BeginEncoding cycle.
+//
+// Reference: Rust wgpu-hal end_encoding (vulkan/command.rs:153-163).
 func (e *CommandEncoder) EndEncoding() (hal.CommandBuffer, error) {
-	if !e.isRecording {
+	if e.active == 0 {
 		return nil, fmt.Errorf("vulkan: command encoder is not recording")
 	}
-	if e.cmdBuffer == 0 {
-		return nil, fmt.Errorf("vulkan: EndEncoding called with null command buffer handle")
-	}
 
-	result := vkEndCommandBuffer(e.device.cmds, e.cmdBuffer)
+	result := vkEndCommandBuffer(e.device.cmds, e.active)
 	if result != vk.Success {
 		return nil, fmt.Errorf("vulkan: vkEndCommandBuffer failed: %d", result)
 	}
 
-	e.isRecording = false
-
 	// Reuse CommandBuffer struct from pool (VK-PERF-004).
 	cb := cmdBufferResultPool.Get().(*CommandBuffer)
-	cb.handle = e.cmdBuffer
+	cb.handle = e.active
+	e.active = 0
 
 	if e.poolManaged {
 		// Pool-managed mode: encoder retains VkCommandPool ownership.
@@ -121,53 +176,75 @@ func (e *CommandEncoder) EndEncoding() (hal.CommandBuffer, error) {
 	} else {
 		// Standalone mode: CommandBuffer takes ownership of pool.
 		cb.pool = e.pool
-	}
 
-	if !e.poolManaged {
-		// Standalone mode: detach resources to CommandBuffer, return encoder struct.
+		// Detach resources to CommandBuffer, return encoder struct.
+		// The pool goes with the CommandBuffer; free/discarded buffers
+		// are abandoned (they belong to the pool and will be reset when
+		// the pool is recycled via FreeCommandBuffer).
 		e.device = nil
 		e.pool = 0
-		e.cmdBuffer = 0
+		e.free = e.free[:0]
+		e.discarded = e.discarded[:0]
 		e.label = ""
 		encoderPool.Put(e)
 	}
-	// Pool-managed mode: encoder retains pool+cmdBuffer for ResetAll+reuse.
 
 	return cb, nil
 }
 
-// DiscardEncoding discards the encoder without creating a command buffer.
-// In standalone mode, recycles pool+cmdBuffer pair for reuse.
-// In pool-managed mode, retains resources for the encoder pool.
+// DiscardEncoding discards the current recording without creating a command buffer.
+// The active command buffer is moved to the discarded list for later pool reset.
+// Rust wgpu-hal does NOT call vkEndCommandBuffer on discarded buffers —
+// vkResetCommandPool handles them in any state (vulkan/command.rs:165-173).
+//
+// In standalone mode, recycles the pool and returns the encoder struct.
+// In pool-managed mode, retains resources for ResetAll+reuse.
 func (e *CommandEncoder) DiscardEncoding() {
-	if e.isRecording {
-		// End the command buffer even though we're discarding it.
-		_ = vkEndCommandBuffer(e.device.cmds, e.cmdBuffer)
-		e.isRecording = false
+	if e.active != 0 {
+		e.discarded = append(e.discarded, e.active)
+		e.active = 0
 	}
 
 	if !e.poolManaged {
-		// Standalone mode: recycle pool+buffer pair and encoder struct (VK-POOL-001).
-		if e.device != nil && e.pool != 0 && e.cmdBuffer != 0 {
-			e.device.recycleAllocator(commandAllocator{pool: e.pool, cmdBuffer: e.cmdBuffer})
+		// Standalone mode: recycle pool and encoder struct (VK-POOL-001).
+		// The pool contains all free+discarded buffers; they will be reset
+		// when the pool is recycled via FreeCommandBuffer/acquireAllocator.
+		if e.device != nil && e.pool != 0 {
+			e.device.recyclePool(e.pool)
 		}
 		e.device = nil
 		e.pool = 0
-		e.cmdBuffer = 0
+		e.free = e.free[:0]
+		e.discarded = e.discarded[:0]
 		e.label = ""
 		encoderPool.Put(e)
 	}
 	// Pool-managed mode: encoder retains resources for ResetAll+reuse.
 }
 
-// ResetAll resets the encoder's command pool, restoring the cmdBuffer to initial
-// state. After this call, the encoder is ready for a new BeginEncoding cycle.
-// The commandBuffers parameter is unused — Vulkan resets all buffers in the pool.
+// ResetAll recycles completed command buffers and discarded buffers back to the
+// free list, then resets the entire command pool. After this call, all buffers
+// in the free list are in Vulkan "initial" state, ready for vkBeginCommandBuffer.
+//
+// This is much cheaper than individual vkResetCommandBuffer calls (NVIDIA, ARM).
+// Reference: Rust wgpu-hal reset_all (vulkan/command.rs:175-192).
 func (e *CommandEncoder) ResetAll(commandBuffers []hal.CommandBuffer) {
+	// Recycle completed command buffers back to the free list.
+	for _, cb := range commandBuffers {
+		if vcb, ok := cb.(*CommandBuffer); ok && vcb.handle != 0 {
+			e.free = append(e.free, vcb.handle)
+		}
+	}
+
+	// Recycle discarded buffers.
+	e.free = append(e.free, e.discarded...)
+	e.discarded = e.discarded[:0]
+
+	// Batch reset entire pool — one call resets all command buffers to
+	// initial state. Much cheaper than N individual resets (NVIDIA, ARM docs).
 	if e.device != nil && e.pool != 0 {
 		vkResetCommandPool(e.device.cmds, e.device.handle, e.pool, 0)
 	}
-	_ = commandBuffers // Individual buffers are reset with the pool
 }
 
 // SetPoolManaged marks this encoder as managed by the wgpu-level encoder pool.
@@ -179,22 +256,22 @@ func (e *CommandEncoder) SetPoolManaged(managed bool) {
 }
 
 // Destroy releases the VkCommandPool owned by this encoder.
+// Destroying the pool implicitly frees all command buffers allocated from it.
 // Must be called when the encoder is permanently retired (e.g., device shutdown).
 func (e *CommandEncoder) Destroy() {
 	if e.device != nil && e.pool != 0 {
 		vkDestroyCommandPool(e.device.cmds, e.device.handle, e.pool, nil)
 	}
 	e.pool = 0
-	e.cmdBuffer = 0
+	e.active = 0
+	e.free = nil
+	e.discarded = nil
 	e.device = nil
 }
 
 // TransitionBuffers transitions buffer states for synchronization.
 func (e *CommandEncoder) TransitionBuffers(barriers []hal.BufferBarrier) {
-	if !e.isRecording || len(barriers) == 0 {
-		return
-	}
-	if e.cmdBuffer == 0 {
+	if e.active == 0 || len(barriers) == 0 {
 		return
 	}
 
@@ -228,7 +305,7 @@ func (e *CommandEncoder) TransitionBuffers(barriers []hal.BufferBarrier) {
 	// Use vkCmdPipelineBarrier with buffer memory barriers
 	vkCmdPipelineBarrier(
 		e.device.cmds,
-		e.cmdBuffer,
+		e.active,
 		vk.PipelineStageFlags(vk.PipelineStageAllCommandsBit),
 		vk.PipelineStageFlags(vk.PipelineStageAllCommandsBit),
 		0,      // dependencyFlags
@@ -240,12 +317,7 @@ func (e *CommandEncoder) TransitionBuffers(barriers []hal.BufferBarrier) {
 
 // TransitionTextures transitions texture states for synchronization.
 func (e *CommandEncoder) TransitionTextures(barriers []hal.TextureBarrier) {
-	if !e.isRecording || len(barriers) == 0 {
-		return
-	}
-	// VK-001: Defense-in-depth null guard. Prevents SIGSEGV at addr=0x10
-	// if cmdBuffer is somehow null while isRecording is true (gogpu#119).
-	if e.cmdBuffer == 0 {
+	if e.active == 0 || len(barriers) == 0 {
 		return
 	}
 
@@ -284,7 +356,7 @@ func (e *CommandEncoder) TransitionTextures(barriers []hal.TextureBarrier) {
 
 	vkCmdPipelineBarrier(
 		e.device.cmds,
-		e.cmdBuffer,
+		e.active,
 		vk.PipelineStageFlags(vk.PipelineStageAllCommandsBit),
 		vk.PipelineStageFlags(vk.PipelineStageAllCommandsBit),
 		0,
@@ -296,7 +368,7 @@ func (e *CommandEncoder) TransitionTextures(barriers []hal.TextureBarrier) {
 
 // ClearBuffer clears a buffer region to zero.
 func (e *CommandEncoder) ClearBuffer(buffer hal.Buffer, offset, size uint64) {
-	if !e.isRecording || e.cmdBuffer == 0 {
+	if e.active == 0 {
 		return
 	}
 
@@ -306,12 +378,12 @@ func (e *CommandEncoder) ClearBuffer(buffer hal.Buffer, offset, size uint64) {
 	}
 
 	// vkCmdFillBuffer fills with a 32-bit value (0 for zero fill)
-	vkCmdFillBuffer(e.device.cmds, e.cmdBuffer, buf.handle, vk.DeviceSize(offset), vk.DeviceSize(size), 0)
+	vkCmdFillBuffer(e.device.cmds, e.active, buf.handle, vk.DeviceSize(offset), vk.DeviceSize(size), 0)
 }
 
 // CopyBufferToBuffer copies data between buffers.
 func (e *CommandEncoder) CopyBufferToBuffer(src, dst hal.Buffer, regions []hal.BufferCopy) {
-	if !e.isRecording || e.cmdBuffer == 0 {
+	if e.active == 0 {
 		return
 	}
 
@@ -330,7 +402,7 @@ func (e *CommandEncoder) CopyBufferToBuffer(src, dst hal.Buffer, regions []hal.B
 		}
 	}
 
-	vkCmdCopyBuffer(e.device.cmds, e.cmdBuffer, srcBuf.handle, dstBuf.handle, uint32(len(vkRegions)), &vkRegions[0])
+	vkCmdCopyBuffer(e.device.cmds, e.active, srcBuf.handle, dstBuf.handle, uint32(len(vkRegions)), &vkRegions[0])
 }
 
 // blockCopySize returns the number of bytes per block for a given texture format.
@@ -421,7 +493,7 @@ func convertBufferImageCopyRegions(regions []hal.BufferTextureCopy, format gputy
 
 // CopyBufferToTexture copies data from a buffer to a texture.
 func (e *CommandEncoder) CopyBufferToTexture(src hal.Buffer, dst hal.Texture, regions []hal.BufferTextureCopy) {
-	if !e.isRecording || e.cmdBuffer == 0 {
+	if e.active == 0 {
 		return
 	}
 
@@ -434,7 +506,7 @@ func (e *CommandEncoder) CopyBufferToTexture(src hal.Buffer, dst hal.Texture, re
 	vkRegions := convertBufferImageCopyRegions(regions, dstTex.format)
 	vkCmdCopyBufferToImage(
 		e.device.cmds,
-		e.cmdBuffer,
+		e.active,
 		srcBuf.handle,
 		dstTex.handle,
 		vk.ImageLayoutTransferDstOptimal,
@@ -445,7 +517,7 @@ func (e *CommandEncoder) CopyBufferToTexture(src hal.Buffer, dst hal.Texture, re
 
 // CopyTextureToBuffer copies data from a texture to a buffer.
 func (e *CommandEncoder) CopyTextureToBuffer(src hal.Texture, dst hal.Buffer, regions []hal.BufferTextureCopy) {
-	if !e.isRecording || e.cmdBuffer == 0 {
+	if e.active == 0 {
 		return
 	}
 
@@ -458,7 +530,7 @@ func (e *CommandEncoder) CopyTextureToBuffer(src hal.Texture, dst hal.Buffer, re
 	vkRegions := convertBufferImageCopyRegions(regions, srcTex.format)
 	vkCmdCopyImageToBuffer(
 		e.device.cmds,
-		e.cmdBuffer,
+		e.active,
 		srcTex.handle,
 		vk.ImageLayoutTransferSrcOptimal,
 		dstBuf.handle,
@@ -469,7 +541,7 @@ func (e *CommandEncoder) CopyTextureToBuffer(src hal.Texture, dst hal.Buffer, re
 
 // CopyTextureToTexture copies data between textures.
 func (e *CommandEncoder) CopyTextureToTexture(src, dst hal.Texture, regions []hal.TextureCopy) {
-	if !e.isRecording || e.cmdBuffer == 0 {
+	if e.active == 0 {
 		return
 	}
 
@@ -514,7 +586,7 @@ func (e *CommandEncoder) CopyTextureToTexture(src, dst hal.Texture, regions []ha
 
 	vkCmdCopyImage(
 		e.device.cmds,
-		e.cmdBuffer,
+		e.active,
 		srcTex.handle,
 		vk.ImageLayoutTransferSrcOptimal,
 		dstTex.handle,
@@ -529,7 +601,7 @@ func (e *CommandEncoder) CopyTextureToTexture(src, dst hal.Texture, regions []ha
 // This uses vkCmdCopyQueryPoolResults under the hood.
 func (e *CommandEncoder) ResolveQuerySet(querySet hal.QuerySet, firstQuery, queryCount uint32, destination hal.Buffer, destinationOffset uint64) {
 	qs, ok := querySet.(*QuerySet)
-	if !ok || qs.pool == 0 || !e.isRecording || e.cmdBuffer == 0 {
+	if !ok || qs.pool == 0 || e.active == 0 {
 		return
 	}
 	buf, ok := destination.(*Buffer)
@@ -545,7 +617,7 @@ func (e *CommandEncoder) ResolveQuerySet(querySet hal.QuerySet, firstQuery, quer
 	}
 	vkCmdPipelineBarrier(
 		e.device.cmds,
-		e.cmdBuffer,
+		e.active,
 		vk.PipelineStageFlags(vk.PipelineStageAllCommandsBit),
 		vk.PipelineStageFlags(vk.PipelineStageTransferBit),
 		0,
@@ -559,7 +631,7 @@ func (e *CommandEncoder) ResolveQuerySet(querySet hal.QuerySet, firstQuery, quer
 	// Flags: VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT.
 	vkCmdCopyQueryPoolResults(
 		e.device.cmds,
-		e.cmdBuffer,
+		e.active,
 		qs.pool,
 		firstQuery,
 		queryCount,
@@ -583,7 +655,7 @@ func (e *CommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.Ren
 	rpe.renderPass = 0
 	rpe.framebuffer = 0
 
-	if !e.isRecording || e.cmdBuffer == 0 || len(desc.ColorAttachments) == 0 {
+	if e.active == 0 || len(desc.ColorAttachments) == 0 {
 		return rpe
 	}
 
@@ -728,7 +800,7 @@ func (e *CommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.Ren
 		PClearValues:    &clearValues[0],
 	}
 
-	vkCmdBeginRenderPass(e.device.cmds, e.cmdBuffer, &renderPassBegin, vk.SubpassContentsInline)
+	vkCmdBeginRenderPass(e.device.cmds, e.active, &renderPassBegin, vk.SubpassContentsInline)
 	runtime.KeepAlive(clearValues)
 
 	// Set default viewport and scissor for the render area.
@@ -752,19 +824,19 @@ func (e *CommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.Ren
 		MinDepth: 0.0,
 		MaxDepth: 1.0,
 	}
-	vkCmdSetViewport(e.device.cmds, e.cmdBuffer, 0, 1, &viewport)
+	vkCmdSetViewport(e.device.cmds, e.active, 0, 1, &viewport)
 
 	scissor := vk.Rect2D{
 		Offset: vk.Offset2D{X: 0, Y: 0},
 		Extent: vk.Extent2D{Width: max(renderWidth, 1), Height: max(renderHeight, 1)},
 	}
-	vkCmdSetScissor(e.device.cmds, e.cmdBuffer, 0, 1, &scissor)
+	vkCmdSetScissor(e.device.cmds, e.active, 0, 1, &scissor)
 
 	// Set default blend constants and stencil reference.
 	// All pipelines declare these as dynamic state (matching Rust wgpu),
 	// so they must be initialized before any draw call (VK-PIPE-001).
-	vkCmdSetBlendConstants(e.device.cmds, e.cmdBuffer, &[4]float32{0, 0, 0, 0})
-	vkCmdSetStencilReference(e.device.cmds, e.cmdBuffer,
+	vkCmdSetBlendConstants(e.device.cmds, e.active, &[4]float32{0, 0, 0, 0})
+	vkCmdSetStencilReference(e.device.cmds, e.active,
 		vk.StencilFaceFlags(vk.StencilFaceFrontAndBack), 0)
 
 	return rpe
@@ -779,16 +851,16 @@ func (e *CommandEncoder) BeginComputePass(desc *hal.ComputePassDescriptor) hal.C
 	cpe.timestampWrites = nil
 
 	// Write beginning-of-pass timestamp if requested.
-	// VK-001: Defense-in-depth — check both isRecording and cmdBuffer != 0
-	// to prevent SIGSEGV from null dispatch table dereference (gogpu#119).
+	// active != 0 check prevents SIGSEGV from null dispatch table
+	// dereference (VK-001, gogpu#119).
 	if desc != nil && desc.TimestampWrites != nil {
 		cpe.timestampWrites = desc.TimestampWrites
 		if qs, ok := desc.TimestampWrites.QuerySet.(*QuerySet); ok && qs.pool != 0 {
-			if desc.TimestampWrites.BeginningOfPassWriteIndex != nil && e.isRecording && e.cmdBuffer != 0 {
+			if desc.TimestampWrites.BeginningOfPassWriteIndex != nil && e.active != 0 {
 				idx := *desc.TimestampWrites.BeginningOfPassWriteIndex
-				e.device.cmds.CmdResetQueryPool(e.cmdBuffer, qs.pool, idx, 1)
+				e.device.cmds.CmdResetQueryPool(e.active, qs.pool, idx, 1)
 				e.device.cmds.CmdWriteTimestamp(
-					e.cmdBuffer,
+					e.active,
 					vk.PipelineStageTopOfPipeBit,
 					qs.pool,
 					idx,
@@ -814,13 +886,13 @@ type RenderPassEncoder struct {
 // End finishes the render pass.
 // Returns the encoder to the pool for reuse (VK-PERF-006).
 func (e *RenderPassEncoder) End() {
-	if !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if e.encoder.active == 0 {
 		return
 	}
 
 	// Use vkCmdEndRenderPass (VkRenderPass handles layout transitions automatically
 	// via FinalLayout in AttachmentDescription)
-	vkCmdEndRenderPass(e.encoder.device.cmds, e.encoder.cmdBuffer)
+	vkCmdEndRenderPass(e.encoder.device.cmds, e.encoder.active)
 
 	// Return to pool for reuse.
 	e.encoder = nil
@@ -834,17 +906,17 @@ func (e *RenderPassEncoder) End() {
 // SetPipeline sets the render pipeline.
 func (e *RenderPassEncoder) SetPipeline(pipeline hal.RenderPipeline) {
 	p, ok := pipeline.(*RenderPipeline)
-	if !ok || !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if !ok || e.encoder.active == 0 {
 		return
 	}
 	e.pipeline = p
-	vkCmdBindPipeline(e.encoder.device.cmds, e.encoder.cmdBuffer, vk.PipelineBindPointGraphics, p.handle)
+	vkCmdBindPipeline(e.encoder.device.cmds, e.encoder.active, vk.PipelineBindPointGraphics, p.handle)
 }
 
 // SetBindGroup sets a bind group.
 func (e *RenderPassEncoder) SetBindGroup(index uint32, group hal.BindGroup, offsets []uint32) {
 	bg, ok := group.(*BindGroup)
-	if !ok || !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if !ok || e.encoder.active == 0 {
 		return
 	}
 
@@ -855,7 +927,7 @@ func (e *RenderPassEncoder) SetBindGroup(index uint32, group hal.BindGroup, offs
 
 	vkCmdBindDescriptorSets(
 		e.encoder.device.cmds,
-		e.encoder.cmdBuffer,
+		e.encoder.active,
 		vk.PipelineBindPointGraphics,
 		e.pipeline.layout,
 		index,
@@ -870,7 +942,7 @@ func (e *RenderPassEncoder) SetBindGroup(index uint32, group hal.BindGroup, offs
 // Uses stack variables instead of slice allocations (VK-PERF-007).
 func (e *RenderPassEncoder) SetVertexBuffer(slot uint32, buffer hal.Buffer, offset uint64) {
 	buf, ok := buffer.(*Buffer)
-	if !ok || !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if !ok || e.encoder.active == 0 {
 		return
 	}
 
@@ -878,13 +950,13 @@ func (e *RenderPassEncoder) SetVertexBuffer(slot uint32, buffer hal.Buffer, offs
 	vkOffset := vk.DeviceSize(offset)
 	vkBuffer := buf.handle
 
-	vkCmdBindVertexBuffers(e.encoder.device.cmds, e.encoder.cmdBuffer, slot, 1, &vkBuffer, &vkOffset)
+	vkCmdBindVertexBuffers(e.encoder.device.cmds, e.encoder.active, slot, 1, &vkBuffer, &vkOffset)
 }
 
 // SetIndexBuffer sets the index buffer.
 func (e *RenderPassEncoder) SetIndexBuffer(buffer hal.Buffer, format gputypes.IndexFormat, offset uint64) {
 	buf, ok := buffer.(*Buffer)
-	if !ok || !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if !ok || e.encoder.active == 0 {
 		return
 	}
 
@@ -894,13 +966,13 @@ func (e *RenderPassEncoder) SetIndexBuffer(buffer hal.Buffer, format gputypes.In
 		indexType = vk.IndexTypeUint32
 	}
 
-	vkCmdBindIndexBuffer(e.encoder.device.cmds, e.encoder.cmdBuffer, buf.handle, vk.DeviceSize(offset), indexType)
+	vkCmdBindIndexBuffer(e.encoder.device.cmds, e.encoder.active, buf.handle, vk.DeviceSize(offset), indexType)
 }
 
 // SetViewport sets the viewport.
 // NOTE: Applies Y-flip for WebGPU/OpenGL coordinate system compatibility (matches Rust wgpu).
 func (e *RenderPassEncoder) SetViewport(x, y, width, height, minDepth, maxDepth float32) {
-	if !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if e.encoder.active == 0 {
 		return
 	}
 
@@ -914,12 +986,12 @@ func (e *RenderPassEncoder) SetViewport(x, y, width, height, minDepth, maxDepth 
 		MaxDepth: maxDepth,
 	}
 
-	vkCmdSetViewport(e.encoder.device.cmds, e.encoder.cmdBuffer, 0, 1, &viewport)
+	vkCmdSetViewport(e.encoder.device.cmds, e.encoder.active, 0, 1, &viewport)
 }
 
 // SetScissorRect sets the scissor rectangle.
 func (e *RenderPassEncoder) SetScissorRect(x, y, width, height uint32) {
-	if !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if e.encoder.active == 0 {
 		return
 	}
 
@@ -928,12 +1000,12 @@ func (e *RenderPassEncoder) SetScissorRect(x, y, width, height uint32) {
 		Extent: vk.Extent2D{Width: width, Height: height},
 	}
 
-	vkCmdSetScissor(e.encoder.device.cmds, e.encoder.cmdBuffer, 0, 1, &scissor)
+	vkCmdSetScissor(e.encoder.device.cmds, e.encoder.active, 0, 1, &scissor)
 }
 
 // SetBlendConstant sets the blend constant.
 func (e *RenderPassEncoder) SetBlendConstant(color *gputypes.Color) {
-	if !e.encoder.isRecording || e.encoder.cmdBuffer == 0 || color == nil {
+	if e.encoder.active == 0 || color == nil {
 		return
 	}
 
@@ -944,66 +1016,66 @@ func (e *RenderPassEncoder) SetBlendConstant(color *gputypes.Color) {
 		float32(color.A),
 	}
 
-	vkCmdSetBlendConstants(e.encoder.device.cmds, e.encoder.cmdBuffer, &blendConstants)
+	vkCmdSetBlendConstants(e.encoder.device.cmds, e.encoder.active, &blendConstants)
 }
 
 // SetStencilReference sets the stencil reference value.
 func (e *RenderPassEncoder) SetStencilReference(ref uint32) {
-	if !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if e.encoder.active == 0 {
 		return
 	}
 
 	// Set for both front and back faces
-	vkCmdSetStencilReference(e.encoder.device.cmds, e.encoder.cmdBuffer, vk.StencilFaceFlags(vk.StencilFaceFrontAndBack), ref)
+	vkCmdSetStencilReference(e.encoder.device.cmds, e.encoder.active, vk.StencilFaceFlags(vk.StencilFaceFrontAndBack), ref)
 }
 
 // Draw draws primitives.
 func (e *RenderPassEncoder) Draw(vertexCount, instanceCount, firstVertex, firstInstance uint32) {
-	if !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if e.encoder.active == 0 {
 		return
 	}
-	vkCmdDraw(e.encoder.device.cmds, e.encoder.cmdBuffer, vertexCount, instanceCount, firstVertex, firstInstance)
+	vkCmdDraw(e.encoder.device.cmds, e.encoder.active, vertexCount, instanceCount, firstVertex, firstInstance)
 }
 
 // DrawIndexed draws indexed primitives.
 func (e *RenderPassEncoder) DrawIndexed(indexCount, instanceCount, firstIndex uint32, baseVertex int32, firstInstance uint32) {
-	if !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if e.encoder.active == 0 {
 		return
 	}
 
-	vkCmdDrawIndexed(e.encoder.device.cmds, e.encoder.cmdBuffer, indexCount, instanceCount, firstIndex, baseVertex, firstInstance)
+	vkCmdDrawIndexed(e.encoder.device.cmds, e.encoder.active, indexCount, instanceCount, firstIndex, baseVertex, firstInstance)
 }
 
 // DrawIndirect draws primitives with GPU-generated parameters.
 func (e *RenderPassEncoder) DrawIndirect(buffer hal.Buffer, offset uint64) {
 	buf, ok := buffer.(*Buffer)
-	if !ok || !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if !ok || e.encoder.active == 0 {
 		return
 	}
 
-	vkCmdDrawIndirect(e.encoder.device.cmds, e.encoder.cmdBuffer, buf.handle, vk.DeviceSize(offset), 1, 0)
+	vkCmdDrawIndirect(e.encoder.device.cmds, e.encoder.active, buf.handle, vk.DeviceSize(offset), 1, 0)
 }
 
 // DrawIndexedIndirect draws indexed primitives with GPU-generated parameters.
 func (e *RenderPassEncoder) DrawIndexedIndirect(buffer hal.Buffer, offset uint64) {
 	buf, ok := buffer.(*Buffer)
-	if !ok || !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if !ok || e.encoder.active == 0 {
 		return
 	}
 
-	vkCmdDrawIndexedIndirect(e.encoder.device.cmds, e.encoder.cmdBuffer, buf.handle, vk.DeviceSize(offset), 1, 0)
+	vkCmdDrawIndexedIndirect(e.encoder.device.cmds, e.encoder.active, buf.handle, vk.DeviceSize(offset), 1, 0)
 }
 
 // ExecuteBundle executes a pre-recorded render bundle.
 func (e *RenderPassEncoder) ExecuteBundle(bundle hal.RenderBundle) {
 	vkBundle, ok := bundle.(*RenderBundle)
-	if !ok || vkBundle == nil || !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if !ok || vkBundle == nil || e.encoder.active == 0 {
 		return
 	}
 
 	// Execute the secondary command buffer
 	e.encoder.device.cmds.CmdExecuteCommands(
-		e.encoder.cmdBuffer,
+		e.encoder.active,
 		1,
 		&vkBundle.commandBuffer,
 	)
@@ -1024,9 +1096,9 @@ type ComputePassEncoder struct {
 // writing, causing stale/zero reads.
 // Returns the encoder to the pool for reuse (VK-PERF-005).
 func (e *ComputePassEncoder) End() {
-	// VK-001: Defense-in-depth — check both isRecording and cmdBuffer != 0
-	// to prevent SIGSEGV from null dispatch table dereference (gogpu#119).
-	if e.encoder == nil || !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	// VK-001: Defense-in-depth — active == 0 check prevents SIGSEGV from
+	// null dispatch table dereference (gogpu#119).
+	if e.encoder == nil || e.encoder.active == 0 {
 		return
 	}
 
@@ -1035,9 +1107,9 @@ func (e *ComputePassEncoder) End() {
 		if qs, ok := e.timestampWrites.QuerySet.(*QuerySet); ok && qs.pool != 0 {
 			if e.timestampWrites.EndOfPassWriteIndex != nil {
 				idx := *e.timestampWrites.EndOfPassWriteIndex
-				e.encoder.device.cmds.CmdResetQueryPool(e.encoder.cmdBuffer, qs.pool, idx, 1)
+				e.encoder.device.cmds.CmdResetQueryPool(e.encoder.active, qs.pool, idx, 1)
 				e.encoder.device.cmds.CmdWriteTimestamp(
-					e.encoder.cmdBuffer,
+					e.encoder.active,
 					vk.PipelineStageBottomOfPipeBit,
 					qs.pool,
 					idx,
@@ -1054,7 +1126,7 @@ func (e *ComputePassEncoder) End() {
 	}
 	vkCmdPipelineBarrier(
 		e.encoder.device.cmds,
-		e.encoder.cmdBuffer,
+		e.encoder.active,
 		vk.PipelineStageFlags(vk.PipelineStageComputeShaderBit),
 		vk.PipelineStageFlags(vk.PipelineStageComputeShaderBit|vk.PipelineStageTransferBit|vk.PipelineStageHostBit),
 		0,
@@ -1073,18 +1145,18 @@ func (e *ComputePassEncoder) End() {
 // SetPipeline sets the compute pipeline.
 func (e *ComputePassEncoder) SetPipeline(pipeline hal.ComputePipeline) {
 	p, ok := pipeline.(*ComputePipeline)
-	if !ok || !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if !ok || e.encoder.active == 0 {
 		return
 	}
 	e.pipeline = p
 
-	vkCmdBindPipeline(e.encoder.device.cmds, e.encoder.cmdBuffer, vk.PipelineBindPointCompute, p.handle)
+	vkCmdBindPipeline(e.encoder.device.cmds, e.encoder.active, vk.PipelineBindPointCompute, p.handle)
 }
 
 // SetBindGroup sets a bind group.
 func (e *ComputePassEncoder) SetBindGroup(index uint32, group hal.BindGroup, offsets []uint32) {
 	bg, ok := group.(*BindGroup)
-	if !ok || !e.encoder.isRecording || e.encoder.cmdBuffer == 0 || e.pipeline == nil {
+	if !ok || e.encoder.active == 0 || e.pipeline == nil {
 		return
 	}
 
@@ -1095,7 +1167,7 @@ func (e *ComputePassEncoder) SetBindGroup(index uint32, group hal.BindGroup, off
 
 	vkCmdBindDescriptorSets(
 		e.encoder.device.cmds,
-		e.encoder.cmdBuffer,
+		e.encoder.active,
 		vk.PipelineBindPointCompute,
 		e.pipeline.layout,
 		index,
@@ -1108,21 +1180,21 @@ func (e *ComputePassEncoder) SetBindGroup(index uint32, group hal.BindGroup, off
 
 // Dispatch dispatches compute work.
 func (e *ComputePassEncoder) Dispatch(x, y, z uint32) {
-	if !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if e.encoder.active == 0 {
 		return
 	}
 
-	vkCmdDispatch(e.encoder.device.cmds, e.encoder.cmdBuffer, x, y, z)
+	vkCmdDispatch(e.encoder.device.cmds, e.encoder.active, x, y, z)
 }
 
 // DispatchIndirect dispatches compute work with GPU-generated parameters.
 func (e *ComputePassEncoder) DispatchIndirect(buffer hal.Buffer, offset uint64) {
 	buf, ok := buffer.(*Buffer)
-	if !ok || !e.encoder.isRecording || e.encoder.cmdBuffer == 0 {
+	if !ok || e.encoder.active == 0 {
 		return
 	}
 
-	vkCmdDispatchIndirect(e.encoder.device.cmds, e.encoder.cmdBuffer, buf.handle, vk.DeviceSize(offset))
+	vkCmdDispatchIndirect(e.encoder.device.cmds, e.encoder.active, buf.handle, vk.DeviceSize(offset))
 }
 
 // --- Helper functions ---

--- a/hal/vulkan/command_nullguard_test.go
+++ b/hal/vulkan/command_nullguard_test.go
@@ -10,33 +10,14 @@ import (
 
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/hal"
+	"github.com/gogpu/wgpu/hal/vulkan/vk"
 )
-
-// TestBeginEncodingNullCmdBuffer verifies that BeginEncoding returns an error
-// when the command buffer handle is null (VK-001).
-func TestBeginEncodingNullCmdBuffer(t *testing.T) {
-	enc := &CommandEncoder{
-		device:    &Device{},
-		cmdBuffer: 0, // null handle
-	}
-
-	err := enc.BeginEncoding("test")
-	if err == nil {
-		t.Fatal("BeginEncoding with null cmdBuffer should return error")
-	}
-
-	expected := "vulkan: BeginEncoding called with null command buffer handle"
-	if err.Error() != expected {
-		t.Errorf("error = %q, want %q", err.Error(), expected)
-	}
-}
 
 // TestBeginEncodingNilDevice verifies that BeginEncoding returns an error
 // when the device is nil (VK-001).
 func TestBeginEncodingNilDevice(t *testing.T) {
 	enc := &CommandEncoder{
-		device:    nil,
-		cmdBuffer: 42, // non-null handle
+		device: nil,
 	}
 
 	err := enc.BeginEncoding("test")
@@ -50,33 +31,12 @@ func TestBeginEncodingNilDevice(t *testing.T) {
 	}
 }
 
-// TestEndEncodingNullCmdBuffer verifies that EndEncoding returns an error
-// when the command buffer handle is null (VK-001).
-func TestEndEncodingNullCmdBuffer(t *testing.T) {
-	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0, // null handle
-		isRecording: true,
-	}
-
-	_, err := enc.EndEncoding()
-	if err == nil {
-		t.Fatal("EndEncoding with null cmdBuffer should return error")
-	}
-
-	expected := "vulkan: EndEncoding called with null command buffer handle"
-	if err.Error() != expected {
-		t.Errorf("error = %q, want %q", err.Error(), expected)
-	}
-}
-
 // TestEndEncodingNotRecording verifies that EndEncoding returns an error
-// when the encoder is not recording.
+// when the encoder is not recording (active == 0).
 func TestEndEncodingNotRecording(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   42,
-		isRecording: false,
+		device: &Device{},
+		active: 0, // not recording
 	}
 
 	_, err := enc.EndEncoding()
@@ -90,28 +50,26 @@ func TestEndEncodingNotRecording(t *testing.T) {
 	}
 }
 
-// TestTransitionTexturesNullCmdBuffer verifies that TransitionTextures
-// silently returns when cmdBuffer is null (VK-001 defense-in-depth).
-func TestTransitionTexturesNullCmdBuffer(t *testing.T) {
+// TestTransitionTexturesNullActive verifies that TransitionTextures
+// silently returns when active is 0 (VK-001 defense-in-depth).
+func TestTransitionTexturesNullActive(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0,
-		isRecording: true, // Simulates inconsistent state
+		device: &Device{},
+		active: 0,
 	}
 
-	// Should not panic — defense-in-depth guard catches null handle.
+	// Should not panic — active == 0 guard catches null handle.
 	enc.TransitionTextures([]hal.TextureBarrier{
 		{}, // dummy barrier
 	})
 }
 
 // TestTransitionTexturesNotRecording verifies that TransitionTextures
-// silently returns when not recording.
+// silently returns when not recording (active == 0).
 func TestTransitionTexturesNotRecording(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   42,
-		isRecording: false,
+		device: &Device{},
+		active: 0,
 	}
 
 	// Should not panic.
@@ -120,13 +78,12 @@ func TestTransitionTexturesNotRecording(t *testing.T) {
 	})
 }
 
-// TestTransitionBuffersNullCmdBuffer verifies that TransitionBuffers
-// silently returns when cmdBuffer is null (VK-001 defense-in-depth).
-func TestTransitionBuffersNullCmdBuffer(t *testing.T) {
+// TestTransitionBuffersNullActive verifies that TransitionBuffers
+// silently returns when active is 0 (VK-001 defense-in-depth).
+func TestTransitionBuffersNullActive(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0,
-		isRecording: true,
+		device: &Device{},
+		active: 0,
 	}
 
 	// Should not panic.
@@ -135,26 +92,24 @@ func TestTransitionBuffersNullCmdBuffer(t *testing.T) {
 	})
 }
 
-// TestClearBufferNullCmdBuffer verifies that ClearBuffer silently returns
-// when cmdBuffer is null (VK-001 defense-in-depth).
-func TestClearBufferNullCmdBuffer(t *testing.T) {
+// TestClearBufferNullActive verifies that ClearBuffer silently returns
+// when active is 0 (VK-001 defense-in-depth).
+func TestClearBufferNullActive(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0,
-		isRecording: true,
+		device: &Device{},
+		active: 0,
 	}
 
 	// Should not panic.
 	enc.ClearBuffer(&Buffer{handle: 1}, 0, 256)
 }
 
-// TestRenderPassEncoderDrawNullCmdBuffer verifies that Draw silently returns
-// when the underlying command buffer is null (VK-001 defense-in-depth).
-func TestRenderPassEncoderDrawNullCmdBuffer(t *testing.T) {
+// TestRenderPassEncoderDrawNullActive verifies that Draw silently returns
+// when the underlying active command buffer is 0 (VK-001 defense-in-depth).
+func TestRenderPassEncoderDrawNullActive(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0,
-		isRecording: true,
+		device: &Device{},
+		active: 0,
 	}
 	rpe := &RenderPassEncoder{encoder: enc}
 
@@ -162,13 +117,12 @@ func TestRenderPassEncoderDrawNullCmdBuffer(t *testing.T) {
 	rpe.Draw(3, 1, 0, 0)
 }
 
-// TestRenderPassEncoderEndNullCmdBuffer verifies that End silently returns
-// when the underlying command buffer is null (VK-001 defense-in-depth).
-func TestRenderPassEncoderEndNullCmdBuffer(t *testing.T) {
+// TestRenderPassEncoderEndNullActive verifies that End silently returns
+// when the underlying active command buffer is 0 (VK-001 defense-in-depth).
+func TestRenderPassEncoderEndNullActive(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0,
-		isRecording: true,
+		device: &Device{},
+		active: 0,
 	}
 	rpe := &RenderPassEncoder{encoder: enc}
 
@@ -176,13 +130,12 @@ func TestRenderPassEncoderEndNullCmdBuffer(t *testing.T) {
 	rpe.End()
 }
 
-// TestComputePassEncoderEndNullCmdBuffer verifies that End silently returns
-// when the underlying command buffer is null (VK-001 defense-in-depth).
-func TestComputePassEncoderEndNullCmdBuffer(t *testing.T) {
+// TestComputePassEncoderEndNullActive verifies that End silently returns
+// when the underlying active command buffer is 0 (VK-001 defense-in-depth).
+func TestComputePassEncoderEndNullActive(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0,
-		isRecording: true,
+		device: &Device{},
+		active: 0,
 	}
 	cpe := &ComputePassEncoder{encoder: enc}
 
@@ -190,13 +143,12 @@ func TestComputePassEncoderEndNullCmdBuffer(t *testing.T) {
 	cpe.End()
 }
 
-// TestComputePassEncoderDispatchNullCmdBuffer verifies that Dispatch silently
-// returns when the underlying command buffer is null (VK-001 defense-in-depth).
-func TestComputePassEncoderDispatchNullCmdBuffer(t *testing.T) {
+// TestComputePassEncoderDispatchNullActive verifies that Dispatch silently
+// returns when the underlying active command buffer is 0 (VK-001 defense-in-depth).
+func TestComputePassEncoderDispatchNullActive(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0,
-		isRecording: true,
+		device: &Device{},
+		active: 0,
 	}
 	cpe := &ComputePassEncoder{encoder: enc}
 
@@ -204,13 +156,12 @@ func TestComputePassEncoderDispatchNullCmdBuffer(t *testing.T) {
 	cpe.Dispatch(1, 1, 1)
 }
 
-// TestRenderPassEncoderSetViewportNullCmdBuffer verifies that SetViewport
-// silently returns when the command buffer is null (VK-001 defense-in-depth).
-func TestRenderPassEncoderSetViewportNullCmdBuffer(t *testing.T) {
+// TestRenderPassEncoderSetViewportNullActive verifies that SetViewport
+// silently returns when active is 0 (VK-001 defense-in-depth).
+func TestRenderPassEncoderSetViewportNullActive(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0,
-		isRecording: true,
+		device: &Device{},
+		active: 0,
 	}
 	rpe := &RenderPassEncoder{encoder: enc}
 
@@ -218,13 +169,12 @@ func TestRenderPassEncoderSetViewportNullCmdBuffer(t *testing.T) {
 	rpe.SetViewport(0, 0, 800, 600, 0, 1)
 }
 
-// TestRenderPassEncoderSetScissorNullCmdBuffer verifies that SetScissorRect
-// silently returns when the command buffer is null (VK-001 defense-in-depth).
-func TestRenderPassEncoderSetScissorNullCmdBuffer(t *testing.T) {
+// TestRenderPassEncoderSetScissorNullActive verifies that SetScissorRect
+// silently returns when active is 0 (VK-001 defense-in-depth).
+func TestRenderPassEncoderSetScissorNullActive(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0,
-		isRecording: true,
+		device: &Device{},
+		active: 0,
 	}
 	rpe := &RenderPassEncoder{encoder: enc}
 
@@ -232,13 +182,12 @@ func TestRenderPassEncoderSetScissorNullCmdBuffer(t *testing.T) {
 	rpe.SetScissorRect(0, 0, 800, 600)
 }
 
-// TestCopyBufferToBufferNullCmdBuffer verifies that CopyBufferToBuffer
-// silently returns when cmdBuffer is null (VK-001 defense-in-depth).
-func TestCopyBufferToBufferNullCmdBuffer(t *testing.T) {
+// TestCopyBufferToBufferNullActive verifies that CopyBufferToBuffer
+// silently returns when active is 0 (VK-001 defense-in-depth).
+func TestCopyBufferToBufferNullActive(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0,
-		isRecording: true,
+		device: &Device{},
+		active: 0,
 	}
 
 	// Should not panic.
@@ -247,13 +196,12 @@ func TestCopyBufferToBufferNullCmdBuffer(t *testing.T) {
 	})
 }
 
-// TestBeginRenderPassNullCmdBuffer verifies that BeginRenderPass returns
-// an empty encoder when cmdBuffer is null (VK-001 defense-in-depth).
-func TestBeginRenderPassNullCmdBuffer(t *testing.T) {
+// TestBeginRenderPassNullActive verifies that BeginRenderPass returns
+// an empty encoder when active is 0 (VK-001 defense-in-depth).
+func TestBeginRenderPassNullActive(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0,
-		isRecording: true,
+		device: &Device{},
+		active: 0,
 	}
 
 	rpe := enc.BeginRenderPass(&hal.RenderPassDescriptor{
@@ -266,19 +214,77 @@ func TestBeginRenderPassNullCmdBuffer(t *testing.T) {
 
 	// Should return a non-nil encoder that does nothing.
 	if rpe == nil {
-		t.Fatal("BeginRenderPass should return non-nil encoder even with null cmdBuffer")
+		t.Fatal("BeginRenderPass should return non-nil encoder even with null active")
 	}
 }
 
-// TestDiscardEncodingNullCmdBuffer verifies that DiscardEncoding does not
-// panic when cmdBuffer is null.
-func TestDiscardEncodingNullCmdBuffer(t *testing.T) {
+// TestDiscardEncodingNotRecording verifies that DiscardEncoding does not
+// panic when active is 0 (not recording).
+func TestDiscardEncodingNotRecording(t *testing.T) {
 	enc := &CommandEncoder{
-		device:      &Device{},
-		cmdBuffer:   0,
-		isRecording: false,
+		device: &Device{},
+		active: 0,
 	}
 
 	// Should not panic.
 	enc.DiscardEncoding()
+}
+
+// TestDiscardEncodingTracksActive verifies that DiscardEncoding moves the
+// active command buffer to the discarded list (VK-CMD-001).
+func TestDiscardEncodingTracksActive(t *testing.T) {
+	enc := &CommandEncoder{
+		device:      &Device{},
+		active:      42, // simulated active handle
+		poolManaged: true,
+	}
+
+	enc.DiscardEncoding()
+
+	if enc.active != 0 {
+		t.Errorf("active = %d, want 0 after discard", enc.active)
+	}
+	if len(enc.discarded) != 1 || enc.discarded[0] != 42 {
+		t.Errorf("discarded = %v, want [42]", enc.discarded)
+	}
+}
+
+// TestResetAllRecyclesCBs verifies that ResetAll moves completed and
+// discarded command buffers back to the free list (VK-CMD-001).
+func TestResetAllRecyclesCBs(t *testing.T) {
+	enc := &CommandEncoder{
+		device:    &Device{},
+		discarded: []vk.CommandBuffer{10, 20},
+	}
+
+	// Simulate completed command buffers returned from GPU.
+	completed := []hal.CommandBuffer{
+		&CommandBuffer{handle: 30},
+		&CommandBuffer{handle: 40},
+	}
+
+	enc.ResetAll(completed)
+
+	// Completed + discarded should be in free list.
+	if len(enc.free) != 4 {
+		t.Fatalf("free = %d, want 4", len(enc.free))
+	}
+	if len(enc.discarded) != 0 {
+		t.Errorf("discarded = %d, want 0", len(enc.discarded))
+	}
+
+	// Verify the handles are present (order: completed first, then discarded).
+	expected := map[vk.CommandBuffer]bool{10: true, 20: true, 30: true, 40: true}
+	for _, h := range enc.free {
+		if !expected[h] {
+			t.Errorf("unexpected handle %d in free list", h)
+		}
+	}
+}
+
+// TestAllocationGranularity verifies the batch allocation constant.
+func TestAllocationGranularity(t *testing.T) {
+	if allocationGranularity != 16 {
+		t.Errorf("allocationGranularity = %d, want 16 (Rust wgpu-hal parity)", allocationGranularity)
+	}
 }

--- a/hal/vulkan/compute_test.go
+++ b/hal/vulkan/compute_test.go
@@ -57,7 +57,7 @@ func TestVulkanComputePipelineCreation(t *testing.T) {
 // TestVulkanComputeDispatch tests basic dispatch execution.
 func TestVulkanComputeDispatch(t *testing.T) {
 	t.Run("encoder initialization", func(t *testing.T) {
-		encoder := &CommandEncoder{isRecording: true}
+		encoder := &CommandEncoder{active: 1}
 		cpe := &ComputePassEncoder{encoder: encoder}
 		if cpe.encoder != encoder {
 			t.Error("encoder not set correctly")
@@ -77,7 +77,7 @@ func TestVulkanComputeDispatch(t *testing.T) {
 			{1, 1, 1}, {64, 1, 1}, {8, 8, 8}, {256, 256, 1}, {0, 0, 0},
 		}
 		for _, tt := range tests {
-			cpe := &ComputePassEncoder{encoder: &CommandEncoder{isRecording: false}}
+			cpe := &ComputePassEncoder{encoder: &CommandEncoder{active: 0}}
 			cpe.Dispatch(tt.x, tt.y, tt.z) // Should not panic
 		}
 	})
@@ -86,14 +86,14 @@ func TestVulkanComputeDispatch(t *testing.T) {
 // TestVulkanComputeDispatchIndirect tests indirect dispatch from buffer.
 func TestVulkanComputeDispatchIndirect(t *testing.T) {
 	t.Run("nil buffer", func(t *testing.T) {
-		cpe := &ComputePassEncoder{encoder: &CommandEncoder{isRecording: true}}
+		cpe := &ComputePassEncoder{encoder: &CommandEncoder{active: 1}}
 		cpe.DispatchIndirect(nil, 0) // Should not panic
 	})
 
 	t.Run("offset validation", func(t *testing.T) {
 		offsets := []uint64{0, 16, 256, 4096}
 		for _, offset := range offsets {
-			cpe := &ComputePassEncoder{encoder: &CommandEncoder{isRecording: false}}
+			cpe := &ComputePassEncoder{encoder: &CommandEncoder{active: 0}}
 			cpe.DispatchIndirect(nil, offset) // Should not panic
 		}
 	})
@@ -104,7 +104,7 @@ func TestVulkanComputeDispatchIndirect(t *testing.T) {
 			size:   256,
 			usage:  gputypes.BufferUsageIndirect | gputypes.BufferUsageStorage,
 		}
-		cpe := &ComputePassEncoder{encoder: &CommandEncoder{isRecording: false}}
+		cpe := &ComputePassEncoder{encoder: &CommandEncoder{active: 0}}
 		cpe.DispatchIndirect(buffer, 0) // Should not panic
 	})
 }
@@ -181,7 +181,7 @@ func TestVulkanComputeMultipleBindGroups(t *testing.T) {
 
 	t.Run("SetBindGroup nil group", func(t *testing.T) {
 		cpe := &ComputePassEncoder{
-			encoder:  &CommandEncoder{isRecording: true},
+			encoder:  &CommandEncoder{active: 1},
 			pipeline: &ComputePipeline{handle: vk.Pipeline(100), layout: vk.PipelineLayout(200)},
 		}
 		cpe.SetBindGroup(0, nil, nil) // Should not panic
@@ -195,7 +195,7 @@ func TestVulkanComputeMultipleBindGroups(t *testing.T) {
 			{0, nil}, {0, []uint32{0, 256}}, {1, nil}, {2, []uint32{0, 128}},
 		}
 		for _, tt := range tests {
-			cpe := &ComputePassEncoder{encoder: &CommandEncoder{isRecording: false}}
+			cpe := &ComputePassEncoder{encoder: &CommandEncoder{active: 0}}
 			bg := &BindGroup{handle: vk.DescriptorSet(100)}
 			cpe.SetBindGroup(tt.index, bg, tt.offsets) // Should not panic
 		}
@@ -237,7 +237,7 @@ func TestVulkanComputeShaderStages(t *testing.T) {
 // TestVulkanComputeSetPipeline tests compute pipeline binding.
 func TestVulkanComputeSetPipeline(t *testing.T) {
 	t.Run("nil pipeline", func(t *testing.T) {
-		cpe := &ComputePassEncoder{encoder: &CommandEncoder{isRecording: true}}
+		cpe := &ComputePassEncoder{encoder: &CommandEncoder{active: 1}}
 		cpe.SetPipeline(nil) // Should not panic
 		if cpe.pipeline != nil {
 			t.Error("pipeline should remain nil")
@@ -245,7 +245,7 @@ func TestVulkanComputeSetPipeline(t *testing.T) {
 	})
 
 	t.Run("not recording", func(t *testing.T) {
-		cpe := &ComputePassEncoder{encoder: &CommandEncoder{isRecording: false}}
+		cpe := &ComputePassEncoder{encoder: &CommandEncoder{active: 0}}
 		pipeline := &ComputePipeline{handle: vk.Pipeline(12345)}
 		cpe.SetPipeline(pipeline)
 		if cpe.pipeline != nil {
@@ -257,7 +257,7 @@ func TestVulkanComputeSetPipeline(t *testing.T) {
 // TestVulkanBeginComputePass tests compute pass creation.
 func TestVulkanBeginComputePass(t *testing.T) {
 	t.Run("returns encoder", func(t *testing.T) {
-		cmdEncoder := &CommandEncoder{isRecording: true}
+		cmdEncoder := &CommandEncoder{active: 1}
 		cpe := cmdEncoder.BeginComputePass(&hal.ComputePassDescriptor{Label: "test"})
 		if cpe == nil {
 			t.Fatal("BeginComputePass returned nil")
@@ -268,7 +268,7 @@ func TestVulkanBeginComputePass(t *testing.T) {
 	})
 
 	t.Run("nil descriptor", func(t *testing.T) {
-		cmdEncoder := &CommandEncoder{isRecording: true}
+		cmdEncoder := &CommandEncoder{active: 1}
 		if cpe := cmdEncoder.BeginComputePass(nil); cpe == nil {
 			t.Fatal("BeginComputePass returned nil for nil descriptor")
 		}

--- a/hal/vulkan/device.go
+++ b/hal/vulkan/device.go
@@ -19,20 +19,15 @@ import (
 	"github.com/gogpu/wgpu/hal/vulkan/vk"
 )
 
-// commandAllocator pairs a VkCommandPool with a pre-allocated VkCommandBuffer.
-// Each CreateCommandEncoder gets its own dedicated pool+buffer pair. After GPU
-// completion, FreeCommandBuffer recycles the pair back to the free list for reuse.
-//
-// This design eliminates the race between per-frame bulk pool reset and individual
-// command buffer freeing that caused "Couldn't find VkCommandBuffer Object" crashes.
-// Pool reset (vkResetCommandPool flag 0) restores the command buffer to initial
-// state without destroying the handle, enabling fast recycle (VK-POOL-001).
+// commandAllocator holds a recycled VkCommandPool.
+// Each CreateCommandEncoder gets its own dedicated pool. The encoder manages
+// its own free list of VkCommandBuffers internally (VK-CMD-001).
+// After GPU completion, FreeCommandBuffer recycles the pool back for reuse.
 //
 // Reference: Rust wgpu-hal uses the same per-encoder pool pattern — each
-// CommandEncoder owns its own VkCommandPool.
+// CommandEncoder owns its own VkCommandPool with internal free list.
 type commandAllocator struct {
-	pool      vk.CommandPool
-	cmdBuffer vk.CommandBuffer
+	pool vk.CommandPool
 }
 
 // encoderPool reuses CommandEncoder structs across CreateCommandEncoder calls.
@@ -76,11 +71,10 @@ type Device struct {
 	// with a single timeline semaphore. Falls back to binary fences on older drivers.
 	timelineFence *deviceFence
 
-	// Per-encoder command pool recycling (VK-POOL-001).
-	// Each CreateCommandEncoder gets a dedicated VkCommandPool + VkCommandBuffer pair.
-	// After GPU completion, FreeCommandBuffer recycles the pair for reuse.
-	// This eliminates the race between per-frame pool reset and individual buffer freeing
-	// that caused "Couldn't find VkCommandBuffer Object" crashes.
+	// Per-encoder command pool recycling (VK-POOL-001, VK-CMD-001).
+	// Each CreateCommandEncoder gets a dedicated VkCommandPool.
+	// The encoder manages its own command buffer free list internally.
+	// After GPU completion, FreeCommandBuffer recycles the pool for reuse.
 	freeAllocators []commandAllocator
 	allocatorMu    sync.Mutex // protects freeAllocators
 
@@ -1141,35 +1135,26 @@ func (d *Device) DestroyShaderModule(module hal.ShaderModule) {
 	vkModule.device = nil
 }
 
-// acquireAllocator returns a command allocator (pool+buffer pair) for a new encoder.
-// If the free list has a recycled pair, it pops one and resets its pool.
-// Otherwise, it creates a new VkCommandPool with TRANSIENT_BIT and allocates
-// a single primary command buffer from it (VK-POOL-001).
+// acquireAllocator returns a command allocator (pool) for a new encoder.
+// If the free list has a recycled pool, it pops one. Otherwise, it creates
+// a new VkCommandPool with TRANSIENT_BIT (VK-POOL-001, VK-CMD-001).
+//
+// Command buffer allocation is deferred to BeginEncoding — the encoder's
+// internal free list batch-allocates via vkAllocateCommandBuffers on demand.
 func (d *Device) acquireAllocator() (commandAllocator, error) {
 	d.allocatorMu.Lock()
 	if n := len(d.freeAllocators); n > 0 {
 		alloc := d.freeAllocators[n-1]
 		d.freeAllocators = d.freeAllocators[:n-1]
 		d.allocatorMu.Unlock()
-
-		// Reset the pool: restores the command buffer to initial state
-		// without destroying its handle (flag 0). This is faster than
-		// vkFreeCommandBuffers + vkAllocateCommandBuffers.
-		result := d.cmds.ResetCommandPool(d.handle, alloc.pool, 0)
-		if result != vk.Success {
-			return commandAllocator{}, fmt.Errorf("vulkan: vkResetCommandPool failed: %d", result)
-		}
-
-		// Post-condition: validate recycled handle is still valid (VK-001).
-		if alloc.cmdBuffer == 0 {
-			return commandAllocator{}, fmt.Errorf("vulkan: recycled allocator has null command buffer handle")
-		}
-
 		return alloc, nil
 	}
 	d.allocatorMu.Unlock()
 
 	// Create a new dedicated pool with TRANSIENT_BIT (short-lived buffers).
+	// No RESET_COMMAND_BUFFER_BIT — we use vkResetCommandPool for batch reset
+	// instead of individual vkResetCommandBuffer. Mesa explicitly warns against
+	// RESET_COMMAND_BUFFER_BIT: it prevents single large allocator optimization.
 	createInfo := vk.CommandPoolCreateInfo{
 		SType:            vk.StructureTypeCommandPoolCreateInfo,
 		Flags:            vk.CommandPoolCreateFlags(vk.CommandPoolCreateTransientBit),
@@ -1182,44 +1167,26 @@ func (d *Device) acquireAllocator() (commandAllocator, error) {
 		return commandAllocator{}, fmt.Errorf("vulkan: vkCreateCommandPool failed: %d", result)
 	}
 
-	// Allocate a single primary command buffer from the new pool.
-	allocInfo := vk.CommandBufferAllocateInfo{
-		SType:              vk.StructureTypeCommandBufferAllocateInfo,
-		CommandPool:        pool,
-		Level:              vk.CommandBufferLevelPrimary,
-		CommandBufferCount: 1,
-	}
-
-	var cmdBuffer vk.CommandBuffer
-	result = vkAllocateCommandBuffers(d.cmds, d.handle, &allocInfo, &cmdBuffer)
-	if result != vk.Success {
-		vkDestroyCommandPool(d.cmds, d.handle, pool, nil)
-		return commandAllocator{}, fmt.Errorf("vulkan: vkAllocateCommandBuffers failed: %d", result)
-	}
-
-	// Post-condition: validate handle is non-null (VK-001).
-	// goffi returns zeros on nil function pointer (no crash, no error),
-	// so vkAllocateCommandBuffers could "succeed" with cmdBuffer=0.
-	if cmdBuffer == 0 {
-		vkDestroyCommandPool(d.cmds, d.handle, pool, nil)
-		return commandAllocator{}, fmt.Errorf("vulkan: vkAllocateCommandBuffers returned null command buffer handle")
-	}
-
 	d.setObjectName(vk.ObjectTypeCommandPool, uint64(pool), "CommandPool")
 
-	return commandAllocator{pool: pool, cmdBuffer: cmdBuffer}, nil
+	return commandAllocator{pool: pool}, nil
 }
 
-// recycleAllocator returns a command allocator back to the free list for reuse.
-// The pool is NOT reset here — it will be reset lazily in the next acquireAllocator call.
-func (d *Device) recycleAllocator(alloc commandAllocator) {
+// recyclePool returns a command pool back to the free list for reuse.
+// The pool is NOT reset here — the encoder's ResetAll handles that,
+// or acquireAllocator can reset lazily if needed.
+func (d *Device) recyclePool(pool vk.CommandPool) {
+	if pool == 0 {
+		return
+	}
 	d.allocatorMu.Lock()
-	d.freeAllocators = append(d.freeAllocators, alloc)
+	d.freeAllocators = append(d.freeAllocators, commandAllocator{pool: pool})
 	d.allocatorMu.Unlock()
 }
 
 // CreateCommandEncoder creates a command encoder with its own dedicated
-// VkCommandPool + VkCommandBuffer pair. This per-encoder pool design matches
+// VkCommandPool. Command buffers are allocated on demand from the pool's
+// internal free list (VK-CMD-001). This per-encoder pool design matches
 // Rust wgpu-hal and eliminates races between pool reset and buffer freeing
 // that caused "Couldn't find VkCommandBuffer Object" crashes (VK-POOL-001).
 // Uses sync.Pool for CommandEncoder struct reuse (VK-PERF-003).
@@ -1233,9 +1200,11 @@ func (d *Device) CreateCommandEncoder(desc *hal.CommandEncoderDescriptor) (hal.C
 	e := encoderPool.Get().(*CommandEncoder)
 	e.device = d
 	e.pool = alloc.pool
-	e.cmdBuffer = alloc.cmdBuffer
+	e.active = 0
 	e.label = desc.Label
-	e.isRecording = false
+	// free and discarded slices may retain capacity from previous use — clear length.
+	e.free = e.free[:0]
+	e.discarded = e.discarded[:0]
 	return e, nil
 }
 
@@ -1263,18 +1232,22 @@ func (d *Device) ResetCommandPool() error {
 	return nil
 }
 
-// FreeCommandBuffer recycles a command buffer's pool+buffer pair for reuse.
+// FreeCommandBuffer recycles a command buffer's pool for reuse.
 // Only call this AFTER the GPU has finished using the command buffer (after fence wait).
-// The pool is returned to the free list; it will be reset lazily on next acquire.
-// No vkFreeCommandBuffers call is needed because pool reset restores the buffer.
+// The pool is returned to the free list and reset on next acquireAllocator.
+// This is only called for standalone-mode encoders where the CommandBuffer
+// carries pool ownership. Pool-managed encoders use ResetAll instead.
 func (d *Device) FreeCommandBuffer(cmdBuffer hal.CommandBuffer) {
 	vkCmdBuf, ok := cmdBuffer.(*CommandBuffer)
 	if !ok || vkCmdBuf.handle == 0 || vkCmdBuf.pool == 0 {
 		return
 	}
 
-	// Recycle the pool+buffer pair back to the free list.
-	d.recycleAllocator(commandAllocator{pool: vkCmdBuf.pool, cmdBuffer: vkCmdBuf.handle})
+	// Recycle the pool back to the free list.
+	// The pool contains all command buffers (active + free + discarded from
+	// the encoder). Destroying the pool frees them all; resetting the pool
+	// puts them all back to initial state.
+	d.recyclePool(vkCmdBuf.pool)
 
 	vkCmdBuf.handle = 0
 	vkCmdBuf.pool = 0
@@ -1456,10 +1429,6 @@ func vkCreateCommandPool(cmds *vk.Commands, device vk.Device, createInfo *vk.Com
 //nolint:unparam // Vulkan API wrapper — signature mirrors vkDestroyCommandPool spec
 func vkDestroyCommandPool(cmds *vk.Commands, device vk.Device, pool vk.CommandPool, allocator *vk.AllocationCallbacks) {
 	cmds.DestroyCommandPool(device, pool, allocator)
-}
-
-func vkAllocateCommandBuffers(cmds *vk.Commands, device vk.Device, allocInfo *vk.CommandBufferAllocateInfo, cmdBuffers *vk.CommandBuffer) vk.Result {
-	return cmds.AllocateCommandBuffers(device, allocInfo, cmdBuffers)
 }
 
 func vkCreateSampler(cmds *vk.Commands, device vk.Device, createInfo *vk.SamplerCreateInfo, allocator *vk.AllocationCallbacks, sampler *vk.Sampler) vk.Result {


### PR DESCRIPTION
## Summary

- **Vulkan command buffer free list** (VK-CMD-001) — replace single-CB-per-encoder with industry-standard free list pattern. Batch allocate 16 CBs, `vkResetCommandPool` for batch reset. Fixes VUID-vkBeginCommandBuffer-commandBuffer-00049.
- Enterprise parity: Khronos, NVIDIA, ARM, Mesa, Rust wgpu-hal

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] `gofmt` — clean
- [ ] CI