### PR TITLE
v0.26.6: compute dispatch barriers + workgroup validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Implemented in all 6 HAL backends, now exposed on public API.
 - `TextureCopy` descriptor type for texture-to-texture copy regions.
 
+## [0.26.6] - 2026-04-26
+
+### Added
+
+- **Compute dispatch memory barriers** (VAL-008) — automatic compute→compute memory barrier
+  after every `Dispatch` and `DispatchIndirect` across all GPU backends. Prevents silent
+  data corruption when consecutive dispatches share storage buffers. Vulkan:
+  `vkCmdPipelineBarrier`, DX12: global UAV barrier, Metal: `memoryBarrierWithScope:`, GLES:
+  already had per-dispatch barriers. Matches Rust wgpu-core `flush_bindings` pattern.
+- **Dispatch workgroup count validation** (VAL-009) — `Dispatch(x, y, z)` checks each
+  dimension against `MaxComputeWorkgroupsPerDimension`. Returns clean error instead of
+  driver crash. `(0, 0, 0)` allowed as no-op per WebGPU spec.
+- **CreateComputePipeline workgroup_size validation** (VAL-010) — validates each dimension
+  against `MaxComputeWorkgroupSizeX/Y/Z` and total invocations against
+  `MaxComputeInvocationsPerWorkgroup`. Rejects workgroup_size containing 0.
+
 ## [0.26.4] - 2026-04-25
 
 ### Fixed

--- a/computepass_native.go
+++ b/computepass_native.go
@@ -103,6 +103,18 @@ func (p *ComputePassEncoder) Dispatch(x, y, z uint32) {
 	if !p.validateDispatchState("Dispatch") {
 		return
 	}
+
+	// VAL-009: Validate workgroup counts against device limits.
+	// Matches Rust wgpu-core compute.rs:853-870.
+	// (0, 0, 0) is allowed as a no-op per spec.
+	limit := p.encoder.device.core.Limits.MaxComputeWorkgroupsPerDimension
+	if x > limit || y > limit || z > limit {
+		p.encoder.setError(fmt.Errorf(
+			"wgpu: ComputePass.Dispatch: workgroup count (%d, %d, %d) exceeds device limit %d",
+			x, y, z, limit))
+		return
+	}
+
 	p.core.Dispatch(x, y, z)
 }
 

--- a/core/error.go
+++ b/core/error.go
@@ -605,6 +605,12 @@ const (
 	CreateComputePipelineErrorMissingEntryPoint
 	// CreateComputePipelineErrorHAL indicates the HAL backend failed to create the pipeline.
 	CreateComputePipelineErrorHAL
+	// CreateComputePipelineErrorWorkgroupSizeExceeded indicates a workgroup dimension exceeds device limits.
+	CreateComputePipelineErrorWorkgroupSizeExceeded
+	// CreateComputePipelineErrorWorkgroupSizeZero indicates a workgroup dimension is zero.
+	CreateComputePipelineErrorWorkgroupSizeZero
+	// CreateComputePipelineErrorTooManyInvocations indicates total invocations exceed device limit.
+	CreateComputePipelineErrorTooManyInvocations
 )
 
 // CreateComputePipelineError represents an error during compute pipeline creation.
@@ -612,6 +618,14 @@ type CreateComputePipelineError struct {
 	Kind     CreateComputePipelineErrorKind
 	Label    string
 	HALError error
+	// Dimension is the axis name ("X", "Y", "Z") for workgroup size errors.
+	Dimension string
+	// Size is the workgroup size value that caused the error.
+	Size uint32
+	// Limit is the device limit that was exceeded.
+	Limit uint32
+	// TotalInvocations is the product x*y*z for TooManyInvocations errors.
+	TotalInvocations uint64
 }
 
 // Error implements the error interface.
