### PR TITLE
v0.25.7: fix v0.25.6 retag issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.25.7] - 2026-04-24
+
+### Fixed
+
+- **v0.25.6 retag fix** — v0.25.6 was incorrectly retagged after Go module proxy cached the
+  original. This release contains the correct code with all pool reset fixes.
+
 ## [0.25.6] - 2026-04-24
 
 ### Changed


### PR DESCRIPTION
v0.25.6 was incorrectly retagged after Go module proxy cached the original. v0.25.7 is the canonical release with all pool reset fixes.