### PR TITLE
v0.26.5: CopyTextureToTexture public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.5] - 2026-04-26
+
+### Added
+
+- **Public API: `CommandEncoder.CopyTextureToTexture`** — WebGPU spec
+  `GPUCommandEncoder.copyTextureToTexture()`. DMA hardware copy between textures with
+  sub-region support (Origin + Size). Uses Copy engine, not 3D engine — significantly
+  cheaper than render pass blit. Enables dirty-region-only present path for UI frameworks.
+  Implemented in all 6 HAL backends, now exposed on public API.
+- `TextureCopy` descriptor type for texture-to-texture copy regions.
+
 ## [0.26.4] - 2026-04-25
 
 ### Fixed

--- a/descriptor.go
+++ b/descriptor.go
@@ -509,6 +509,22 @@ func (i *ImageCopyTexture) toHAL() *hal.ImageCopyTexture {
 	}
 }
 
+// TextureCopy describes a texture-to-texture copy region.
+// WebGPU spec: GPUCommandEncoder.copyTextureToTexture()
+type TextureCopy struct {
+	Source      ImageCopyTexture
+	Destination ImageCopyTexture
+	Size        Extent3D
+}
+
+func (t *TextureCopy) toHAL() hal.TextureCopy {
+	return hal.TextureCopy{
+		SrcBase: *t.Source.toHAL(),
+		DstBase: *t.Destination.toHAL(),
+		Size:    t.Size.toHAL(),
+	}
+}
+
 // TextureUsageTransition defines a texture usage state transition.
 type TextureUsageTransition struct {
 	OldUsage TextureUsage

--- a/descriptor_browser.go
+++ b/descriptor_browser.go
@@ -255,6 +255,13 @@ type TextureBarrier struct {
 	Usage   TextureUsageTransition
 }
 
+// TextureCopy describes a texture-to-texture copy region.
+type TextureCopy struct {
+	Source      ImageCopyTexture
+	Destination ImageCopyTexture
+	Size        Extent3D
+}
+
 // BufferTextureCopy defines a buffer-texture copy region.
 type BufferTextureCopy struct {
 	BufferLayout ImageDataLayout

--- a/encoder_browser.go
+++ b/encoder_browser.go
@@ -27,6 +27,11 @@ func (e *CommandEncoder) CopyTextureToBuffer(src *Texture, dst *Buffer, regions 
 	panic("wgpu: browser backend not yet implemented")
 }
 
+// CopyTextureToTexture copies data between textures.
+func (e *CommandEncoder) CopyTextureToTexture(src, dst *Texture, regions []TextureCopy) {
+	panic("wgpu: browser backend not yet implemented")
+}
+
 // TransitionTextures transitions texture states for synchronization.
 func (e *CommandEncoder) TransitionTextures(barriers []TextureBarrier) {
 	panic("wgpu: browser backend not yet implemented")

--- a/encoder_native.go
+++ b/encoder_native.go
@@ -146,6 +146,34 @@ func (e *CommandEncoder) CopyTextureToBuffer(src *Texture, dst *Buffer, regions 
 	raw.CopyTextureToBuffer(src.hal, halDst, halRegions)
 }
 
+// CopyTextureToTexture copies data between textures using DMA hardware copy.
+// WebGPU spec: GPUCommandEncoder.copyTextureToTexture()
+func (e *CommandEncoder) CopyTextureToTexture(src, dst *Texture, regions []TextureCopy) {
+	if e.released {
+		return
+	}
+	if src == nil {
+		e.setError(fmt.Errorf("wgpu: CommandEncoder.CopyTextureToTexture: source texture is nil"))
+		return
+	}
+	if dst == nil {
+		e.setError(fmt.Errorf("wgpu: CommandEncoder.CopyTextureToTexture: destination texture is nil"))
+		return
+	}
+	raw := e.core.RawEncoder()
+	if raw == nil {
+		return
+	}
+	if src.hal == nil || dst.hal == nil {
+		return
+	}
+	halRegions := make([]hal.TextureCopy, len(regions))
+	for i, r := range regions {
+		halRegions[i] = r.toHAL()
+	}
+	raw.CopyTextureToTexture(src.hal, dst.hal, halRegions)
+}
+
 // TransitionTextures transitions texture states for synchronization.
 // This is needed on Vulkan for layout transitions between render pass
 // and copy operations (e.g., after MSAA resolve before CopyTextureToBuffer).


### PR DESCRIPTION
## Summary

- **`CommandEncoder.CopyTextureToTexture`** — WebGPU spec `GPUCommandEncoder.copyTextureToTexture()`. DMA hardware copy between textures with sub-region support.
- `TextureCopy` descriptor type
- Browser stubs for WASM build

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] `gofmt -l .` — clean
- [ ] CI