@@ -628,6 +642,14 @@ func (e *CreateComputePipelineError) Error() string {
 		return fmt.Sprintf("compute pipeline %q: compute entry point must not be empty", label)
 	case CreateComputePipelineErrorHAL:
 		return fmt.Sprintf("compute pipeline %q: HAL error: %v", label, e.HALError)
+	case CreateComputePipelineErrorWorkgroupSizeExceeded:
+		return fmt.Sprintf("compute pipeline %q: workgroup_size %s = %d exceeds device limit %d",
+			label, e.Dimension, e.Size, e.Limit)
+	case CreateComputePipelineErrorWorkgroupSizeZero:
+		return fmt.Sprintf("compute pipeline %q: workgroup_size %s must not be zero", label, e.Dimension)
+	case CreateComputePipelineErrorTooManyInvocations:
+		return fmt.Sprintf("compute pipeline %q: total workgroup invocations %d exceeds device limit %d",
+			label, e.TotalInvocations, e.Limit)
 	default:
 		return fmt.Sprintf("compute pipeline %q: unknown error", label)
 	}

--- a/core/validate_test.go
+++ b/core/validate_test.go
@@ -1113,6 +1113,30 @@ func TestCreateComputePipelineError_Error(t *testing.T) {
 			err:      &CreateComputePipelineError{Kind: CreateComputePipelineErrorMissingEntryPoint, Label: "test"},
 			contains: "entry point",
 		},
+		{
+			name: "workgroup size exceeded",
+			err: &CreateComputePipelineError{
+				Kind: CreateComputePipelineErrorWorkgroupSizeExceeded, Label: "test",
+				Dimension: "X", Size: 512, Limit: 256,
+			},
+			contains: "workgroup_size X = 512 exceeds device limit 256",
+		},
+		{
+			name: "workgroup size zero",
+			err: &CreateComputePipelineError{
+				Kind: CreateComputePipelineErrorWorkgroupSizeZero, Label: "test",
+				Dimension: "Y",
+			},
+			contains: "workgroup_size Y must not be zero",
+		},
+		{
+			name: "too many invocations",
+			err: &CreateComputePipelineError{
+				Kind: CreateComputePipelineErrorTooManyInvocations, Label: "test",
+				TotalInvocations: 2048, Limit: 256,
+			},
+			contains: "total workgroup invocations 2048 exceeds device limit 256",
+		},
 	}
 
 	for _, tt := range tests {

--- a/device_native.go
+++ b/device_native.go
@@ -539,6 +539,14 @@ func (d *Device) CreateComputePipeline(desc *ComputePipelineDescriptor) (*Comput
 		return nil, err
 	}
 
+	// VAL-010: Validate workgroup_size against device limits.
+	// Matches Rust wgpu-core validation.rs:1243-1264.
+	if desc.Module != nil && desc.Module.irModule != nil {
+		if err := d.validateComputeWorkgroupSize(desc.Label, desc.EntryPoint, desc.Module); err != nil {
+			return nil, err
+		}
+	}
+
 	halPipeline, err := halDevice.CreateComputePipeline(halDesc)
 	if err != nil {
 		return nil, fmt.Errorf("wgpu: failed to create compute pipeline: %w", err)
@@ -567,6 +575,71 @@ func (d *Device) CreateComputePipeline(desc *ComputePipelineDescriptor) (*Comput
 		lateSizedBufferGroups: lateGroups,
 		ref:                   core.NewResourceRef("ComputePipeline:"+desc.Label, nil),
 	}, nil
+}
+
+// validateComputeWorkgroupSize checks shader workgroup_size against device limits.
+// VAL-010: Matches Rust wgpu-core validation.rs:1243-1264.
+func (d *Device) validateComputeWorkgroupSize(label, entryPoint string, module *ShaderModule) error {
+	irMod := module.irModule
+	if irMod == nil {
+		return nil
+	}
+
+	// Find the entry point matching the requested name.
+	for i := range irMod.EntryPoints {
+		ep := &irMod.EntryPoints[i]
+		if ep.Name != entryPoint || ep.Stage != ir.StageCompute {
+			continue
+		}
+
+		wg := ep.Workgroup
+		limits := d.core.Limits
+
+		// Check each dimension for zero.
+		dimNames := [3]string{"X", "Y", "Z"}
+		for dim := 0; dim < 3; dim++ {
+			if wg[dim] == 0 {
+				return &core.CreateComputePipelineError{
+					Kind:      core.CreateComputePipelineErrorWorkgroupSizeZero,
+					Label:     label,
+					Dimension: dimNames[dim],
+				}
+			}
+		}
+
+		// Check each dimension against device limits.
+		dimLimits := [3]uint32{
+			limits.MaxComputeWorkgroupSizeX,
+			limits.MaxComputeWorkgroupSizeY,
+			limits.MaxComputeWorkgroupSizeZ,
+		}
+		for dim := 0; dim < 3; dim++ {
+			if wg[dim] > dimLimits[dim] {
+				return &core.CreateComputePipelineError{
+					Kind:      core.CreateComputePipelineErrorWorkgroupSizeExceeded,
+					Label:     label,
+					Dimension: dimNames[dim],
+					Size:      wg[dim],
+					Limit:     dimLimits[dim],
+				}
+			}
+		}
+
+		// Check total invocations (x*y*z) against MaxComputeInvocationsPerWorkgroup.
+		total := uint64(wg[0]) * uint64(wg[1]) * uint64(wg[2])
+		if total > uint64(limits.MaxComputeInvocationsPerWorkgroup) {
+			return &core.CreateComputePipelineError{
+				Kind:             core.CreateComputePipelineErrorTooManyInvocations,
+				Label:            label,
+				TotalInvocations: total,
+				Limit:            limits.MaxComputeInvocationsPerWorkgroup,
+			}
+		}
+
+		break
+	}
+
+	return nil
 }
 
 // CreateCommandEncoder creates a command encoder for recording GPU commands.

--- a/hal/dx12/command.go
+++ b/hal/dx12/command.go
@@ -891,6 +891,7 @@ func (e *ComputePassEncoder) Dispatch(x, y, z uint32) {
 	}
 
 	e.encoder.cmdList.Dispatch(x, y, z)
+	e.insertUAVBarrier()
 }
 
 // DispatchIndirect dispatches compute work with GPU-generated parameters.
