### PR TITLE
v0.26.1: damage-aware present for Vulkan, DX12, GLES (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.1] - 2026-04-25
+
+### Added
+
+- **Vulkan: damage-aware present via `VK_KHR_incremental_present`** — chains
+  `VkPresentRegionsKHR` into `VkPresentInfoKHR.pNext` when damage rects provided.
+  Extension probed at adapter enumeration; graceful fallback when unavailable.
+- **DX12: damage-aware present via `IDXGISwapChain1::Present1`** — passes
+  `DXGI_PRESENT_PARAMETERS.pDirtyRects` to DWM compositor. Requires opt-in
+  `EnableDamagePresent: true` in `SurfaceConfiguration` (selects `FLIP_SEQUENTIAL`).
+  Triple guard: damage rects + FLIP_SEQUENTIAL + no tearing. Falls back to `Present()`.
+- **GLES: damage-aware present via `eglSwapBuffersWithDamageKHR`** (Linux only) —
+  probes extension at init, Y-flips coordinates (EGL bottom-left → WebGPU top-left).
+  Falls back to `eglSwapBuffers` when extension unavailable. WGL (Windows) unchanged.
+- `hal.SurfaceConfiguration.EnableDamagePresent` — opt-in flag for DX12 `FLIP_SEQUENTIAL`.
+- Zero allocations maintained: stack arrays `[8]vk.RectLayerKHR`, `[8]dxgi.RECT`,
+  `[32]int32` for ≤8 damage rects across all backends.
+
 ## [0.26.0] - 2026-04-25
 
 ### Added

--- a/hal/descriptor.go
+++ b/hal/descriptor.go
@@ -158,6 +158,18 @@ type SurfaceConfiguration struct {
 
 	// AlphaMode controls alpha compositing.
 	AlphaMode gputypes.CompositeAlphaMode
+
+	// EnableDamagePresent requests the backend to configure for damage-aware
+	// presentation. On DX12, this selects DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL
+	// instead of FLIP_DISCARD, enabling IDXGISwapChain1::Present1 with dirty
+	// rects. On other backends this flag is ignored (they handle damage rects
+	// without special surface configuration).
+	//
+	// Default false = current behavior (FLIP_DISCARD on DX12).
+	// Should only be set for GUI/widget workloads where partial surface
+	// updates are common. Games and full-screen renderers should leave this
+	// false because FLIP_DISCARD has lower overhead.
+	EnableDamagePresent bool
 }
 
 // BufferDescriptor describes how to create a buffer.

--- a/hal/dx12/dxgi/factory.go
+++ b/hal/dx12/dxgi/factory.go
@@ -908,6 +908,29 @@ func (s *IDXGISwapChain4) Present(syncInterval, flags uint32) error {
 	return nil
 }
 
