### PR TITLE
v0.26.3: fix Vulkan offscreen semaphore hijack + resource lifecycle + zero-alloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.3] - 2026-04-25
+
+### Fixed
+
+- **Vulkan: offscreen submit hijacks swapchain semaphores** (BUG-WGPU-VK-005) — when two GPU
+  submits occur per frame (offscreen RepaintBoundary + compositor), the first submit consumed
+  acquire/present semaphores meant for the compositor → race condition → flickering. Fix:
+  `Queue.SetSwapchainSuppressed(bool)` temporarily disables semaphore binding for offscreen
+  submits. Follows VK-004 precedent (`WriteTexture` save/restore pattern). ADR-019.
+
 ## [0.26.2] - 2026-04-25
 
 ### Fixed

--- a/hal/api.go
+++ b/hal/api.go
@@ -299,6 +299,33 @@ type Queue interface {
 	// GLES, Software). When false, PendingWrites passes WriteBuffer/WriteTexture
 	// directly to the HAL without batching.
 	SupportsCommandBufferCopies() bool
+
+	// SetSwapchainSuppressed temporarily disables swapchain semaphore binding
+	// for subsequent Submit calls. Used for offscreen renders (e.g., RepaintBoundary)
+	// that must not consume acquire/present semaphores intended for the compositor
+	// submit. Call with true before offscreen submits, false after.
+	//
+	// BUG-WGPU-VK-005: Without this, the first Submit per frame hijacks swapchain
+	// semaphores even when rendering to an offscreen texture, causing the compositor
+	// submit to run without synchronization (race condition -> flickering).
+	//
+	// Only meaningful on Vulkan — other backends are no-ops (DX12/Metal/GLES/Software
+	// have different synchronization models that don't exhibit this issue).
+	//
+	// Thread-safe: acquires the queue mutex internally.
+	// Zero allocations: two pointer writes + one bool write.
+	//
+	// Callers must restore state with SetSwapchainSuppressed(false) after offscreen
+	// submits complete. Use defer for safety:
+	//
+	//   queue.SetSwapchainSuppressed(true)
+	//   defer queue.SetSwapchainSuppressed(false)
+	//   queue.Submit(offscreenCmds)
+	//
+	// Precedent: VK-004 save/restore pattern in WriteTexture (queue.go:620-634).
+	// Long-term: Phase B (ADR-019) will add surface_textures to Submit signature
+	// matching Rust wgpu-hal, eliminating the need for this method.
+	SetSwapchainSuppressed(suppressed bool)
 }
 
 // MaxStagingBufferSizer is an optional interface implemented by HAL devices

--- a/hal/dx12/queue.go
+++ b/hal/dx12/queue.go
@@ -483,6 +483,12 @@ func (q *Queue) SupportsCommandBufferCopies() bool {
 	return true
 }
 
+// SetSwapchainSuppressed is a no-op on DX12.
+// DX12 does not use swapchain semaphores — presentation synchronization is
+// handled by DXGI fence signaling, which is not affected by submit ordering.
+// See BUG-WGPU-VK-005 (Vulkan-specific issue).
+func (q *Queue) SetSwapchainSuppressed(_ bool) {}
+
 // -----------------------------------------------------------------------------
 // Compile-time interface assertions
 // -----------------------------------------------------------------------------