@@ -904,6 +905,14 @@ func (e *ComputePassEncoder) DispatchIndirect(buffer hal.Buffer, offset uint64) 
 	// For now, this is a stub
 	_ = buf
 	_ = offset
+}
+
+// insertUAVBarrier inserts a global UAV barrier after a dispatch.
+// VAL-008: ensures UAV writes from one dispatch are visible to subsequent
+// dispatches. NULL resource = global barrier across all UAV resources.
+func (e *ComputePassEncoder) insertUAVBarrier() {
+	barrier := d3d12.NewUAVBarrier(nil)
+	e.encoder.cmdList.ResourceBarrier(1, &barrier)
 }
 
 // --- Helper functions ---

--- a/hal/metal/encoder.go
+++ b/hal/metal/encoder.go
@@ -704,6 +704,7 @@ func (e *ComputePassEncoder) Dispatch(x, y, z uint32) {
 		argStruct(threadgroupsPerGrid, mtlSizeType),
 		argStruct(threadsPerThreadgroup, mtlSizeType),
 	)
+	e.insertComputeBarrier()
 }
 
 // DispatchIndirect dispatches compute work with GPU-generated parameters.
@@ -722,6 +723,18 @@ func (e *ComputePassEncoder) DispatchIndirect(buffer hal.Buffer, offset uint64) 
 		argUint64(offset),
 		argStruct(threadsPerThreadgroup, mtlSizeType),
 	)
