### PR TITLE
v0.26.2: automatic resource lifecycle + zero-alloc batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.2] - 2026-04-25
+
+### Fixed
+
+- **Automatic Buffer/BindGroup cleanup via `runtime.AddCleanup`** (BUG-WGPU-RESOURCE-LIFECYCLE-001) —
+  per-frame resources that are not explicitly Released are now automatically scheduled for deferred
+  destruction when collected by GC. Prevents resource leaks (120 buffers/sec) that caused stuttering
+  on Intel Iris Xe. Matches Rust wgpu `Arc<T>` + `Drop` pattern and gogpu `Texture` `AddCleanup` pattern.
+  Leak detection: `slog.Warn` when GC releases a forgotten resource. Explicit `Release()` still preferred
+  and cancels the cleanup (no double-free). ADR-018.
+
+- **Interior pointer bug in `released` field** — changed `Buffer.released` and `BindGroup.released`
+  from embedded `atomic.Bool` to heap-allocated `*atomic.Bool`. The embedded value created an interior
+  pointer in the cleanup ref, preventing GC from ever collecting the object.
+
+### Changed
+
+- **Zero-allocation WriteBuffer batching** — pre-allocate `[1]hal.BufferCopy` in `pendingWrites`
+  struct to avoid heap escape through `hal.CommandEncoder` interface method call. Stack-allocate
+  `[8]hal.BufferBarrier` for flush barriers. Batching path: 43 B/op → 19 B/op, 1 alloc → **0 allocs**.
+  All PendingWrites hot paths now 0 allocs/op.
+
 ## [0.26.1] - 2026-04-25
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.26.0
+## Current State: v0.26.2
 
 ✅ **All 5 HAL backends complete** (~127K LOC)
 ✅ **Three-layer WebGPU stack** — wgpu API → wgpu/core → wgpu/hal
@@ -47,7 +47,9 @@
 ✅ **Vulkan relay semaphores** — GPU-side submission ordering (Mesa ANV workaround)
 ✅ **WASM platform split** — root package _native.go/_browser.go, core/hal excluded from WASM build
 ✅ **Vulkan command buffer free list** — batch alloc 16 CBs, pool reset (Khronos/NVIDIA/ARM/Mesa/Rust parity)
-✅ **Damage-aware surface presentation** — `PresentWithDamage()` with compositor dirty rects. First WebGPU implementation. Phase 1: Software backend (BitBlt/XPutImage per rect). GPU backends in future phases.
+✅ **Damage-aware surface presentation** — `PresentWithDamage()` with compositor dirty rects. First WebGPU implementation. Software + Vulkan + DX12 + GLES backends.
+✅ **Automatic resource lifecycle** — `runtime.AddCleanup` for Buffer/BindGroup (ADR-018, Rust Arc+Drop pattern). GC safety net prevents per-frame resource leaks.
+✅ **Zero-allocation WriteBuffer batching** — pre-allocated BufferCopy + stack barrier arrays. All PendingWrites hot paths 0 allocs/op.
 
 ### Remaining validation (planned)
 - Late buffer binding size (SPIR-V reflection → min binding size)

--- a/bind_native.go
+++ b/bind_native.go
@@ -3,10 +3,26 @@
 package wgpu
 
 import (
+	"log/slog"
+	"runtime"
+	"sync/atomic"
+
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/core"
 	"github.com/gogpu/wgpu/hal"
 )