--- a/hal/gles/queue.go
+++ b/hal/gles/queue.go
@@ -143,3 +143,8 @@ func (q *Queue) GetTimestampPeriod() float32 {
 func (q *Queue) SupportsCommandBufferCopies() bool {
 	return false
 }
+
+// SetSwapchainSuppressed is a no-op on GLES.
+// GLES uses eglSwapBuffers for presentation, which is not affected by command
+// submission ordering. See BUG-WGPU-VK-005 (Vulkan-specific).
+func (q *Queue) SetSwapchainSuppressed(_ bool) {}

--- a/hal/gles/queue_linux.go
+++ b/hal/gles/queue_linux.go
@@ -177,3 +177,8 @@ func (q *Queue) GetTimestampPeriod() float32 {
 func (q *Queue) SupportsCommandBufferCopies() bool {
 	return false
 }
+
+// SetSwapchainSuppressed is a no-op on GLES.
+// GLES uses eglSwapBuffers for presentation, which is not affected by command
+// submission ordering. See BUG-WGPU-VK-005 (Vulkan-specific).
+func (q *Queue) SetSwapchainSuppressed(_ bool) {}

--- a/hal/metal/queue.go
+++ b/hal/metal/queue.go
@@ -417,3 +417,9 @@ func (q *Queue) GetTimestampPeriod() float32 {
 func (q *Queue) SupportsCommandBufferCopies() bool {
 	return true
 }
+
+// SetSwapchainSuppressed is a no-op on Metal.
+// Metal presents via CAMetalDrawable which is not affected by command buffer
+// submission ordering — each presentDrawable: call operates on a specific
+// drawable, not on implicit semaphore state. See BUG-WGPU-VK-005 (Vulkan-specific).
+func (q *Queue) SetSwapchainSuppressed(_ bool) {}

--- a/hal/noop/queue.go
+++ b/hal/noop/queue.go
@@ -67,3 +67,7 @@ func (q *Queue) GetTimestampPeriod() float32 {
 func (q *Queue) SupportsCommandBufferCopies() bool {
 	return false
 }
+
+// SetSwapchainSuppressed is a no-op on the noop backend.
+// See BUG-WGPU-VK-005 (Vulkan-specific).
+func (q *Queue) SetSwapchainSuppressed(_ bool) {}

--- a/hal/noop/swapchain_suppressed_test.go
+++ b/hal/noop/swapchain_suppressed_test.go
@@ -1,0 +1,154 @@
+//go:build !(js && wasm)
+
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+package noop_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/hal"
+	"github.com/gogpu/wgpu/hal/noop"
+)
+
+// TestSetSwapchainSuppressed_NoopNoPanic verifies that SetSwapchainSuppressed
+// does not panic on the noop backend. This is the minimum contract for non-Vulkan
+// backends: accept the call silently.
+func TestSetSwapchainSuppressed_NoopNoPanic(t *testing.T) {
+	api := noop.API{}
+	instance, err := api.CreateInstance(nil)
+	if err != nil {
+		t.Fatalf("CreateInstance failed: %v", err)
+	}
+	defer instance.Destroy()
+
+	adapters := instance.EnumerateAdapters(nil)
+	if len(adapters) == 0 {
+		t.Fatal("no adapters")
+	}
+	openDevice, err := adapters[0].Adapter.Open(0, gputypes.DefaultLimits())
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer openDevice.Device.Destroy()
+
+	queue := openDevice.Queue
+
+	// Should not panic.
+	queue.SetSwapchainSuppressed(true)
+	queue.SetSwapchainSuppressed(false)
+}
+
+// TestSetSwapchainSuppressed_SubmitDuringSuppression verifies that Submit works
+// normally while swapchain is suppressed. On noop this is trivially true but
+// confirms the interface contract holds end-to-end.
+func TestSetSwapchainSuppressed_SubmitDuringSuppression(t *testing.T) {
+	api := noop.API{}
+	instance, err := api.CreateInstance(nil)
+	if err != nil {
+		t.Fatalf("CreateInstance failed: %v", err)
+	}
+	defer instance.Destroy()
+
+	adapters := instance.EnumerateAdapters(nil)
+	openDevice, err := adapters[0].Adapter.Open(0, gputypes.DefaultLimits())
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer openDevice.Device.Destroy()
+
+	queue := openDevice.Queue
+	device := openDevice.Device
+
+	// Create a command buffer.
+	encoder, err := device.CreateCommandEncoder(&hal.CommandEncoderDescriptor{Label: "test"})
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder failed: %v", err)
+	}
+	if err := encoder.BeginEncoding("test"); err != nil {
+		t.Fatalf("BeginEncoding failed: %v", err)
+	}
+	cmdBuffer, err := encoder.EndEncoding()
+	if err != nil {
+		t.Fatalf("EndEncoding failed: %v", err)
+	}
+
+	// Suppress -> Submit -> Unsuppress -> Submit.
+	queue.SetSwapchainSuppressed(true)
+	idx1, err := queue.Submit([]hal.CommandBuffer{cmdBuffer})
+	if err != nil {
+		t.Fatalf("Submit during suppression failed: %v", err)
+	}
+	queue.SetSwapchainSuppressed(false)
+
+	encoder2, _ := device.CreateCommandEncoder(&hal.CommandEncoderDescriptor{Label: "test2"})
+	_ = encoder2.BeginEncoding("test2")
+	cmdBuffer2, _ := encoder2.EndEncoding()
+
+	idx2, err := queue.Submit([]hal.CommandBuffer{cmdBuffer2})
+	if err != nil {
+		t.Fatalf("Submit after unsuppression failed: %v", err)
+	}
+
+	if idx2 <= idx1 {
+		t.Errorf("submission indices should be monotonically increasing: %d <= %d", idx2, idx1)
+	}
+}
+
+// TestSetSwapchainSuppressed_Idempotent verifies that calling
+// SetSwapchainSuppressed(true) twice or SetSwapchainSuppressed(false) twice
+// does not panic or corrupt state.
+func TestSetSwapchainSuppressed_Idempotent(t *testing.T) {
+	api := noop.API{}
+	instance, err := api.CreateInstance(nil)
+	if err != nil {
+		t.Fatalf("CreateInstance failed: %v", err)
+	}
+	defer instance.Destroy()
+
+	adapters := instance.EnumerateAdapters(nil)
+	openDevice, err := adapters[0].Adapter.Open(0, gputypes.DefaultLimits())
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer openDevice.Device.Destroy()
+
+	queue := openDevice.Queue
+
+	// Double-true, double-false: must not panic.
+	queue.SetSwapchainSuppressed(true)
+	queue.SetSwapchainSuppressed(true)
+	queue.SetSwapchainSuppressed(false)
+	queue.SetSwapchainSuppressed(false)
+
+	// Alternating: must not panic.
+	queue.SetSwapchainSuppressed(true)
+	queue.SetSwapchainSuppressed(false)
+	queue.SetSwapchainSuppressed(true)
+	queue.SetSwapchainSuppressed(false)
+}
+
+// BenchmarkSetSwapchainSuppressed verifies zero allocations for the
+// suppress/unsuppress cycle. This is called twice per frame in the
+// RepaintBoundary path (suppress before offscreen, unsuppress after).
+func BenchmarkSetSwapchainSuppressed(b *testing.B) {
+	b.ReportAllocs()
+
+	api := noop.API{}
+	instance, _ := api.CreateInstance(nil)
+	defer instance.Destroy()
+
+	adapters := instance.EnumerateAdapters(nil)
+	openDevice, _ := adapters[0].Adapter.Open(0, gputypes.DefaultLimits())
+	defer openDevice.Device.Destroy()
+
+	queue := openDevice.Queue
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		queue.SetSwapchainSuppressed(true)
+		queue.SetSwapchainSuppressed(false)
+	}
+}

--- a/hal/software/queue.go
+++ b/hal/software/queue.go
@@ -155,3 +155,7 @@ func (q *Queue) GetTimestampPeriod() float32 {
 func (q *Queue) SupportsCommandBufferCopies() bool {
 	return false
 }
+
+// SetSwapchainSuppressed is a no-op on the software backend.
+// Software backend has no GPU semaphores. See BUG-WGPU-VK-005 (Vulkan-specific).
+func (q *Queue) SetSwapchainSuppressed(_ bool) {}

--- a/hal/vulkan/queue.go
+++ b/hal/vulkan/queue.go
@@ -128,6 +128,14 @@ type Queue struct {
 	acquireUsed     bool       // True if acquire semaphore was consumed by a submit
 	relay           *relaySemaphores
 	mu              sync.Mutex // Protects Submit() and Present() from concurrent access
+
+	// BUG-WGPU-VK-005: Offscreen submit semaphore suppression.
+	// When swapchainSuppressed is true, Submit skips swapchain semaphore binding.
+	// savedSwapchain/savedAcquireUsed hold the original values for restoration.
+	// Same pattern as VK-004 (WriteTexture, lines 620-634) but caller-controlled.
+	swapchainSuppressed bool
+	savedSwapchain      *Swapchain
+	savedAcquireUsed    bool
 }
 
 // Submit submits command buffers to the GPU.
@@ -702,6 +710,40 @@ func (q *Queue) GetTimestampPeriod() float32 {
 // Vulkan uses command buffers for copy operations — PendingWrites batches them.
 func (q *Queue) SupportsCommandBufferCopies() bool {
 	return true
+}
+
+// SetSwapchainSuppressed temporarily disables swapchain semaphore binding
+// for subsequent Submit calls. Used for offscreen renders that must not
+// consume acquire/present semaphores intended for the compositor submit.
+//
+// BUG-WGPU-VK-005: When ui uses RepaintBoundary with GPU texture caching,
+// there are two Submit calls per frame (offscreen + compositor). Without
+// suppression, the first (offscreen) submit hijacks swapchain semaphores,
+// leaving the compositor submit without synchronization -> race -> flickering.
+//
+// When suppressed is true: saves activeSwapchain/acquireUsed, clears activeSwapchain.
+// When suppressed is false: restores saved values.
+//
+// Same save/restore pattern as VK-004 in WriteTexture (lines 620-634).
+func (q *Queue) SetSwapchainSuppressed(suppressed bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if suppressed {
+		// Save current swapchain state and suppress semaphore binding.
+		q.savedSwapchain = q.activeSwapchain
+		q.savedAcquireUsed = q.acquireUsed
+		q.activeSwapchain = nil
+		q.swapchainSuppressed = true
+	} else if q.swapchainSuppressed {
+		// Restore saved swapchain state so the next Submit (compositor)
+		// correctly binds acquire/present semaphores.
+		q.activeSwapchain = q.savedSwapchain
+		q.acquireUsed = q.savedAcquireUsed
+		q.savedSwapchain = nil
+		q.savedAcquireUsed = false
+		q.swapchainSuppressed = false
+	}
 }
 
 // Vulkan function wrapper

--- a/queue_browser.go
+++ b/queue_browser.go
@@ -27,6 +27,10 @@ func (q *Queue) WriteTexture(dst *ImageCopyTexture, data []byte, layout *ImageDa
 	panic("wgpu: browser backend not yet implemented")
 }
 
+// SetSwapchainSuppressed is a no-op on the browser backend.
+// WebGPU browser API handles swapchain synchronization internally.
+func (q *Queue) SetSwapchainSuppressed(_ bool) {}
+
 // LastSubmissionIndex returns the most recent submission index.
 func (q *Queue) LastSubmissionIndex() uint64 {
 	return 0

--- a/queue_native.go
+++ b/queue_native.go
@@ -236,6 +236,29 @@ func (q *Queue) WriteTexture(dst *ImageCopyTexture, data []byte, layout *ImageDa
 	return q.hal.WriteTexture(halDst, data, &halLayout, &halSize)
 }
 
+// SetSwapchainSuppressed temporarily disables swapchain semaphore binding
+// for subsequent Submit calls. Used for offscreen renders (e.g., RepaintBoundary)
+// that must not consume acquire/present semaphores intended for the compositor
+// submit.
+//
+// BUG-WGPU-VK-005: When rendering to an offscreen texture before compositing
+// to the swapchain surface, the offscreen submit must not hijack swapchain
+// semaphores. Without suppression, the compositor submit runs without GPU-side
+// synchronization, causing a race condition (flickering).
+//
+// Call with true before offscreen submits, false after:
+//
+//	queue.SetSwapchainSuppressed(true)
+//	defer queue.SetSwapchainSuppressed(false)
+//	queue.Submit(offscreenCmds...)
+//
+// Only meaningful on Vulkan — other backends are no-ops.
+func (q *Queue) SetSwapchainSuppressed(suppressed bool) {
+	if q.hal != nil {
+		q.hal.SetSwapchainSuppressed(suppressed)
+	}
+}
+
 // LastSubmissionIndex returns the most recent submission index.
 // Used by resource Release() methods to schedule deferred destruction.
 func (q *Queue) LastSubmissionIndex() uint64 {


### PR DESCRIPTION
## Summary

- **fix(vulkan): offscreen submit semaphore hijack** (BUG-WGPU-VK-005) — first submit per frame consumed swapchain semaphores even for offscreen renders → compositor submit without sync → flickering. `Queue.SetSwapchainSuppressed(bool)` disables semaphore binding for offscreen submits. ADR-019. Same bug existed in [Rust wgpu #5559](https://github.com/gfx-rs/wgpu/issues/5559).
- **fix: automatic Buffer/BindGroup cleanup** (BUG-WGPU-RESOURCE-LIFECYCLE-001) — `runtime.AddCleanup` GC safety net prevents per-frame resource leaks. ADR-018.
- **perf: zero-alloc WriteBuffer batching** — pre-allocated BufferCopy + stack barriers. 1 alloc → **0 allocs/op**.

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues all 3 platforms
- [x] Benchmarks: 0 allocs on all hot paths
- [ ] CI