+// Present1 presents a rendered frame with dirty rectangle information.
+// This is IDXGISwapChain1::Present1 — requires FLIP_SEQUENTIAL swap effect
+// for the dirty rects to be meaningful. With FLIP_DISCARD or when params
+// is nil, this behaves identically to Present().
+//
+// params.DirtyRectsCount=0 with nil DirtyRects signals full-surface update.
+func (s *IDXGISwapChain4) Present1(syncInterval, flags uint32, params *DXGI_PRESENT_PARAMETERS) error {
+	ret, _, _ := syscall.Syscall6(
+		s.vtbl.Present1,
+		4,
+		uintptr(unsafe.Pointer(s)),
+		uintptr(syncInterval),
+		uintptr(flags),
+		uintptr(unsafe.Pointer(params)),
+		0, 0,
+	)
+
+	if ret != 0 {
+		return d3d12.HRESULTError(ret)
+	}
+	return nil
+}
+
 // GetBuffer retrieves a back buffer from the swap chain.
 func (s *IDXGISwapChain4) GetBuffer(index uint32, riid *GUID) (unsafe.Pointer, error) {
 	var resource unsafe.Pointer

--- a/hal/dx12/instance.go
+++ b/hal/dx12/instance.go
@@ -353,6 +353,11 @@ type Surface struct {
 	swapchainFlags             uint32
 	allowTearing               bool
 	frameLatencyWaitableObject uintptr // HANDLE from GetFrameLatencyWaitableObject
+
+	// damagePresent is true when the swapchain was created with
+	// DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL (instead of FLIP_DISCARD).
+	// Only in this mode can Present1 with dirty rects be used.
+	damagePresent bool
 }
 
 // Configure configures the surface for presentation.

--- a/hal/dx12/queue.go
+++ b/hal/dx12/queue.go
@@ -372,10 +372,12 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 // Present presents a surface texture to the screen.
 // The texture must have been acquired via Surface.AcquireTexture.
 //
-// damageRects is accepted but ignored in this phase — DX12 damage-aware
-// present requires FLIP_SEQUENTIAL swap effect (Phase 3, ADR-017).
-// Current FLIP_DISCARD does not support dirty rects.
-func (q *Queue) Present(surface hal.Surface, texture hal.SurfaceTexture, _ []image.Rectangle) error {
+// damageRects is an optional list of rectangles (physical pixels, top-left
+// origin) indicating which surface regions changed this frame. When non-empty
+// and the surface was configured with EnableDamagePresent (FLIP_SEQUENTIAL),
+// IDXGISwapChain1::Present1 is called with DXGI_PRESENT_PARAMETERS containing
+// the dirty rects. Otherwise, the standard Present() path is used.
+func (q *Queue) Present(surface hal.Surface, _ hal.SurfaceTexture, damageRects []image.Rectangle) error {
 	dx12Surface, ok := surface.(*Surface)
 	if !ok {
 		return fmt.Errorf("dx12: surface is not a DX12 surface")
@@ -415,13 +417,40 @@ func (q *Queue) Present(surface hal.Surface, texture hal.SurfaceTexture, _ []ima
 		syncInterval = 1
 	}
 
-	// Present the frame
+	// Present the frame. Use Present1 with dirty rects when the surface
+	// is configured for damage-aware present (FLIP_SEQUENTIAL) and the
+	// caller provided damage rects. Otherwise use standard Present.
 	presentStart := time.Now()
-	if err := dx12Surface.swapchain.Present(syncInterval, presentFlags); err != nil {
-		return fmt.Errorf("dx12: Present failed: %w", err)
+
+	if len(damageRects) > 0 && dx12Surface.damagePresent {
+		// Convert image.Rectangle to DXGI RECT (top-left origin, same
+		// coordinate system). Stack-allocate up to 8 to avoid heap alloc.
+		var stackRects [8]dxgi.RECT
+		rects := stackRects[:0]
+		for _, r := range damageRects {
+			rects = append(rects, dxgi.RECT{
+				Left:   int32(r.Min.X),
+				Top:    int32(r.Min.Y),
+				Right:  int32(r.Max.X),
+				Bottom: int32(r.Max.Y),
+			})
+		}
+		params := dxgi.DXGI_PRESENT_PARAMETERS{
+			DirtyRectsCount: uint32(len(rects)),
+			DirtyRects:      &rects[0],
+		}
+		if err := dx12Surface.swapchain.Present1(syncInterval, presentFlags, &params); err != nil {
+			return fmt.Errorf("dx12: Present1 failed: %w", err)
+		}
+	} else {
+		if err := dx12Surface.swapchain.Present(syncInterval, presentFlags); err != nil {
+			return fmt.Errorf("dx12: Present failed: %w", err)
+		}
 	}
+
 	hal.Logger().Debug("dx12: present",
 		"syncInterval", syncInterval,
+		"damageRects", len(damageRects),
 		"elapsed", time.Since(presentStart),
 	)
 

--- a/hal/dx12/surface.go
+++ b/hal/dx12/surface.go
@@ -52,6 +52,19 @@ func (s *Surface) createSwapchain(device *Device, config *hal.SurfaceConfigurati
 	// Add frame latency waitable object flag for better frame pacing
 	swapchainFlags |= uint32(dxgi.DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT)
 
+	// Select swap effect. FLIP_SEQUENTIAL preserves back buffer content across
+	// Present calls, enabling IDXGISwapChain1::Present1 with dirty rects.
+	// FLIP_DISCARD is the default (lower overhead, back buffer undefined after
+	// Present). Damage-aware present is only meaningful with FLIP_SEQUENTIAL.
+	//
+	// FLIP_SEQUENTIAL is NOT compatible with ALLOW_TEARING, so we only use it
+	// when damage present is requested AND tearing is not enabled.
+	swapEffect := dxgi.DXGI_SWAP_EFFECT_FLIP_DISCARD
+	useDamagePresent := config.EnableDamagePresent && !s.allowTearing
+	if useDamagePresent {
+		swapEffect = dxgi.DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL
+	}
+
 	// Create swapchain description
 	desc := dxgi.DXGI_SWAP_CHAIN_DESC1{
 		Width:       config.Width,
@@ -62,7 +75,7 @@ func (s *Surface) createSwapchain(device *Device, config *hal.SurfaceConfigurati
 		BufferUsage: dxgi.DXGI_USAGE_RENDER_TARGET_OUTPUT,
 		BufferCount: defaultBufferCount,
 		Scaling:     dxgi.DXGI_SCALING_STRETCH,
-		SwapEffect:  dxgi.DXGI_SWAP_EFFECT_FLIP_DISCARD,
+		SwapEffect:  swapEffect,
 		AlphaMode:   compositeAlphaModeToDXGI(config.AlphaMode),
 		Flags:       swapchainFlags,
 	}
@@ -93,6 +106,7 @@ func (s *Surface) createSwapchain(device *Device, config *hal.SurfaceConfigurati
 	s.height = config.Height
 	s.presentMode = config.PresentMode
 	s.swapchainFlags = swapchainFlags
+	s.damagePresent = useDamagePresent
 
 	// Set maximum frame latency
 	if err := swapchain4.SetMaximumFrameLatency(maxFrameLatency); err != nil {

--- a/hal/gles/egl/egl.go
+++ b/hal/gles/egl/egl.go
@@ -18,48 +18,54 @@ var (
 	eglLib unsafe.Pointer
 
 	// EGL 1.0+ core function symbols
-	symEglGetError             unsafe.Pointer
-	symEglGetDisplay           unsafe.Pointer
-	symEglInitialize           unsafe.Pointer
-	symEglTerminate            unsafe.Pointer
-	symEglQueryString          unsafe.Pointer
-	symEglChooseConfig         unsafe.Pointer
-	symEglGetConfigAttrib      unsafe.Pointer
-	symEglCreateWindowSurface  unsafe.Pointer
-	symEglCreatePbufferSurface unsafe.Pointer
-	symEglDestroySurface       unsafe.Pointer
-	symEglBindAPI              unsafe.Pointer
-	symEglSwapInterval         unsafe.Pointer
-	symEglCreateContext        unsafe.Pointer
-	symEglDestroyContext       unsafe.Pointer
-	symEglMakeCurrent          unsafe.Pointer
-	symEglGetCurrentContext    unsafe.Pointer
-	symEglGetCurrentDisplay    unsafe.Pointer
-	symEglSwapBuffers          unsafe.Pointer
-	symEglGetProcAddress       unsafe.Pointer
-	symEglGetPlatformDisplay   unsafe.Pointer // EGL 1.5, may be nil
+	symEglGetError                 unsafe.Pointer
+	symEglGetDisplay               unsafe.Pointer
+	symEglInitialize               unsafe.Pointer
+	symEglTerminate                unsafe.Pointer
+	symEglQueryString              unsafe.Pointer
+	symEglChooseConfig             unsafe.Pointer
+	symEglGetConfigAttrib          unsafe.Pointer
+	symEglCreateWindowSurface      unsafe.Pointer
+	symEglCreatePbufferSurface     unsafe.Pointer
+	symEglDestroySurface           unsafe.Pointer
+	symEglBindAPI                  unsafe.Pointer
+	symEglSwapInterval             unsafe.Pointer
+	symEglCreateContext            unsafe.Pointer
+	symEglDestroyContext           unsafe.Pointer
+	symEglMakeCurrent              unsafe.Pointer
+	symEglGetCurrentContext        unsafe.Pointer
+	symEglGetCurrentDisplay        unsafe.Pointer
+	symEglSwapBuffers              unsafe.Pointer
+	symEglGetProcAddress           unsafe.Pointer
+	symEglGetPlatformDisplay       unsafe.Pointer // EGL 1.5, may be nil
+	symEglSwapBuffersWithDamageKHR unsafe.Pointer // EGL_KHR_swap_buffers_with_damage, may be nil
 
 	// CallInterfaces for each function signature
-	cifEglGetError             types.CallInterface
-	cifEglGetDisplay           types.CallInterface
-	cifEglInitialize           types.CallInterface
-	cifEglTerminate            types.CallInterface
-	cifEglQueryString          types.CallInterface
-	cifEglChooseConfig         types.CallInterface
-	cifEglGetConfigAttrib      types.CallInterface
-	cifEglCreateWindowSurface  types.CallInterface
-	cifEglCreatePbufferSurface types.CallInterface
-	cifEglDestroySurface       types.CallInterface
-	cifEglBindAPI              types.CallInterface
-	cifEglSwapInterval         types.CallInterface
-	cifEglCreateContext        types.CallInterface
-	cifEglDestroyContext       types.CallInterface
-	cifEglMakeCurrent          types.CallInterface
-	cifEglGetCurrentContext    types.CallInterface
-	cifEglGetCurrentDisplay    types.CallInterface
-	cifEglSwapBuffers          types.CallInterface
-	cifEglGetProcAddress       types.CallInterface
-	cifEglGetPlatformDisplay   types.CallInterface
+	cifEglGetError                 types.CallInterface
+	cifEglGetDisplay               types.CallInterface
+	cifEglInitialize               types.CallInterface
+	cifEglTerminate                types.CallInterface
+	cifEglQueryString              types.CallInterface
+	cifEglChooseConfig             types.CallInterface
+	cifEglGetConfigAttrib          types.CallInterface
+	cifEglCreateWindowSurface      types.CallInterface
+	cifEglCreatePbufferSurface     types.CallInterface
+	cifEglDestroySurface           types.CallInterface
+	cifEglBindAPI                  types.CallInterface
+	cifEglSwapInterval             types.CallInterface
+	cifEglCreateContext            types.CallInterface
+	cifEglDestroyContext           types.CallInterface
+	cifEglMakeCurrent              types.CallInterface
+	cifEglGetCurrentContext        types.CallInterface
+	cifEglGetCurrentDisplay        types.CallInterface
+	cifEglSwapBuffers              types.CallInterface
+	cifEglGetProcAddress           types.CallInterface
+	cifEglGetPlatformDisplay       types.CallInterface
+	cifEglSwapBuffersWithDamageKHR types.CallInterface
+
+	// hasSwapBuffersWithDamage is true when eglSwapBuffersWithDamageKHR
+	// was successfully loaded (EGL_KHR_swap_buffers_with_damage extension).
+	hasSwapBuffersWithDamage bool
 )
 
 // Init loads the EGL library and initializes function pointers.
@@ -80,7 +86,14 @@ func Init() error {
 		return err
 	}
 
-	return prepareEGLCallInterfaces()
+	if err := prepareEGLCallInterfaces(); err != nil {
+		return err
+	}
+
+	// Probe optional EGL extensions via eglGetProcAddress (must be done
+	// after core symbols and CIFs are prepared).
+	loadOptionalExtensions()
+	return nil
 }
 
 // loadEGLSymbols loads all required EGL function symbols.
@@ -621,6 +634,60 @@ func GetProcAddress(procname string) uintptr {
 		unsafe.Pointer(&ptr),
 	}
 	_ = ffi.CallFunction(&cifEglGetProcAddress, symEglGetProcAddress, unsafe.Pointer(&result), args[:])
+	return result
+}
+
+// loadOptionalExtensions probes for optional EGL extensions via
+// eglGetProcAddress and prepares their CallInterfaces. Called once
+// during Init after core CIFs are ready.
+func loadOptionalExtensions() {
+	// EGL_KHR_swap_buffers_with_damage — allows telling the compositor
+	// which surface regions changed, enabling partial recomposition.
+	addr := GetProcAddress("eglSwapBuffersWithDamageKHR")
+	if addr != 0 {
+		//nolint:govet // Converting eglGetProcAddress result to unsafe.Pointer is required for goffi
+		symEglSwapBuffersWithDamageKHR = unsafe.Pointer(addr)
+		// EGLBoolean eglSwapBuffersWithDamageKHR(EGLDisplay, EGLSurface, EGLint*, EGLint)
+		err := ffi.PrepareCallInterface(&cifEglSwapBuffersWithDamageKHR, types.DefaultCall,
+			types.UInt32TypeDescriptor, // EGLBoolean
+			[]*types.TypeDescriptor{
+				types.PointerTypeDescriptor, // EGLDisplay
+				types.PointerTypeDescriptor, // EGLSurface
+				types.PointerTypeDescriptor, // EGLint* rects
+				types.UInt32TypeDescriptor,  // EGLint n_rects
+			})
+		if err == nil {
+			hasSwapBuffersWithDamage = true
+		}
+	}
+}
+
+// HasSwapBuffersWithDamage reports whether the EGL_KHR_swap_buffers_with_damage
+// extension was successfully loaded and is available for use.
+func HasSwapBuffersWithDamage() bool {
+	return hasSwapBuffersWithDamage
+}
+
+// SwapBuffersWithDamage presents the EGL surface with damage rectangle hints.
+// rects is a packed array of int32 quadruples {x, y, width, height} using
+// bottom-left origin (EGL convention — caller must Y-flip from top-left).
+// nRects is the number of rectangles (NOT the number of ints).
+// Returns False on failure.
+//
+// Falls back to SwapBuffers when EGL_KHR_swap_buffers_with_damage is
+// not available or nRects is 0.
+func SwapBuffersWithDamage(dpy EGLDisplay, surface EGLSurface, rects *int32, nRects int32) EGLBoolean {
+	if !hasSwapBuffersWithDamage || nRects == 0 {
+		return SwapBuffers(dpy, surface)
+	}
+	var result EGLBoolean
+	args := [4]unsafe.Pointer{
+		unsafe.Pointer(&dpy),
+		unsafe.Pointer(&surface),
+		unsafe.Pointer(&rects),
+		unsafe.Pointer(&nRects),
+	}
+	_ = ffi.CallFunction(&cifEglSwapBuffersWithDamageKHR, symEglSwapBuffersWithDamageKHR, unsafe.Pointer(&result), args[:])
 	return result
 }
 

--- a/hal/gles/queue_linux.go
+++ b/hal/gles/queue_linux.go
@@ -117,9 +117,13 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 // Y-flip); the blit un-flips for presentation. Mirrors Rust wgpu-hal
 // src/gles/egl.rs Surface::present (1280-1308).
 //
-// damageRects is accepted but ignored in this phase — GLES damage-aware
-// present via eglSwapBuffersWithDamageKHR is Phase 4 (ADR-017).
-func (q *Queue) Present(surface hal.Surface, _ hal.SurfaceTexture, _ []image.Rectangle) error {
+// damageRects is an optional list of rectangles (physical pixels, top-left
+// origin) indicating which surface regions changed this frame. When non-empty
+// and EGL_KHR_swap_buffers_with_damage is available, the rects are passed to
+// eglSwapBuffersWithDamageKHR as compositor hints. EGL uses bottom-left
+// origin, so Y coordinates are flipped here. When the extension is unavailable
+// or no rects are provided, the standard eglSwapBuffers path is used.
+func (q *Queue) Present(surface hal.Surface, _ hal.SurfaceTexture, damageRects []image.Rectangle) error {
 	surf, ok := surface.(*Surface)
 	if !ok {
 		return fmt.Errorf("gles: invalid surface type")
@@ -127,7 +131,32 @@ func (q *Queue) Present(surface hal.Surface, _ hal.SurfaceTexture, _ []image.Rec
 
 	surf.blitSwapchainToDefault()
 
-	// Use EGL SwapBuffers to present the rendered content
+	// Use damage-aware swap when the extension is available and rects provided.
+	if len(damageRects) > 0 && egl.HasSwapBuffersWithDamage() {
+		// Convert image.Rectangle (top-left origin) to EGL packed int32 array
+		// (bottom-left origin). Each rect is {x, y, width, height}.
+		// Stack-allocate for up to 8 rects (8 * 4 = 32 ints).
+		var stackInts [32]int32
+		ints := stackInts[:0]
+		surfaceHeight := int32(surf.fboHeight)
+		for _, r := range damageRects {
+			// Y-flip: EGL uses bottom-left origin.
+			// egl_y = surface_height - rect.Max.Y
+			ints = append(ints,
+				int32(r.Min.X),
+				surfaceHeight-int32(r.Max.Y),
+				int32(r.Dx()),
+				int32(r.Dy()),
+			)
+		}
+		result := egl.SwapBuffersWithDamage(surf.eglDisplay, surf.eglSurface, &ints[0], int32(len(damageRects)))
+		if result == egl.False {
+			return fmt.Errorf("gles: eglSwapBuffersWithDamageKHR failed: error 0x%x", egl.GetError())
+		}
+		return nil
+	}
+
+	// Standard full-surface swap.
 	result := egl.SwapBuffers(surf.eglDisplay, surf.eglSurface)
 	if result == egl.False {
 		return fmt.Errorf("gles: eglSwapBuffers failed: error 0x%x", egl.GetError())

--- a/hal/vulkan/adapter.go
+++ b/hal/vulkan/adapter.go
@@ -58,9 +58,33 @@ func (a *Adapter) Open(features gputypes.Features, limits gputypes.Limits) (hal.
 		PQueuePriorities: &queuePriority,
 	}
 
+	// Query supported device extensions to enable optional features.
+	hasIncrementalPresent := false
+	{
+		var extCount uint32
+		a.instance.cmds.EnumerateDeviceExtensionProperties(a.physicalDevice, 0, &extCount, nil)
+		if extCount > 0 {
+			extProps := make([]vk.ExtensionProperties, extCount)
+			a.instance.cmds.EnumerateDeviceExtensionProperties(a.physicalDevice, 0, &extCount, &extProps[0])
+			for i := range extProps {
+				name := cStringToGo(extProps[i].ExtensionName[:])
+				if name == "VK_KHR_incremental_present" {
+					hasIncrementalPresent = true
+					break
+				}
+			}
+		}
+	}
+
 	// Required extensions
 	extensions := []string{
 		"VK_KHR_swapchain\x00",
+	}
+	// Optional: VK_KHR_incremental_present for damage-aware presentation.
+	// Allows chaining VkPresentRegionsKHR into VkPresentInfoKHR.PNext
+	// so the compositor can skip recompositing unchanged pixels.
+	if hasIncrementalPresent {
+		extensions = append(extensions, "VK_KHR_incremental_present\x00")
 	}
 	extensionPtrs := make([]uintptr, len(extensions))
 	for i, ext := range extensions {
@@ -119,11 +143,12 @@ func (a *Adapter) Open(features gputypes.Features, limits gputypes.Limits) (hal.
 	vkGetDeviceQueue(&deviceCmds, device, uint32(graphicsFamily), 0, &queue)
 
 	dev := &Device{
-		handle:         device,
-		physicalDevice: a.physicalDevice,
-		instance:       a.instance,
-		graphicsFamily: uint32(graphicsFamily),
-		cmds:           &deviceCmds,
+		handle:                     device,
+		physicalDevice:             a.physicalDevice,
+		instance:                   a.instance,
+		graphicsFamily:             uint32(graphicsFamily),
+		cmds:                       &deviceCmds,
+		supportsIncrementalPresent: hasIncrementalPresent,
 	}
 
 	// Initialize synchronization fence (VK-IMPL-001 / VK-IMPL-003).

--- a/hal/vulkan/device.go
+++ b/hal/vulkan/device.go
@@ -66,6 +66,12 @@ type Device struct {
 	queue               *Queue               // Primary queue (for swapchain synchronization)
 	renderPassCache     *RenderPassCache     // Cache for VkRenderPass and VkFramebuffer objects
 
+	// supportsIncrementalPresent is true when VK_KHR_incremental_present
+	// is enabled on this device. When true, Present can chain
+	// VkPresentRegionsKHR into VkPresentInfoKHR.PNext to hint the
+	// compositor about which surface regions changed (damage rects).
+	supportsIncrementalPresent bool
+
 	// Timeline semaphore fence (VK-IMPL-001).
 	// When available (Vulkan 1.2+), replaces both frame fences and transfer fence
 	// with a single timeline semaphore. Falls back to binary fences on older drivers.

--- a/hal/vulkan/queue.go
+++ b/hal/vulkan/queue.go
@@ -669,9 +669,12 @@ func (q *Queue) waitForGPU() {
 
 // Present presents a surface texture to the screen.
 //
-// damageRects is accepted but ignored in this phase — Vulkan damage-aware
-// present requires VK_KHR_incremental_present extension (Phase 2, ADR-017).
-func (q *Queue) Present(surface hal.Surface, texture hal.SurfaceTexture, _ []image.Rectangle) error {
+// damageRects is an optional list of rectangles (physical pixels, top-left
+// origin) indicating which surface regions changed this frame. When non-empty
+// and VK_KHR_incremental_present is supported, the rects are chained into
+// VkPresentInfoKHR.PNext as a compositor hint. When empty or the extension
+// is unavailable, the present path is identical to a full-surface present.
+func (q *Queue) Present(surface hal.Surface, _ hal.SurfaceTexture, damageRects []image.Rectangle) error {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 
@@ -684,7 +687,7 @@ func (q *Queue) Present(surface hal.Surface, texture hal.SurfaceTexture, _ []ima
 		return fmt.Errorf("vulkan: surface not configured")
 	}
 
-	err := vkSurface.swapchain.present(q)
+	err := vkSurface.swapchain.present(q, damageRects)
 	q.activeSwapchain = nil
 	return err
 }

--- a/hal/vulkan/swapchain.go
+++ b/hal/vulkan/swapchain.go
@@ -7,6 +7,8 @@ package vulkan
 
 import (
 	"fmt"
+	"image"
+	"unsafe"
 
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/hal"
@@ -497,7 +499,13 @@ func (sc *Swapchain) acquireNextImage() (*SwapchainTexture, bool, error) {
 }
 
 // present presents the current image to the screen.
-func (sc *Swapchain) present(queue *Queue) error {
+//
+// damageRects is an optional list of rectangles (physical pixels, top-left
+// origin) indicating which surface regions changed this frame. When non-empty
+// and the device supports VK_KHR_incremental_present, a VkPresentRegionsKHR
+// structure is chained into VkPresentInfoKHR.PNext as a compositor hint.
+// When empty or unsupported, the present path is identical to a full present.
+func (sc *Swapchain) present(queue *Queue, damageRects []image.Rectangle) error {
 	if !sc.imageAcquired {
 		return fmt.Errorf("vulkan: no image acquired to present")
 	}
@@ -513,6 +521,34 @@ func (sc *Swapchain) present(queue *Queue) error {
 		SwapchainCount:     1,
 		PSwapchains:        &sc.handle,
 		PImageIndices:      &sc.currentImage,
+	}
+
+	// VK_KHR_incremental_present: chain damage rects as a compositor hint.
+	// Stack-allocate up to 8 rects to avoid heap allocation in the common case.
+	var (
+		stackRects     [8]vk.RectLayerKHR
+		presentRegion  vk.PresentRegionKHR
+		presentRegions vk.PresentRegionsKHR
+	)
+	if len(damageRects) > 0 && sc.device.supportsIncrementalPresent {
+		vkRects := stackRects[:0]
+		for _, r := range damageRects {
+			vkRects = append(vkRects, vk.RectLayerKHR{
+				Offset: vk.Offset2D{X: int32(r.Min.X), Y: int32(r.Min.Y)},
+				Extent: vk.Extent2D{Width: uint32(r.Dx()), Height: uint32(r.Dy())},
+				Layer:  0,
+			})
+		}
+		presentRegion = vk.PresentRegionKHR{
+			RectangleCount: uint32(len(vkRects)),
+			PRectangles:    &vkRects[0],
+		}
+		presentRegions = vk.PresentRegionsKHR{
+			SType:          vk.StructureTypePresentRegionsKhr,
+			SwapchainCount: 1,
+			PRegions:       &presentRegion,
+		}
+		presentInfo.PNext = (*uintptr)(unsafe.Pointer(&presentRegions))
 	}
 
 	result := vkQueuePresentKHR(queue, &presentInfo)


### PR DESCRIPTION
## Summary

Complete damage-aware present for ALL GPU backends (Phases 2-4):

- **Vulkan:** `VK_KHR_incremental_present` — VkPresentRegionsKHR chained in pNext
- **DX12:** `Present1` with dirty rects + `FLIP_SEQUENTIAL` opt-in via `EnableDamagePresent`
- **GLES:** `eglSwapBuffersWithDamageKHR` (Linux, Y-flip) + fallback

All backends: 0 allocs for ≤8 rects. Graceful fallback when unavailable. Nil path untouched.

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] `gofmt` — clean
- [x] Benchmarks: 0 B/op, 0 allocs for nil, 1-rect, 8-rects
- [ ] CI