+
+// bindGroupCleanupRef holds the data needed to destroy a bind group's HAL
+// resources from a runtime.AddCleanup callback. This struct must NOT reference
+// the BindGroup itself — runtime.AddCleanup requires the callback argument to
+// be independent of the cleaned-up object.
+type bindGroupCleanupRef struct {
+	label        string
+	released     *atomic.Bool
+	destroyQueue *core.DestroyQueue
+	lastSubIdx   func() uint64
+	destroyFn    func()
+}
 
 // BindGroupLayout defines the structure of resource bindings for shaders.
 type BindGroupLayout struct {
@@ -156,9 +172,14 @@ type LateBufferBindingInfo struct {
 
 // BindGroup represents bound GPU resources for shader access.
 type BindGroup struct {
-	hal      hal.BindGroup
-	device   *Device
-	released bool
+	hal     hal.BindGroup
+	device  *Device
+	cleanup runtime.Cleanup
+	// released is heap-allocated separately so that the cleanup ref can share
+	// it without holding an interior pointer into the BindGroup struct. An interior
+	// pointer would make the BindGroup reachable from the cleanup arg, preventing
+	// GC collection and causing the cleanup to never fire.
+	released *atomic.Bool
 	// layout is the bind group layout used to create this bind group.
 	// Stored for draw-time compatibility validation via the binder.
 	layout *BindGroupLayout
@@ -180,10 +201,12 @@ type BindGroup struct {
 // Matches Rust wgpu pattern: BindGroup::drop() only fires after
 // triage_submissions confirms fence completion.
 func (g *BindGroup) Release() {
-	if g.released {
+	if g.released == nil || !g.released.CompareAndSwap(false, true) {
 		return
 	}
-	g.released = true
+
+	// Cancel the GC cleanup — we are destroying explicitly.
+	g.cleanup.Stop()
 
 	if g.device == nil {
 		return
@@ -204,5 +227,52 @@ func (g *BindGroup) Release() {
 	halBG := g.hal
 	dq.Defer(subIdx, "BindGroup", func() {
 		halDevice.DestroyBindGroup(halBG)
+	})
+}
+
+// registerBindGroupCleanup registers a runtime.AddCleanup handler on the bind group.
+// When GC collects the bind group without an explicit Release(), the cleanup
+// schedules deferred destruction via DestroyQueue — the same path as Release().
+func registerBindGroupCleanup(bg *BindGroup, dev *Device, label string) runtime.Cleanup {
+	halDevice := dev.halDevice()
+	if halDevice == nil {
+		// No HAL device — nothing to destroy.
+		return runtime.Cleanup{}
+	}
+
+	halBG := bg.hal
+	destroyFn := func() {
+		halDevice.DestroyBindGroup(halBG)
+	}
+
+	dq := dev.destroyQueue()
+	if dq == nil {
+		// No DestroyQueue — register cleanup that destroys immediately.
+		return runtime.AddCleanup(bg, func(ref bindGroupCleanupRef) {
+			if !ref.released.CompareAndSwap(false, true) {
+				return
+			}
+			slog.Warn("wgpu: BindGroup released by GC (missing explicit Release)", "label", ref.label)
+			ref.destroyFn()
+		}, bindGroupCleanupRef{
+			label:     label,
+			released:  bg.released,
+			destroyFn: destroyFn,
+		})
+	}
+
+	return runtime.AddCleanup(bg, func(ref bindGroupCleanupRef) {
+		if !ref.released.CompareAndSwap(false, true) {
+			return
+		}
+		slog.Warn("wgpu: BindGroup released by GC (missing explicit Release)", "label", ref.label)
+		subIdx := ref.lastSubIdx()
+		ref.destroyQueue.Defer(subIdx, "BindGroup(GC):"+ref.label, ref.destroyFn)
+	}, bindGroupCleanupRef{
+		label:        label,
+		released:     bg.released,
+		destroyQueue: dq,
+		lastSubIdx:   dev.lastSubmissionIndex,
+		destroyFn:    destroyFn,
 	})
 }

--- a/buffer.go
+++ b/buffer.go
@@ -4,17 +4,37 @@ package wgpu
 
 import (
 	"context"
+	"log/slog"
+	"runtime"
+	"sync/atomic"
 	"unsafe"
 
 	"github.com/gogpu/wgpu/core"
 	"github.com/gogpu/wgpu/hal"
 )
 
+// bufferCleanupRef holds the data needed to destroy a buffer's HAL resources
+// from a runtime.AddCleanup callback. This struct must NOT reference the Buffer
+// itself — runtime.AddCleanup requires the callback argument to be independent
+// of the cleaned-up object to avoid preventing garbage collection.
+type bufferCleanupRef struct {
+	label        string
+	released     *atomic.Bool
+	destroyQueue *core.DestroyQueue
+	lastSubIdx   func() uint64
+	destroyFn    func()
+}
+
 // Buffer represents a GPU buffer.
 type Buffer struct {
-	core     *core.Buffer
-	device   *Device
-	released bool
+	core    *core.Buffer
+	device  *Device
+	cleanup runtime.Cleanup
+	// released is heap-allocated separately so that the cleanup ref can share
+	// it without holding an interior pointer into the Buffer struct. An interior
+	// pointer would make the Buffer reachable from the cleanup arg, preventing
+	// GC collection and causing the cleanup to never fire.
+	released *atomic.Bool
 }
 
 // Size returns the buffer size in bytes.
@@ -31,10 +51,12 @@ func (b *Buffer) Label() string { return b.core.Label() }
 // that may reference it. This prevents use-after-free on DX12/Vulkan when a
 // buffer is released while the GPU is still reading from it (BUG-DX12-TDR).
 func (b *Buffer) Release() {
-	if b.released {
+	if b.released == nil || !b.released.CompareAndSwap(false, true) {
 		return
 	}
-	b.released = true
+
+	// Cancel the GC cleanup — we are destroying explicitly.
+	b.cleanup.Stop()
 
 	if b.device == nil {
 		b.core.Destroy()
@@ -243,4 +265,49 @@ func (b *Buffer) halBuffer() hal.Buffer {
 	guard := b.device.core.SnatchLock().Read()
 	defer guard.Release()
 	return b.core.Raw(guard)
+}
+
+// registerBufferCleanup registers a runtime.AddCleanup handler on the buffer.
+// When GC collects the buffer without an explicit Release(), the cleanup
+// schedules deferred destruction via DestroyQueue — the same path as Release().
+//
+// The cleanup ref struct captures only the label, released flag, DestroyQueue,
+// and core destroy function — NOT the Buffer pointer itself. This is a Go 1.24
+// runtime.AddCleanup requirement: the callback argument must not reference the
+// object being cleaned up.
+func registerBufferCleanup(buf *Buffer, dev *Device, coreBuf *core.Buffer, label string) runtime.Cleanup {
+	dq := dev.destroyQueue()
+	if dq == nil {
+		// No DestroyQueue — register cleanup that destroys immediately.
+		return runtime.AddCleanup(buf, func(ref bufferCleanupRef) {
+			if !ref.released.CompareAndSwap(false, true) {
+				return
+			}
+			slog.Warn("wgpu: Buffer released by GC (missing explicit Release)", "label", ref.label)
+			ref.destroyFn()
+		}, bufferCleanupRef{
+			label:    label,
+			released: buf.released,
+			destroyFn: func() {
+				coreBuf.Destroy()
+			},
+		})
+	}
+
+	return runtime.AddCleanup(buf, func(ref bufferCleanupRef) {
+		if !ref.released.CompareAndSwap(false, true) {
+			return
+		}
+		slog.Warn("wgpu: Buffer released by GC (missing explicit Release)", "label", ref.label)
+		subIdx := ref.lastSubIdx()
+		ref.destroyQueue.Defer(subIdx, "Buffer(GC):"+ref.label, ref.destroyFn)
+	}, bufferCleanupRef{
+		label:        label,
+		released:     buf.released,
+		destroyQueue: dq,
+		lastSubIdx:   dev.lastSubmissionIndex,
+		destroyFn: func() {
+			coreBuf.Destroy()
+		},
+	})
 }

--- a/cleanup_test.go
+++ b/cleanup_test.go
@@ -1,0 +1,353 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/gogpu/wgpu"
+
+	_ "github.com/gogpu/wgpu/hal/noop"
+)
+
+// =============================================================================
+// Buffer GC cleanup tests (BUG-WGPU-RESOURCE-LIFECYCLE-001 Phase A)
+// =============================================================================
+
+func TestBuffer_CleanupOnGC(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	dq := device.TestDestroyQueue()
+	if dq == nil {
+		t.Skip("device has no DestroyQueue")
+	}
+
+	pendingBefore := dq.Len()
+
+	// Create a buffer without calling Release(), then drop the reference.
+	// The GC cleanup should schedule deferred destruction via DestroyQueue.
+	func() {
+		buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+			Label: "gc-cleanup-buf",
+			Size:  64,
+			Usage: wgpu.BufferUsageVertex,
+		})
+		if err != nil {
+			t.Fatalf("CreateBuffer: %v", err)
+		}
+		// Ensure the buffer is reachable up to this point.
+		runtime.KeepAlive(buf)
+		// buf goes out of scope here — eligible for GC.
+	}()
+
+	// Force GC to trigger the cleanup.
+	runtime.GC()
+	runtime.GC() // second pass to ensure finalizers/cleanups run
+
+	// Give cleanup goroutine time to execute (runtime.AddCleanup runs
+	// asynchronously on a background goroutine).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if dq.Len() > pendingBefore {
+			break
+		}
+		runtime.Gosched()
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	pendingAfter := dq.Len()
+	if pendingAfter <= pendingBefore {
+		t.Errorf("DestroyQueue pending count did not increase after GC: before=%d, after=%d",
+			pendingBefore, pendingAfter)
+	}
+}
+
+func TestBuffer_ExplicitRelease_CancelsCleanup(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	dq := device.TestDestroyQueue()
+	if dq == nil {
+		t.Skip("device has no DestroyQueue")
+	}
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "explicit-release-buf",
+		Size:  64,
+		Usage: wgpu.BufferUsageVertex,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+
+	// Explicit Release should cancel the GC cleanup.
+	buf.Release()
+
+	if !buf.TestReleased() {
+		t.Fatal("buffer should be marked as released after Release()")
+	}
+
+	// Record pending count after Release.
+	pendingAfterRelease := dq.Len()
+
+	// Force GC — cleanup should NOT fire because it was canceled.
+	runtime.GC()
+	runtime.GC()
+	runtime.Gosched()
+	time.Sleep(50 * time.Millisecond)
+
+	pendingAfterGC := dq.Len()
+	if pendingAfterGC != pendingAfterRelease {
+		t.Errorf("GC cleanup fired after explicit Release: pending before GC=%d, after GC=%d",
+			pendingAfterRelease, pendingAfterGC)
+	}
+}
+
+func TestBuffer_DoubleRelease_NoPanic(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "double-release-buf",
+		Size:  64,
+		Usage: wgpu.BufferUsageVertex,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+
+	// Should not panic.
+	buf.Release()
+	buf.Release()
+}
+
+// =============================================================================
+// BindGroup GC cleanup tests (BUG-WGPU-RESOURCE-LIFECYCLE-001 Phase A)
+// =============================================================================
+
+func TestBindGroup_CleanupOnGC(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	dq := device.TestDestroyQueue()
+	if dq == nil {
+		t.Skip("device has no DestroyQueue")
+	}
+
+	layout, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "gc-bgl",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer layout.Release()
+
+	pendingBefore := dq.Len()
+
+	// Create a bind group without calling Release(), then drop the reference.
+	func() {
+		bg, bgErr := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+			Label:  "gc-cleanup-bg",
+			Layout: layout,
+		})
+		if bgErr != nil {
+			t.Fatalf("CreateBindGroup: %v", bgErr)
+		}
+		runtime.KeepAlive(bg)
+	}()
+
+	runtime.GC()
+	runtime.GC()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if dq.Len() > pendingBefore {
+			break
+		}
+		runtime.Gosched()
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	pendingAfter := dq.Len()
+	if pendingAfter <= pendingBefore {
+		t.Errorf("DestroyQueue pending count did not increase after GC: before=%d, after=%d",
+			pendingBefore, pendingAfter)
+	}
+}
+
+func TestBindGroup_ExplicitRelease_CancelsCleanup(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	dq := device.TestDestroyQueue()
+	if dq == nil {
+		t.Skip("device has no DestroyQueue")
+	}
+
+	layout, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "release-bgl",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer layout.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "explicit-release-bg",
+		Layout: layout,
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+
+	bg.Release()
+
+	if !bg.TestBindGroupReleased() {
+		t.Fatal("bind group should be marked as released after Release()")
+	}
+
+	pendingAfterRelease := dq.Len()
+
+	runtime.GC()
+	runtime.GC()
+	runtime.Gosched()
+	time.Sleep(50 * time.Millisecond)
+
+	pendingAfterGC := dq.Len()
+	if pendingAfterGC != pendingAfterRelease {
+		t.Errorf("GC cleanup fired after explicit Release: pending before GC=%d, after GC=%d",
+			pendingAfterRelease, pendingAfterGC)
+	}
+}
+
+func TestBindGroup_DoubleRelease_NoPanic(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	layout, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "dbl-bgl",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer layout.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "double-release-bg",
+		Layout: layout,
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+
+	bg.Release()
+	bg.Release()
+}
+
+// =============================================================================
+// Benchmark: CreateBuffer overhead with runtime.AddCleanup
+// =============================================================================
+
+func BenchmarkCreateBuffer(b *testing.B) {
+	inst, err := wgpu.CreateInstance(nil)
+	if err != nil {
+		b.Fatalf("CreateInstance: %v", err)
+	}
+	defer inst.Release()
+
+	adapter, err := inst.RequestAdapter(nil)
+	if err != nil {
+		b.Fatalf("RequestAdapter: %v", err)
+	}
+	defer adapter.Release()
+
+	device, err := adapter.RequestDevice(nil)
+	if err != nil {
+		b.Fatalf("RequestDevice: %v", err)
+	}
+	defer device.Release()
+
+	q := device.Queue()
+	if q == nil {
+		b.Skip("skipping: device has no HAL integration")
+	}
+
+	desc := &wgpu.BufferDescriptor{
+		Label: "bench-buf",
+		Size:  256,
+		Usage: wgpu.BufferUsageVertex | wgpu.BufferUsageCopyDst,
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		buf, bufErr := device.CreateBuffer(desc)
+		if bufErr != nil {
+			b.Fatalf("CreateBuffer: %v", bufErr)
+		}
+		buf.Release()
+	}
+}
+
+func BenchmarkCreateBindGroup(b *testing.B) {
+	inst, err := wgpu.CreateInstance(nil)
+	if err != nil {
+		b.Fatalf("CreateInstance: %v", err)
+	}
+	defer inst.Release()
+
+	adapter, err := inst.RequestAdapter(nil)
+	if err != nil {
+		b.Fatalf("RequestAdapter: %v", err)
+	}
+	defer adapter.Release()
+
+	device, err := adapter.RequestDevice(nil)
+	if err != nil {
+		b.Fatalf("RequestDevice: %v", err)
+	}
+	defer device.Release()
+
+	q := device.Queue()
+	if q == nil {
+		b.Skip("skipping: device has no HAL integration")
+	}
+
+	layout, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "bench-bgl",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		b.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer layout.Release()
+
+	desc := &wgpu.BindGroupDescriptor{
+		Label:  "bench-bg",
+		Layout: layout,
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		bg, bgErr := device.CreateBindGroup(desc)
+		if bgErr != nil {
+			b.Fatalf("CreateBindGroup: %v", bgErr)
+		}
+		bg.Release()
+	}
+}

--- a/device_native.go
+++ b/device_native.go
@@ -4,6 +4,7 @@ package wgpu
 
 import (
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/gogpu/gputypes"
@@ -82,7 +83,15 @@ func (d *Device) CreateBuffer(desc *BufferDescriptor) (*Buffer, error) {
 	// The Ref tracks in-flight usage: Clone'd on encoding, Drop'd on GPU completion.
 	coreBuffer.Ref = core.NewResourceRef("Buffer:"+desc.Label, nil)
 
-	return &Buffer{core: coreBuffer, device: d}, nil
+	buf := &Buffer{core: coreBuffer, device: d, released: new(atomic.Bool)}
+
+	// Safety net: if the buffer is garbage collected without Release(),
+	// schedule deferred destruction via DestroyQueue. This prevents
+	// resource leaks when callers create per-frame buffers without
+	// explicit lifecycle management (BUG-WGPU-RESOURCE-LIFECYCLE-001).
+	buf.cleanup = registerBufferCleanup(buf, d, coreBuffer, desc.Label)
+
+	return buf, nil
 }
 
 // CreateTexture creates a GPU texture.
@@ -383,13 +392,20 @@ func (d *Device) CreateBindGroup(desc *BindGroupDescriptor) (*BindGroup, error) 
 		})
 	}
 
-	return &BindGroup{
+	bg := &BindGroup{
 		hal:                    halGroup,
 		device:                 d,
+		released:               new(atomic.Bool),
 		layout:                 desc.Layout,
 		lateBufferBindingInfos: lateInfos,
 		ref:                    core.NewResourceRef("BindGroup:"+desc.Label, nil),
-	}, nil
+	}
+
+	// Safety net: if the bind group is garbage collected without Release(),
+	// schedule deferred destruction via DestroyQueue (BUG-WGPU-RESOURCE-LIFECYCLE-001).
+	bg.cleanup = registerBindGroupCleanup(bg, d, desc.Label)
+
+	return bg, nil
 }
 
 // buildBindGroupEntryMap builds a lookup map from binding index to BindGroupEntry

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -237,7 +237,7 @@ Backend.CreateInstance()
         → Device.Destroy*(res)     // release
 ```
 
-All resources must be explicitly released. The `core/` layer provides leak detection.
+Resources should be explicitly Released for deterministic cleanup. `runtime.AddCleanup` (Go 1.24+) provides a GC-based safety net for Buffer and BindGroup — unreleased resources are automatically scheduled for deferred destruction via DestroyQueue when collected. Leak detection logs `slog.Warn` when GC cleans up a forgotten resource (ADR-018).
 
 ## Pure Go Approach
 

--- a/export_test.go
+++ b/export_test.go
@@ -38,3 +38,24 @@ func (d *Device) TestCmdEncoderPoolSize() int {
 	defer d.cmdEncoderPool.mu.Unlock()
 	return len(d.cmdEncoderPool.free)
 }
+
+// TestReleased returns true if the buffer has been released (testing only).
+func (b *Buffer) TestReleased() bool {
+	if b.released == nil {
+		return false
+	}
+	return b.released.Load()
+}
+
+// TestDestroyQueue returns the device's DestroyQueue (testing only).
+func (d *Device) TestDestroyQueue() *core.DestroyQueue {
+	return d.destroyQueue()
+}
+
+// TestBindGroupReleased returns true if the bind group has been released (testing only).
+func (g *BindGroup) TestBindGroupReleased() bool {
+	if g.released == nil {
+		return false
+	}
+	return g.released.Load()
+}

--- a/pending_writes.go
+++ b/pending_writes.go
@@ -54,6 +54,11 @@ type pendingWrites struct {
 	// completes the submission that references them. Moved to inflight on flush.
 	staging []hal.Buffer
 
+	// copyRegion is a pre-allocated single-element BufferCopy slice used by
+	// writeBuffer to avoid heap escape when calling CopyBufferToBuffer through
+	// the hal.CommandEncoder interface. Reused across writes within a frame.
+	copyRegion [1]hal.BufferCopy
+
 	// dstBuffers tracks buffers that have pending writes, keyed by HAL buffer
 	// with their creation usage flags as values. Usage is passed from the wgpu
 	// public API level (matching Rust wgpu-core where usage lives on core::Buffer,
@@ -174,13 +179,13 @@ func (pw *pendingWrites) writeBuffer(buffer hal.Buffer, usage gputypes.BufferUsa
 		pw.belt.chunkedAllocs = pw.belt.chunkedAllocs[:0]
 	} else {
 		// Normal (non-chunked) path: single CopyBufferToBuffer.
-		// Stack-allocate copy region to avoid slice heap escape.
-		copyRegion := [1]hal.BufferCopy{{
+		// Use pre-allocated pw.copyRegion to avoid heap escape through interface call.
+		pw.copyRegion[0] = hal.BufferCopy{
 			SrcOffset: alloc.offset,
 			DstOffset: offset,
 			Size:      dataLen,
-		}}
-		enc.CopyBufferToBuffer(alloc.buffer, buffer, copyRegion[:])
+		}
+		enc.CopyBufferToBuffer(alloc.buffer, buffer, pw.copyRegion[:])
 	}
 
 	// Track destination buffer for barrier computation at flush time.
@@ -412,7 +417,8 @@ func (pw *pendingWrites) flush() (hal.CommandBuffer, hal.CommandEncoder, []hal.T
 	// We extract read-only flags (VERTEX|INDEX|UNIFORM|INDIRECT) from the creation
 	// usage to determine the target state.
 	if len(pw.dstBuffers) > 0 {
-		barriers := make([]hal.BufferBarrier, 0, len(pw.dstBuffers))
+		var stackBarriers [8]hal.BufferBarrier
+		barriers := stackBarriers[:0]
 		for buf, usage := range pw.dstBuffers {
 			readUsage := bufferReadUsage(usage)
 			if readUsage != 0 {


### PR DESCRIPTION
## Summary

- **Automatic Buffer/BindGroup cleanup** (BUG-WGPU-RESOURCE-LIFECYCLE-001) — `runtime.AddCleanup` schedules deferred destruction when GC collects unreleased resources. Prevents per-frame leaks (120 buffers/sec → stuttering). ADR-018.
- **Interior pointer bug fix** — `released` field changed from embedded to heap-allocated `*atomic.Bool` to avoid preventing GC collection.
- **Zero-allocation WriteBuffer batching** — pre-allocated `[1]hal.BufferCopy` + `[8]hal.BufferBarrier` stack arrays. Batching: 1 alloc → **0 allocs/op**.

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass (8 new tests)
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] Benchmarks: all hot paths 0 allocs/op
- [x] `gofmt` — clean
- [ ] CI