+	e.insertComputeBarrier()
+}
+
+// insertComputeBarrier inserts a buffer+texture memory barrier after a dispatch.
+// VAL-008: ensures storage buffer/texture writes from one dispatch are visible
+// to subsequent dispatches. Uses memoryBarrierWithScope: on the compute encoder.
+func (e *ComputePassEncoder) insertComputeBarrier() {
+	if e.raw == 0 {
+		return
+	}
+	scope := MTLBarrierScopeBuffers | MTLBarrierScopeTextures
+	_ = MsgSend(e.raw, Sel("memoryBarrierWithScope:"), uintptr(scope))
 }
 
 // msgSendClearColor sends an Objective-C message with an MTLClearColor argument.

--- a/hal/metal/types.go
+++ b/hal/metal/types.go
@@ -288,6 +288,14 @@ const (
 	MTLIndexTypeUInt32 MTLIndexType = 1
 )
 
+// MTLBarrierScope represents the set of resources affected by a memory barrier.
+type MTLBarrierScope NSUInteger
+
+const (
+	MTLBarrierScopeBuffers  MTLBarrierScope = 1 << 0
+	MTLBarrierScopeTextures MTLBarrierScope = 1 << 1
+)
+
 // MTLCullMode represents face culling modes.
 type MTLCullMode NSUInteger
 

--- a/hal/vulkan/command.go
+++ b/hal/vulkan/command.go
@@ -1188,6 +1188,7 @@ func (e *ComputePassEncoder) Dispatch(x, y, z uint32) {
 	}
 
 	vkCmdDispatch(e.encoder.device.cmds, e.encoder.active, x, y, z)
+	e.insertComputeBarrier()
 }
 
 // DispatchIndirect dispatches compute work with GPU-generated parameters.
@@ -1198,6 +1199,29 @@ func (e *ComputePassEncoder) DispatchIndirect(buffer hal.Buffer, offset uint64) 
 	}
 
 	vkCmdDispatchIndirect(e.encoder.device.cmds, e.encoder.active, buf.handle, vk.DeviceSize(offset))
+	e.insertComputeBarrier()
+}
+
+// insertComputeBarrier inserts a compute→compute memory barrier after a dispatch.
+// VAL-008: ensures storage buffer writes from one dispatch are visible to subsequent
+// dispatches. This is the "global barrier" approach (Option B) — always correct,
+// slightly over-synchronizes but avoids the complexity of per-resource usage tracking.
+func (e *ComputePassEncoder) insertComputeBarrier() {
+	memBarrier := vk.MemoryBarrier{
+		SType:         vk.StructureTypeMemoryBarrier,
+		SrcAccessMask: vk.AccessFlags(vk.AccessShaderWriteBit),
+		DstAccessMask: vk.AccessFlags(vk.AccessShaderReadBit | vk.AccessShaderWriteBit),
+	}
+	vkCmdPipelineBarrier(
+		e.encoder.device.cmds,
+		e.encoder.active,
+		vk.PipelineStageFlags(vk.PipelineStageComputeShaderBit),
+		vk.PipelineStageFlags(vk.PipelineStageComputeShaderBit),
+		0,
+		1, &memBarrier,
+		0, nil,
+		0, nil,
+	)
 }
 
 // --- Helper functions ---

--- a/wgpu_test.go
+++ b/wgpu_test.go
@@ -2171,3 +2171,160 @@ func TestRenderPassDrawIndexedWithIndexBuffer(t *testing.T) {
 	// May fail for other HAL reasons, but index buffer check should pass.
 	_, _ = encoder.Finish()
 }
+
+// =============================================================================
+// VAL-009: Dispatch workgroup count validation
+// =============================================================================
+
+func TestComputePassDispatchWorkgroupCountExceedsLimit(t *testing.T) {
+	device, encoder, pass := newEncoderWithComputePass(t)
+	defer device.Release()
+
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "val009-shader",
+		WGSL:  "@compute @workgroup_size(1) fn main() {}",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer shader.Release()
+
+	pipeline, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Label:      "val009-pipeline",
+		Module:     shader,
+		EntryPoint: "main",
+	})
+	if err != nil {
+		t.Skipf("CreateComputePipeline not supported: %v", err)
+	}
+	defer pipeline.Release()
+
+	pass.SetPipeline(pipeline)
+
+	// Default limit is 65535. Dispatch with a value exceeding it.
+	pass.Dispatch(100000, 1, 1)
+	_ = pass.End()
+
+	_, err = encoder.Finish()
+	if err == nil {
+		t.Fatal("Finish() should return error when dispatch workgroup count exceeds limit")
+	}
+}
+
+func TestComputePassDispatchZeroWorkgroupsAllowed(t *testing.T) {
+	device, encoder, pass := newEncoderWithComputePass(t)
+	defer device.Release()
+
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "val009-zero-shader",
+		WGSL:  "@compute @workgroup_size(1) fn main() {}",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer shader.Release()
+
+	pipeline, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Label:      "val009-zero-pipeline",
+		Module:     shader,
+		EntryPoint: "main",
+	})
+	if err != nil {
+		t.Skipf("CreateComputePipeline not supported: %v", err)
+	}
+	defer pipeline.Release()
+
+	pass.SetPipeline(pipeline)
+
+	// (0, 0, 0) is valid per spec — it is a no-op.
+	pass.Dispatch(0, 0, 0)
+	_ = pass.End()
+
+	_, err = encoder.Finish()
+	if err != nil {
+		t.Fatalf("Finish() should succeed for zero dispatch: %v", err)
+	}
+}
+
+// =============================================================================
+// VAL-010: CreateComputePipeline workgroup_size validation
+// =============================================================================
+
+func TestCreateComputePipelineWorkgroupSizeTooLarge(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	// Default MaxComputeWorkgroupSizeX is 256.
+	// This shader uses @workgroup_size(512) which exceeds it.
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "val010-too-large",
+		WGSL:  "@compute @workgroup_size(512) fn main() {}",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer shader.Release()
+
+	_, err = device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Label:      "val010-pipeline",
+		Module:     shader,
+		EntryPoint: "main",
+	})
+	if err == nil {
+		t.Fatal("CreateComputePipeline should reject workgroup_size(512) when limit is 256")
+	}
+}
+
+func TestCreateComputePipelineTotalInvocationsExceeded(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	// Default MaxComputeInvocationsPerWorkgroup is 256.
+	// @workgroup_size(32, 32, 1) = 1024 invocations, exceeds 256.
+	// But each dimension (32) is within per-dimension limits (256).
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "val010-total",
+		WGSL:  "@compute @workgroup_size(32, 32, 1) fn main() {}",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer shader.Release()
+
+	_, err = device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Label:      "val010-total-pipeline",
+		Module:     shader,
+		EntryPoint: "main",
+	})
+	if err == nil {
+		t.Fatal("CreateComputePipeline should reject when total invocations exceed limit")
+	}
+}
+
+func TestCreateComputePipelineWorkgroupSizeValid(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	// @workgroup_size(16, 16, 1) = 256 invocations, exactly at default limit.
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "val010-valid",
+		WGSL:  "@compute @workgroup_size(16, 16, 1) fn main() {}",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer shader.Release()
+
+	pipeline, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Label:      "val010-valid-pipeline",
+		Module:     shader,
+		EntryPoint: "main",
+	})
+	if err != nil {
+		t.Skipf("CreateComputePipeline not supported: %v", err)
+	}
+	pipeline.Release()
+}


### PR DESCRIPTION
## Summary

- **VAL-008:** Per-dispatch memory barriers on all GPU backends (Vulkan PipelineBarrier, DX12 UAV, Metal memoryBarrierWithScope). Prevents data corruption on chained dispatches sharing storage buffers.
- **VAL-009:** Dispatch workgroup count validation against `MaxComputeWorkgroupsPerDimension`. Clean error instead of driver crash.
- **VAL-010:** CreateComputePipeline workgroup_size validation — per-dimension limits + total invocations + zero-dimension rejection.

ADR: `docs/dev/research/ADR-COMPUTE-PIPELINE-AUDIT-2026-04-26.md`

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass (8 new tests)
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] `gofmt -l .` — clean
- [ ] CI