### PR TITLE
v0.26.9: Validation Phase A — 18 P0 crash prevention checks + naga v0.17.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **naga** v0.17.4 → **v0.17.5** — `ir.TypeSize()` for buffer size reflection (VAL-006)
 
+## [0.26.9] - 2026-04-30
+
+### Added
+
+- **WebGPU validation Phase A — crash prevention** (ADR-VALIDATION-PHASES) — 18 P0 checks
+  matching Rust wgpu-core, preventing GPU crashes from invalid API usage:
+
+  **Queue.WriteBuffer bounds** (VAL-A1):
+  - Buffer not mapped, COPY_DST usage required, offset/size 4-byte alignment, bounds check
+
+  **CreateBindGroup buffer validation** (VAL-A2):
+  - Buffer usage matches binding type (UNIFORM/STORAGE), offset alignment
+    (minUniformBufferOffsetAlignment/minStorageBufferOffsetAlignment), binding size limits,
+    offset+size bounds, zero-size rejection, storage 4-byte alignment
+
+  **Draw-time state validation** (VAL-A3):
+  - 12 typed sentinel errors with `errors.Is()` support: `ErrDrawMissingPipeline`,
+    `ErrDrawMissingBindGroup`, `ErrDrawIncompatibleBindGroup`, `ErrDrawMissingVertexBuffer`,
+    `ErrDrawMissingIndexBuffer`, `ErrDrawMissingBlendConstant`, `ErrDrawLateBufferTooSmall`,
+    `ErrDispatchMissingPipeline`, `ErrDispatchMissingBindGroup`,
+    `ErrDispatchIncompatibleBindGroup`, `ErrDispatchLateBufferTooSmall`,
+    `ErrDispatchWorkgroupCountExceeded`
+  - `EncoderStateError.Unwrap()` — error chain preserved through Finish()
+
+  **CreatePipelineLayout validation** (VAL-A4):
+  - Bind group layout count vs `MaxBindGroups` limit
+
+  **Format type guards** (VAL-A5):
+  - Color target must be color format (not depth/stencil)
+  - Depth/stencil attachment must be depth/stencil format (not color)
+
+  **Queue.Submit resource validation** (VAL-A6):
+  - Referenced buffers not destroyed, not mapped
+  - Referenced textures not destroyed
+  - Double-submit prevention
+  - Resource tracking during encoding (SetBindGroup, SetVertexBuffer, SetIndexBuffer, etc.)
+
+- `CreatePipelineLayoutError` typed error with `errors.As()` support
+- `CreateBindGroupError` extended with 6 buffer validation error kinds
+- `CreateRenderPipelineError` extended with color/depth format guard error kinds
+
+### Dependencies
+
+- **naga** v0.17.6 → **v0.17.8**
+
+### Research
+
+- **[Validation Gap Analysis](docs/dev/research/VALIDATION-GAP-ANALYSIS-RUST-WGPU.md)** — 121-check
+  comparison vs Rust wgpu-core. Coverage: 22% → ~37% after Phase A.
+- **[ADR: Validation Phases](docs/dev/research/ADR-VALIDATION-PHASES.md)** — phased implementation
+  plan (A: crash prevention, B: correctness, C: spec compliance)
+
 ## [0.25.3] - 2026-04-23
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,6 +46,7 @@
 ✅ **Late buffer binding validation** — draw/dispatch-time MinBindingSize=0 checks (Rust parity)
 ✅ **Compute dispatch barriers** — per-dispatch memory barriers on all GPU backends (Rust parity)
 ✅ **Dispatch workgroup validation** — count + size limits checked before dispatch
+✅ **Validation Phase A — crash prevention** — 18 P0 checks (WriteBuffer bounds, BindGroup buffer validation, draw-time state with typed sentinel errors, PipelineLayout count, format type guards, Queue.Submit resource state). Coverage 22% → 37% of Rust wgpu-core.
 ✅ **DX12 buffer state tracking** — per-buffer D3D12_RESOURCE_STATES with automatic transition barriers (Rust BufferTracker pattern)
 ✅ **Pipeline constants passthrough** — Constants map flows from public API through HAL
 ✅ **Zero-init workgroup memory** — WebGPU spec default, plumbed through all layers
@@ -58,7 +59,9 @@
 ✅ **Zero-allocation WriteBuffer batching** — pre-allocated BufferCopy + stack barrier arrays. All PendingWrites hot paths 0 allocs/op.
 
 ### Remaining validation (planned)
-- Late buffer binding size (SPIR-V reflection → min binding size)
+- **Phase B** (P1): Texture format checks, vertex buffer validation, sampler/texture type matching
+- **Phase C** (P2): Spec compliance edge cases, feature gates
+- See [ADR-VALIDATION-PHASES.md](docs/dev/research/ADR-VALIDATION-PHASES.md)
 
 | Backend | Platform | Status |
 |---------|----------|--------|
@@ -140,6 +143,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.26.9** | 2026-04 | **Validation Phase A** — 18 P0 crash prevention checks (WriteBuffer bounds, BindGroup buffer, draw-time state, PipelineLayout, format guards, Submit resource state). Coverage 22% → 37%. |
 | **v0.25.6** | 2026-04 | Vulkan command buffer free list (VK-CMD-001): batch alloc, pool reset, enterprise parity |
 | **v0.25.5** | 2026-04 | WASM platform split (Phase 0): _native.go/_browser.go file split, core/hal excluded from WASM |
 | **v0.25.4** | 2026-04 | Late buffer binding validation (VAL-006) + Vulkan relay semaphores (VK-SYNC-001) |

--- a/bind_native.go
+++ b/bind_native.go
@@ -190,6 +190,14 @@ type BindGroup struct {
 	// ref is the GPU-aware reference counter for this bind group (Phase 2).
 	// Clone'd when used in a render/compute pass, Drop'd when GPU completes submission.
 	ref *core.ResourceRef
+	// boundBuffers holds references to buffers bound in this bind group (VAL-A6).
+	// Used at Submit time to verify that referenced buffers are still alive
+	// and not mapped. Matches Rust wgpu-core's pattern where
+	// validate_command_buffer iterates cmd_buf_data.trackers.buffers.
+	boundBuffers []*Buffer
+	// boundTextures holds references to textures bound in this bind group (VAL-A6).
+	// Used at Submit time to verify that referenced textures are still alive.
+	boundTextures []*Texture
 }
 
 // Release marks the bind group for destruction. The underlying HAL BindGroup

--- a/binder.go
+++ b/binder.go
@@ -2,7 +2,10 @@
 
 package wgpu
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // lateBufferBinding tracks a single buffer binding that requires late validation.
 // Populated from two independent sources (order-independent, matching Rust):
@@ -173,6 +176,9 @@ func validateSetBindGroup(passName string, index uint32, group *BindGroup, offse
 // shader-required minimum. This is the "late" validation for entries with
 // MinBindingSize == 0.
 //
+// The returned error wraps errLateBufferTooSmall so callers can re-wrap with
+// the appropriate public sentinel (ErrDrawLateBufferTooSmall or ErrDispatchLateBufferTooSmall).
+//
 // Matches Rust wgpu-core's Binder::check_late_buffer_bindings (command/bind.rs:480-499).
 func (b *binder) checkLateBufferBindings() error {
 	for groupIndex := uint32(0); groupIndex < b.maxSlots; groupIndex++ {
@@ -186,14 +192,23 @@ func (b *binder) checkLateBufferBindings() error {
 			if lb.BoundSize < lb.ShaderExpectSize {
 				return fmt.Errorf(
 					"wgpu: buffer binding at group %d, binding %d has size %d, "+
-						"but the shader requires a minimum of %d (set MinBindingSize in layout to avoid late validation)",
+						"but the shader requires a minimum of %d (set MinBindingSize in layout to avoid late validation): %w",
 					groupIndex, lb.BindingIndex, lb.BoundSize, lb.ShaderExpectSize,
+					errLateBufferTooSmall,
 				)
 			}
 		}
 	}
 	return nil
 }
+
+// Unexported sentinel errors for binder validation. Callers re-wrap with
+// the appropriate public sentinel (ErrDrawMissing*/ErrDispatchMissing*).
+var (
+	errBindGroupMissing      = errors.New("bind group missing")
+	errBindGroupIncompatible = errors.New("bind group incompatible")
+	errLateBufferTooSmall    = errors.New("late buffer too small")
+)
 
 // checkCompatibility validates that all slots expected by the current pipeline
 // have compatible bind groups assigned. Returns an error describing the first
@@ -204,6 +219,9 @@ func (b *binder) checkLateBufferBindings() error {
 // have the same bindings with matching types, visibility, and counts.
 // This allows equivalent layouts created via separate CreateBindGroupLayout
 // calls to be considered compatible.
+//
+// The returned error wraps errBindGroupMissing or errBindGroupIncompatible
+// so callers can re-wrap with the appropriate public sentinel.
 func (b *binder) checkCompatibility() error {
 	for i := uint32(0); i < b.maxSlots; i++ {
 		exp := b.expected[i]
@@ -214,14 +232,14 @@ func (b *binder) checkCompatibility() error {
 		asg := b.assigned[i]
 		if asg == nil {
 			return fmt.Errorf(
-				"wgpu: bind group at index %d is required by the pipeline but not set (call SetBindGroup)",
-				i,
+				"wgpu: bind group at index %d is required by the pipeline but not set (call SetBindGroup): %w",
+				i, errBindGroupMissing,
 			)
 		}
 		if !asg.isCompatibleWith(exp) {
 			return fmt.Errorf(
-				"wgpu: bind group at index %d has incompatible layout (assigned layout %p != expected layout %p)",
-				i, asg, exp,
+				"wgpu: bind group at index %d has incompatible layout (assigned layout %p != expected layout %p): %w",
+				i, asg, exp, errBindGroupIncompatible,
 			)
 		}
 	}

--- a/computepass_native.go
+++ b/computepass_native.go
@@ -3,6 +3,7 @@
 package wgpu
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gogpu/wgpu/core"
@@ -70,6 +71,13 @@ func (p *ComputePassEncoder) SetBindGroup(index uint32, group *BindGroup, offset
 	p.binder.assign(index, group.layout)
 	p.binder.assignBindGroup(index, group)
 	p.trackRef(group.ref)
+	// Track bind group resources for submit-time validation (VAL-A6).
+	for _, buf := range group.boundBuffers {
+		p.encoder.trackBuffer(buf)
+	}
+	for _, tex := range group.boundTextures {
+		p.encoder.trackTexture(tex)
+	}
 	raw := p.core.RawPass()
 	if raw != nil && group.hal != nil {
 		raw.SetBindGroup(index, group.hal, offsets)
@@ -79,20 +87,29 @@ func (p *ComputePassEncoder) SetBindGroup(index uint32, group *BindGroup, offset
 // validateDispatchState checks that a pipeline has been set and all bind groups
 // are compatible before a dispatch call.
 // Returns true if validation passes, false if an error was recorded.
+//
+// Each validation failure wraps a typed sentinel error so that callers can
+// use errors.Is() to identify the failure category programmatically.
+// Matches Rust wgpu-core State::is_ready (command/compute.rs:278-284).
 func (p *ComputePassEncoder) validateDispatchState(method string) bool {
 	if !p.pipelineSet {
-		p.encoder.setError(fmt.Errorf("wgpu: ComputePass.%s: no pipeline set (call SetPipeline first)", method))
+		p.encoder.setError(fmt.Errorf("wgpu: ComputePass.%s: no pipeline set (call SetPipeline first): %w",
+			method, ErrDispatchMissingPipeline))
 		return false
 	}
 	if err := p.binder.checkCompatibility(); err != nil {
-		p.encoder.setError(fmt.Errorf("wgpu: ComputePass.%s: %w", method, err))
+		sentinel := ErrDispatchMissingBindGroup
+		if errors.Is(err, errBindGroupIncompatible) {
+			sentinel = ErrDispatchIncompatibleBindGroup
+		}
+		p.encoder.setError(fmt.Errorf("wgpu: ComputePass.%s: %w: %w", method, sentinel, err))
 		return false
 	}
 	// Late buffer binding size validation: check that bound buffers are large enough
 	// for bindings with MinBindingSize == 0. Matches Rust wgpu-core's is_ready()
 	// call to check_late_buffer_bindings before dispatch (compute.rs:278-285).
 	if err := p.binder.checkLateBufferBindings(); err != nil {
-		p.encoder.setError(fmt.Errorf("wgpu: ComputePass.%s: %w", method, err))
+		p.encoder.setError(fmt.Errorf("wgpu: ComputePass.%s: %w: %w", method, ErrDispatchLateBufferTooSmall, err))
 		return false
 	}
 	return true
@@ -110,8 +127,8 @@ func (p *ComputePassEncoder) Dispatch(x, y, z uint32) {
 	limit := p.encoder.device.core.Limits.MaxComputeWorkgroupsPerDimension
 	if x > limit || y > limit || z > limit {
 		p.encoder.setError(fmt.Errorf(
-			"wgpu: ComputePass.Dispatch: workgroup count (%d, %d, %d) exceeds device limit %d",
-			x, y, z, limit))
+			"wgpu: ComputePass.Dispatch: workgroup count (%d, %d, %d) exceeds device limit %d: %w",
+			x, y, z, limit, ErrDispatchWorkgroupCountExceeded))
 		return
 	}
 
@@ -128,6 +145,7 @@ func (p *ComputePassEncoder) DispatchIndirect(buffer *Buffer, offset uint64) {
 		return
 	}
 	p.trackRef(buffer.core.Ref)
+	p.encoder.trackBuffer(buffer)
 	p.core.DispatchIndirect(buffer.coreBuffer(), offset)
 }
 

--- a/core/command.go
+++ b/core/command.go
@@ -542,11 +542,17 @@ func (e *CoreCommandEncoder) setError(err error) {
 }
 
 // statusError returns an error for invalid status.
+// When the encoder is in the Error state, the deferred error is attached
+// as the Cause so that errors.Is/errors.As work through the chain.
 func (e *CoreCommandEncoder) statusError(operation string) error {
-	return &EncoderStateError{
+	ese := &EncoderStateError{
 		Operation: operation,
 		Status:    e.Status(),
 	}
+	if e.Status() == CommandEncoderStatusError {
+		ese.Cause = e.error
+	}
+	return ese
 }
 
 // convertRenderPassDescriptor converts a core descriptor to HAL descriptor.

--- a/core/error.go
+++ b/core/error.go
@@ -535,6 +535,14 @@ const (
 	CreateRenderPipelineErrorTooManyColorTargets
 	// CreateRenderPipelineErrorInvalidSampleCount indicates an invalid multisample count.
 	CreateRenderPipelineErrorInvalidSampleCount
+	// CreateRenderPipelineErrorColorTargetDepthFormat indicates a depth/stencil format was used as a color target.
+	// WebGPU spec: color target format must have a color aspect.
+	// Rust: pipeline::ColorStateError::FormatNotColor
+	CreateRenderPipelineErrorColorTargetDepthFormat
+	// CreateRenderPipelineErrorDepthStencilColorFormat indicates a color format was used as a depth/stencil format.
+	// WebGPU spec: depth/stencil format must be a depth/stencil format.
+	// Rust: pipeline::DepthStencilStateError::FormatNotDepth / FormatNotStencil
+	CreateRenderPipelineErrorDepthStencilColorFormat
 	// CreateRenderPipelineErrorHAL indicates the HAL backend failed to create the pipeline.
 	CreateRenderPipelineErrorHAL
 )
@@ -546,7 +554,11 @@ type CreateRenderPipelineError struct {
 	TargetCount uint32
 	MaxTargets  uint32
 	SampleCount uint32
-	HALError    error
+	// TargetIndex is the color target index for format errors.
+	TargetIndex uint32
+	// Format is the texture format that caused the error.
+	Format   string
+	HALError error
 }
 
 // Error implements the error interface.
@@ -573,6 +585,12 @@ func (e *CreateRenderPipelineError) Error() string {
 	case CreateRenderPipelineErrorInvalidSampleCount:
 		return fmt.Sprintf("render pipeline %q: invalid sample count %d (must be 1 or 4)",
 			label, e.SampleCount)
+	case CreateRenderPipelineErrorColorTargetDepthFormat:
+		return fmt.Sprintf("render pipeline %q: color target [%d] format %s does not have a color aspect",
+			label, e.TargetIndex, e.Format)
+	case CreateRenderPipelineErrorDepthStencilColorFormat:
+		return fmt.Sprintf("render pipeline %q: depth/stencil format %s is not a depth/stencil format",
+			label, e.Format)
 	case CreateRenderPipelineErrorHAL:
 		return fmt.Sprintf("render pipeline %q: HAL error: %v", label, e.HALError)
 	default:
@@ -734,15 +752,65 @@ type CreateBindGroupErrorKind int
 const (
 	// CreateBindGroupErrorMissingLayout indicates the layout was nil.
 	CreateBindGroupErrorMissingLayout CreateBindGroupErrorKind = iota
+	// CreateBindGroupErrorBindingsNumMismatch indicates the number of entries
+	// in the bind group descriptor does not match the number of entries
+	// defined in the bind group layout.
+	// Rust: wgpu-core binding_model.rs CreateBindGroupError::BindingsNumMismatch
+	CreateBindGroupErrorBindingsNumMismatch
+	// CreateBindGroupErrorMissingBindingDeclaration indicates a bind group entry
+	// references a binding number that is not declared in the layout.
+	// Rust: wgpu-core binding_model.rs CreateBindGroupError::MissingBindingDeclaration
+	CreateBindGroupErrorMissingBindingDeclaration
+	// CreateBindGroupErrorDuplicateBinding indicates two or more bind group entries
+	// share the same binding number.
+	// Rust: wgpu-core binding_model.rs CreateBindGroupError::DuplicateBinding
+	CreateBindGroupErrorDuplicateBinding
+	// CreateBindGroupErrorBufferUsageMismatch indicates the buffer does not have the
+	// usage flag required by the layout entry's buffer binding type.
+	// E.g., binding a VERTEX buffer where UNIFORM is required.
+	// Rust: wgpu-core resource.rs MissingBufferUsageError
+	CreateBindGroupErrorBufferUsageMismatch
+	// CreateBindGroupErrorBufferOffsetAlignment indicates the buffer offset is not
+	// aligned to the required alignment for its binding type.
+	// Uniform: minUniformBufferOffsetAlignment, Storage: minStorageBufferOffsetAlignment.
+	// Rust: wgpu-core device/resource.rs UnalignedBufferOffset
+	CreateBindGroupErrorBufferOffsetAlignment
+	// CreateBindGroupErrorBufferBindingSizeTooLarge indicates the effective binding
+	// size exceeds the maximum allowed for its binding type.
+	// Uniform: maxUniformBufferBindingSize, Storage: maxStorageBufferBindingSize.
+	// Rust: wgpu-core device/resource.rs BufferRangeTooLarge
+	CreateBindGroupErrorBufferBindingSizeTooLarge
+	// CreateBindGroupErrorBufferBoundsOverflow indicates offset + bindingSize exceeds
+	// the buffer's total size.
+	// Rust: wgpu-core resource.rs BindingRangeTooLarge / BindingOffsetTooLarge
+	CreateBindGroupErrorBufferBoundsOverflow
+	// CreateBindGroupErrorBufferBindingZeroSize indicates the effective binding size
+	// resolved to zero. WebGPU requires a non-zero binding size.
+	// Rust: wgpu-core device/resource.rs BindingZeroSize
+	CreateBindGroupErrorBufferBindingZeroSize
+	// CreateBindGroupErrorStorageBufferSizeAlignment indicates a storage buffer binding
+	// size is not a multiple of 4 bytes, as required by the WebGPU spec.
+	// Rust: wgpu-core device/resource.rs UnalignedEffectiveBufferBindingSizeForStorage
+	CreateBindGroupErrorStorageBufferSizeAlignment
 	// CreateBindGroupErrorHAL indicates the HAL backend failed.
 	CreateBindGroupErrorHAL
 )
 
 // CreateBindGroupError represents an error during bind group creation.
 type CreateBindGroupError struct {
-	Kind     CreateBindGroupErrorKind
-	Label    string
-	HALError error
+	Kind          CreateBindGroupErrorKind
+	Label         string
+	Expected      int    // expected entry count (for BindingsNumMismatch)
+	Actual        int    // actual entry count (for BindingsNumMismatch)
+	Binding       uint32 // binding number (for MissingBindingDeclaration, DuplicateBinding, buffer errors)
+	ExpectedUsage uint64 // required buffer usage flag (for BufferUsageMismatch)
+	ActualUsage   uint64 // actual buffer usage flags (for BufferUsageMismatch)
+	Offset        uint64 // buffer offset (for alignment/bounds errors)
+	Size          uint64 // effective binding size (for size-related errors)
+	BufferSize    uint64 // total buffer size (for bounds overflow)
+	MaxSize       uint64 // maximum allowed binding size (for BindingSizeTooLarge)
+	Alignment     uint64 // required alignment (for alignment errors)
+	HALError      error
 }
 
 // Error implements the error interface.
@@ -755,6 +823,33 @@ func (e *CreateBindGroupError) Error() string {
 	switch e.Kind {
 	case CreateBindGroupErrorMissingLayout:
 		return fmt.Sprintf("bind group %q: layout must not be nil", label)
+	case CreateBindGroupErrorBindingsNumMismatch:
+		return fmt.Sprintf("bind group %q: number of bindings in descriptor (%d) does not match the number defined in the layout (%d)",
+			label, e.Actual, e.Expected)
+	case CreateBindGroupErrorMissingBindingDeclaration:
+		return fmt.Sprintf("bind group %q: unable to find a corresponding declaration for binding %d",
+			label, e.Binding)
+	case CreateBindGroupErrorDuplicateBinding:
+		return fmt.Sprintf("bind group %q: binding %d is used at least twice in the descriptor",
+			label, e.Binding)
+	case CreateBindGroupErrorBufferUsageMismatch:
+		return fmt.Sprintf("bind group %q: binding %d buffer usage mismatch: expected 0x%x, actual 0x%x",
+			label, e.Binding, e.ExpectedUsage, e.ActualUsage)
+	case CreateBindGroupErrorBufferOffsetAlignment:
+		return fmt.Sprintf("bind group %q: binding %d buffer offset %d is not aligned to %d",
+			label, e.Binding, e.Offset, e.Alignment)
+	case CreateBindGroupErrorBufferBindingSizeTooLarge:
+		return fmt.Sprintf("bind group %q: binding %d buffer binding size %d exceeds maximum %d",
+			label, e.Binding, e.Size, e.MaxSize)
+	case CreateBindGroupErrorBufferBoundsOverflow:
+		return fmt.Sprintf("bind group %q: binding %d buffer range overflows: offset %d + size %d > buffer size %d",
+			label, e.Binding, e.Offset, e.Size, e.BufferSize)
+	case CreateBindGroupErrorBufferBindingZeroSize:
+		return fmt.Sprintf("bind group %q: binding %d has zero effective binding size",
+			label, e.Binding)
+	case CreateBindGroupErrorStorageBufferSizeAlignment:
+		return fmt.Sprintf("bind group %q: binding %d storage buffer binding size %d is not a multiple of 4",
+			label, e.Binding, e.Size)
 	case CreateBindGroupErrorHAL:
 		return fmt.Sprintf("bind group %q: HAL error: %v", label, e.HALError)
 	default:
@@ -773,15 +868,84 @@ func IsCreateBindGroupError(err error) bool {
 	return errors.As(err, &cbge)
 }
 
+// =============================================================================
+// Pipeline Layout Creation Errors
+// =============================================================================
+
+// CreatePipelineLayoutErrorKind represents the type of pipeline layout creation error.
+type CreatePipelineLayoutErrorKind int
+
+const (
+	// CreatePipelineLayoutErrorTooManyGroups indicates the number of bind group layouts
+	// exceeds the device limit (maxBindGroups, typically 4).
+	// Rust: binding_model::CreatePipelineLayoutError::TooManyGroups
+	CreatePipelineLayoutErrorTooManyGroups CreatePipelineLayoutErrorKind = iota
+	// CreatePipelineLayoutErrorHAL indicates the HAL backend failed to create the pipeline layout.
+	CreatePipelineLayoutErrorHAL
+)
+
+// CreatePipelineLayoutError represents an error during pipeline layout creation.
+type CreatePipelineLayoutError struct {
+	Kind      CreatePipelineLayoutErrorKind
+	Label     string
+	Count     int
+	MaxGroups uint32
+	HALError  error
+}
+
+// Error implements the error interface.
+func (e *CreatePipelineLayoutError) Error() string {
+	label := e.Label
+	if label == "" {
+		label = unnamedLabel
+	}
+
+	switch e.Kind {
+	case CreatePipelineLayoutErrorTooManyGroups:
+		return fmt.Sprintf("pipeline layout %q: bind group layout count %d exceeds device limit %d",
+			label, e.Count, e.MaxGroups)
+	case CreatePipelineLayoutErrorHAL:
+		return fmt.Sprintf("pipeline layout %q: HAL error: %v", label, e.HALError)
+	default:
+		return fmt.Sprintf("pipeline layout %q: unknown error", label)
+	}
+}
+
+// Unwrap returns the underlying HAL error, if any.
+func (e *CreatePipelineLayoutError) Unwrap() error {
+	return e.HALError
+}
+
+// IsCreatePipelineLayoutError returns true if the error is a CreatePipelineLayoutError.
+func IsCreatePipelineLayoutError(err error) bool {
+	var cple *CreatePipelineLayoutError
+	return errors.As(err, &cple)
+}
+
 // EncoderStateError represents an invalid state transition error.
+// When the encoder is in the Error state (due to a deferred validation error),
+// the Cause field carries the original error so that errors.Is/errors.As
+// work through the chain.
 type EncoderStateError struct {
 	Operation string
 	Status    CommandEncoderStatus
+	// Cause is the deferred error that put the encoder into the Error state.
+	// Non-nil only when Status == CommandEncoderStatusError.
+	Cause error
 }
 
 // Error implements the error interface.
 func (e *EncoderStateError) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("cannot %s: encoder in %v state: %v", e.Operation, e.Status, e.Cause)
+	}
 	return fmt.Sprintf("cannot %s: encoder in %v state", e.Operation, e.Status)
+}
+
+// Unwrap returns the deferred validation error that caused the encoder
+// to enter the Error state. Returns nil for non-error state transitions.
+func (e *EncoderStateError) Unwrap() error {
+	return e.Cause
 }
 
 // IsEncoderStateError returns true if the error is an EncoderStateError.

--- a/core/validate.go
+++ b/core/validate.go
@@ -270,6 +270,45 @@ func ValidateShaderModuleDescriptor(desc *hal.ShaderModuleDescriptor) error {
 	return nil
 }
 
+// ValidatePipelineLayoutDescriptor validates a pipeline layout descriptor against device limits.
+// Returns nil if valid, or a *CreatePipelineLayoutError describing the first validation failure.
+//
+// Checks: bind group layout count <= maxBindGroups (typically 4).
+// Rust: wgpu-core device/resource.rs:3562-3568.
+func ValidatePipelineLayoutDescriptor(desc *hal.PipelineLayoutDescriptor, limits gputypes.Limits) error {
+	label := desc.Label
+
+	// PL1: Bind group layout count must not exceed maxBindGroups.
+	if len(desc.BindGroupLayouts) > int(limits.MaxBindGroups) {
+		return &CreatePipelineLayoutError{
+			Kind:      CreatePipelineLayoutErrorTooManyGroups,
+			Label:     label,
+			Count:     len(desc.BindGroupLayouts),
+			MaxGroups: limits.MaxBindGroups,
+		}
+	}
+
+	return nil
+}
+
+// isDepthStencilFormat returns true if the format is a depth and/or stencil format.
+// These formats do not have a color aspect and cannot be used as color targets.
+//
+// Matches Rust wgpu-types TextureFormat::is_depth_stencil_format().
+// See: https://gpuweb.github.io/gpuweb/#depth-formats
+func isDepthStencilFormat(f gputypes.TextureFormat) bool {
+	switch f {
+	case gputypes.TextureFormatStencil8,
+		gputypes.TextureFormatDepth16Unorm,
+		gputypes.TextureFormatDepth24Plus,
+		gputypes.TextureFormatDepth24PlusStencil8,
+		gputypes.TextureFormatDepth32Float,
+		gputypes.TextureFormatDepth32FloatStencil8:
+		return true
+	}
+	return false
+}
+
 // ValidateRenderPipelineDescriptor validates a render pipeline descriptor against device limits.
 // Returns nil if valid, or a *CreateRenderPipelineError describing the first validation failure.
 func ValidateRenderPipelineDescriptor(desc *hal.RenderPipelineDescriptor, limits gputypes.Limits) error {
@@ -295,6 +334,33 @@ func ValidateRenderPipelineDescriptor(desc *hal.RenderPipelineDescriptor, limits
 	if desc.Fragment != nil {
 		if err := validateFragmentStage(desc.Fragment, label, limits); err != nil {
 			return err
+		}
+	}
+
+	// RP8: Color target formats must be color formats (not depth/stencil).
+	// Rust: resource.rs:4083-4085 — FormatNotColor
+	if desc.Fragment != nil {
+		for i, ct := range desc.Fragment.Targets {
+			if ct.Format != gputypes.TextureFormatUndefined && isDepthStencilFormat(ct.Format) {
+				return &CreateRenderPipelineError{
+					Kind:        CreateRenderPipelineErrorColorTargetDepthFormat,
+					Label:       label,
+					TargetIndex: uint32(i),
+					Format:      ct.Format.String(),
+				}
+			}
+		}
+	}
+
+	// RP9: Depth/stencil format must be a depth/stencil format (not color).
+	// Rust: resource.rs:4144-4165 — FormatNotDepth / FormatNotStencil
+	if desc.DepthStencil != nil {
+		if desc.DepthStencil.Format != gputypes.TextureFormatUndefined && !isDepthStencilFormat(desc.DepthStencil.Format) {
+			return &CreateRenderPipelineError{
+				Kind:   CreateRenderPipelineErrorDepthStencilColorFormat,
+				Label:  label,
+				Format: desc.DepthStencil.Format.String(),
+			}
 		}
 	}
 
@@ -445,9 +511,35 @@ func ValidateBindGroupLayoutDescriptor(desc *hal.BindGroupLayoutDescriptor, limi
 	return nil
 }
 
+// BindGroupBufferInfo carries buffer metadata needed for bind group validation.
+// The core validation layer cannot access buffer objects directly (they are uintptr
+// handles in gputypes.BindGroupEntry), so the caller extracts this info from the
+// public API's typed *Buffer objects and passes it alongside the descriptor.
+type BindGroupBufferInfo struct {
+	// Binding is the binding number this info corresponds to.
+	Binding uint32
+	// Usage is the buffer's usage flags (from Buffer.Usage()).
+	Usage gputypes.BufferUsage
+	// BufferSize is the total size of the buffer in bytes (from Buffer.Size()).
+	BufferSize uint64
+	// Offset is the byte offset into the buffer for this binding.
+	Offset uint64
+	// Size is the requested binding size (0 means "rest of buffer from offset").
+	Size uint64
+}
+
 // ValidateBindGroupDescriptor validates a bind group descriptor.
+// layoutEntries are the entries from the bind group layout — passed separately because
+// the hal.BindGroupLayout interface does not expose entries (they live in core.BindGroupLayout).
+// bufferInfos carries buffer metadata for entries that bind buffers (may be nil if no buffers).
+// limits are the device limits for alignment and size checks.
 // Returns nil if valid, or a *CreateBindGroupError describing the first validation failure.
-func ValidateBindGroupDescriptor(desc *hal.BindGroupDescriptor) error {
+func ValidateBindGroupDescriptor(
+	desc *hal.BindGroupDescriptor,
+	layoutEntries []gputypes.BindGroupLayoutEntry,
+	bufferInfos []BindGroupBufferInfo,
+	limits gputypes.Limits,
+) error {
 	// BG1: Layout must not be nil.
 	if desc.Layout == nil {
 		return &CreateBindGroupError{
@@ -456,7 +548,229 @@ func ValidateBindGroupDescriptor(desc *hal.BindGroupDescriptor) error {
 		}
 	}
 
+	// BG2: Entry count must match layout entry count.
+	// Rust: wgpu-core device/resource.rs:3106-3111 — BindingsNumMismatch
+	if len(desc.Entries) != len(layoutEntries) {
+		return &CreateBindGroupError{
+			Kind:     CreateBindGroupErrorBindingsNumMismatch,
+			Label:    desc.Label,
+			Expected: len(layoutEntries),
+			Actual:   len(desc.Entries),
+		}
+	}
+
+	// BG3: Each entry binding must exist in layout, and no duplicates.
+	// Rust: wgpu-core device/resource.rs:3135-3138 — MissingBindingDeclaration
+	// Rust: wgpu-core device/resource.rs:3275-3278 — DuplicateBinding
+	//
+	// Build a map of layout entries by binding number for O(1) lookup.
+	layoutByBinding := make(map[uint32]*gputypes.BindGroupLayoutEntry, len(layoutEntries))
+	for i := range layoutEntries {
+		layoutByBinding[layoutEntries[i].Binding] = &layoutEntries[i]
+	}
+
+	seen := make(map[uint32]bool, len(desc.Entries))
+	for _, entry := range desc.Entries {
+		// Check duplicate binding numbers in descriptor entries.
+		if seen[entry.Binding] {
+			return &CreateBindGroupError{
+				Kind:    CreateBindGroupErrorDuplicateBinding,
+				Label:   desc.Label,
+				Binding: entry.Binding,
+			}
+		}
+		seen[entry.Binding] = true
+
+		// Check that each entry binding has a corresponding declaration in the layout.
+		if _, ok := layoutByBinding[entry.Binding]; !ok {
+			return &CreateBindGroupError{
+				Kind:    CreateBindGroupErrorMissingBindingDeclaration,
+				Label:   desc.Label,
+				Binding: entry.Binding,
+			}
+		}
+	}
+
+	// BG4-BG9: Buffer binding validation.
+	// Rust: wgpu-core device/resource.rs:2747-2834
+	return validateBindGroupBufferEntries(desc.Label, layoutByBinding, bufferInfos, limits)
+}
+
+// validateBindGroupBufferEntries validates each buffer binding entry against its
+// layout declaration and device limits. Checks usage compatibility, offset alignment,
+// binding size limits, bounds overflow, zero-size, and storage 4-byte alignment.
+//
+// Rust reference: wgpu-core device/resource.rs:2747-2834
+func validateBindGroupBufferEntries(
+	label string,
+	layoutByBinding map[uint32]*gputypes.BindGroupLayoutEntry,
+	bufferInfos []BindGroupBufferInfo,
+	limits gputypes.Limits,
+) error {
+	for _, info := range bufferInfos {
+		layoutEntry, ok := layoutByBinding[info.Binding]
+		if !ok || layoutEntry.Buffer == nil {
+			// No buffer layout declaration for this binding -- skip.
+			// (This would be caught by resource type mismatch validation, not buffer validation.)
+			continue
+		}
+
+		if err := validateSingleBufferEntry(label, layoutEntry.Buffer, info, limits); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+// bufferBindingParams holds the resolved parameters for a buffer binding type.
+type bufferBindingParams struct {
+	requiredUsage    gputypes.BufferUsage
+	maxBindingSize   uint64
+	offsetAlignment  uint32
+	isStorageBinding bool
+}
+
+// resolveBufferBindingParams returns the required usage, max size, alignment, and
+// whether it is a storage binding for the given buffer binding type.
+// Returns ok=false for unknown binding types.
+func resolveBufferBindingParams(bindingType gputypes.BufferBindingType, limits gputypes.Limits) (bufferBindingParams, bool) {
+	switch bindingType {
+	case gputypes.BufferBindingTypeUniform:
+		return bufferBindingParams{
+			requiredUsage:    gputypes.BufferUsageUniform,
+			maxBindingSize:   limits.MaxUniformBufferBindingSize,
+			offsetAlignment:  limits.MinUniformBufferOffsetAlignment,
+			isStorageBinding: false,
+		}, true
+	case gputypes.BufferBindingTypeStorage, gputypes.BufferBindingTypeReadOnlyStorage:
+		return bufferBindingParams{
+			requiredUsage:    gputypes.BufferUsageStorage,
+			maxBindingSize:   limits.MaxStorageBufferBindingSize,
+			offsetAlignment:  limits.MinStorageBufferOffsetAlignment,
+			isStorageBinding: true,
+		}, true
+	default:
+		return bufferBindingParams{}, false
+	}
+}
+
+// validateSingleBufferEntry validates one buffer binding entry against its layout
+// declaration and device limits.
+func validateSingleBufferEntry(
+	label string,
+	bufLayout *gputypes.BufferBindingLayout,
+	info BindGroupBufferInfo,
+	limits gputypes.Limits,
+) error {
+	params, ok := resolveBufferBindingParams(bufLayout.Type, limits)
+	if !ok {
+		return nil // Unknown binding type -- skip.
+	}
+
+	// BG4: Buffer usage must include the required flag.
+	if !info.Usage.Contains(params.requiredUsage) {
+		return &CreateBindGroupError{
+			Kind:          CreateBindGroupErrorBufferUsageMismatch,
+			Label:         label,
+			Binding:       info.Binding,
+			ExpectedUsage: uint64(params.requiredUsage),
+			ActualUsage:   uint64(info.Usage),
+		}
+	}
+
+	// BG5: Buffer offset must be aligned.
+	if params.offsetAlignment > 0 && info.Offset%uint64(params.offsetAlignment) != 0 {
+		return &CreateBindGroupError{
+			Kind:      CreateBindGroupErrorBufferOffsetAlignment,
+			Label:     label,
+			Binding:   info.Binding,
+			Offset:    info.Offset,
+			Alignment: uint64(params.offsetAlignment),
+		}
+	}
+
+	// Resolve effective binding size: 0 means "rest of buffer from offset".
+	effectiveSize := info.Size
+	if effectiveSize == 0 && info.Offset <= info.BufferSize {
+		effectiveSize = info.BufferSize - info.Offset
+	}
+
+	// BG9: Effective binding size must not be zero.
+	// Rust: wgpu-core device/resource.rs:2828 -- BindingZeroSize
+	if effectiveSize == 0 {
+		return &CreateBindGroupError{
+			Kind:    CreateBindGroupErrorBufferBindingZeroSize,
+			Label:   label,
+			Binding: info.Binding,
+		}
+	}
+
+	// BG7: offset + bindingSize must not exceed buffer size.
+	// Rust: wgpu-core resource.rs:517-535 -- BindingRangeTooLarge / BindingOffsetTooLarge
+	if err := validateBufferBounds(label, info); err != nil {
+		return err
+	}
+
+	// BG8: Storage buffer binding size must be a multiple of 4.
+	// Rust: wgpu-core device/resource.rs:2784-2793
+	if params.isStorageBinding && effectiveSize%4 != 0 {
+		return &CreateBindGroupError{
+			Kind:    CreateBindGroupErrorStorageBufferSizeAlignment,
+			Label:   label,
+			Binding: info.Binding,
+			Size:    effectiveSize,
+		}
+	}
+
+	// BG6: Effective binding size must not exceed the maximum for its type.
+	// Rust: wgpu-core device/resource.rs:2798-2804 -- BufferRangeTooLarge
+	if effectiveSize > params.maxBindingSize {
+		return &CreateBindGroupError{
+			Kind:    CreateBindGroupErrorBufferBindingSizeTooLarge,
+			Label:   label,
+			Binding: info.Binding,
+			Size:    effectiveSize,
+			MaxSize: params.maxBindingSize,
+		}
+	}
+
+	return nil
+}
+
+// validateBufferBounds checks that offset + size does not exceed the buffer size.
+func validateBufferBounds(label string, info BindGroupBufferInfo) error {
+	if info.Size != 0 {
+		// Explicit size: check offset + size <= bufferSize (with overflow protection).
+		end, overflow := addUint64(info.Offset, info.Size)
+		if overflow || end > info.BufferSize {
+			return &CreateBindGroupError{
+				Kind:       CreateBindGroupErrorBufferBoundsOverflow,
+				Label:      label,
+				Binding:    info.Binding,
+				Offset:     info.Offset,
+				Size:       info.Size,
+				BufferSize: info.BufferSize,
+			}
+		}
+	} else if info.Offset > info.BufferSize {
+		// Implicit size (0 = rest of buffer): offset must not exceed buffer size.
+		return &CreateBindGroupError{
+			Kind:       CreateBindGroupErrorBufferBoundsOverflow,
+			Label:      label,
+			Binding:    info.Binding,
+			Offset:     info.Offset,
+			Size:       0,
+			BufferSize: info.BufferSize,
+		}
+	}
+	return nil
+}
+
+// addUint64 adds a and b, returning the result and whether it overflowed.
+func addUint64(a, b uint64) (uint64, bool) {
+	sum := a + b
+	return sum, sum < a
 }
 
 // maxMips calculates the maximum number of mip levels for a texture.

--- a/core/validate_test.go
+++ b/core/validate_test.go
@@ -874,11 +874,21 @@ func TestValidateBindGroupLayoutDescriptor_TooManyBindings(t *testing.T) {
 // --- ValidateBindGroupDescriptor tests ---
 
 func TestValidateBindGroupDescriptor_Valid(t *testing.T) {
+	layoutEntries := []gputypes.BindGroupLayoutEntry{
+		{Binding: 0},
+		{Binding: 1},
+		{Binding: 2},
+	}
 	desc := &hal.BindGroupDescriptor{
 		Label:  "test",
 		Layout: mockBindGroupLayout{},
+		Entries: []gputypes.BindGroupEntry{
+			{Binding: 0},
+			{Binding: 1},
+			{Binding: 2},
+		},
 	}
-	err := ValidateBindGroupDescriptor(desc)
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, nil, gputypes.Limits{})
 	if err != nil {
 		t.Fatalf("expected nil error, got: %v", err)
 	}
@@ -889,7 +899,8 @@ func TestValidateBindGroupDescriptor_MissingLayout(t *testing.T) {
 		Label:  "test",
 		Layout: nil,
 	}
-	err := ValidateBindGroupDescriptor(desc)
+	// layoutEntries value does not matter -- nil layout is checked first.
+	err := ValidateBindGroupDescriptor(desc, nil, nil, gputypes.Limits{})
 	if err == nil {
 		t.Fatal("expected error for nil layout")
 	}
@@ -899,6 +910,341 @@ func TestValidateBindGroupDescriptor_MissingLayout(t *testing.T) {
 	}
 	if cbge.Kind != CreateBindGroupErrorMissingLayout {
 		t.Errorf("expected MissingLayout, got %v", cbge.Kind)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BindingsNumMismatch(t *testing.T) {
+	layoutEntries := []gputypes.BindGroupLayoutEntry{
+		{Binding: 0},
+		{Binding: 1},
+		{Binding: 2},
+		{Binding: 3},
+	}
+	desc := &hal.BindGroupDescriptor{
+		Label:  "test",
+		Layout: mockBindGroupLayout{},
+		Entries: []gputypes.BindGroupEntry{
+			{Binding: 0},
+			{Binding: 2},
+			{Binding: 3},
+		},
+	}
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, nil, gputypes.Limits{})
+	if err == nil {
+		t.Fatal("expected error for entry count mismatch (3 entries vs 4 layout entries)")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorBindingsNumMismatch {
+		t.Errorf("expected BindingsNumMismatch, got %v", cbge.Kind)
+	}
+	if cbge.Expected != 4 {
+		t.Errorf("expected Expected=4, got %d", cbge.Expected)
+	}
+	if cbge.Actual != 3 {
+		t.Errorf("expected Actual=3, got %d", cbge.Actual)
+	}
+}
+
+func TestValidateBindGroupDescriptor_MissingBindingDeclaration(t *testing.T) {
+	layoutEntries := []gputypes.BindGroupLayoutEntry{
+		{Binding: 0},
+		{Binding: 1},
+	}
+	desc := &hal.BindGroupDescriptor{
+		Label:  "test",
+		Layout: mockBindGroupLayout{},
+		Entries: []gputypes.BindGroupEntry{
+			{Binding: 0},
+			{Binding: 5}, // not declared in layout
+		},
+	}
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, nil, gputypes.Limits{})
+	if err == nil {
+		t.Fatal("expected error for binding 5 not declared in layout")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorMissingBindingDeclaration {
+		t.Errorf("expected MissingBindingDeclaration, got %v", cbge.Kind)
+	}
+	if cbge.Binding != 5 {
+		t.Errorf("expected Binding=5, got %d", cbge.Binding)
+	}
+}
+
+func TestValidateBindGroupDescriptor_DuplicateBinding(t *testing.T) {
+	layoutEntries := []gputypes.BindGroupLayoutEntry{
+		{Binding: 0},
+		{Binding: 1},
+	}
+	desc := &hal.BindGroupDescriptor{
+		Label:  "test",
+		Layout: mockBindGroupLayout{},
+		Entries: []gputypes.BindGroupEntry{
+			{Binding: 0},
+			{Binding: 0}, // duplicate
+		},
+	}
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, nil, gputypes.Limits{})
+	if err == nil {
+		t.Fatal("expected error for duplicate binding 0")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorDuplicateBinding {
+		t.Errorf("expected DuplicateBinding, got %v", cbge.Kind)
+	}
+	if cbge.Binding != 0 {
+		t.Errorf("expected Binding=0, got %d", cbge.Binding)
+	}
+}
+
+// --- ValidatePipelineLayoutDescriptor tests ---
+
+func TestValidatePipelineLayoutDescriptor_Valid(t *testing.T) {
+	limits := gputypes.DefaultLimits()
+	layouts := make([]hal.BindGroupLayout, limits.MaxBindGroups)
+	for i := range layouts {
+		layouts[i] = mockBindGroupLayout{}
+	}
+	desc := &hal.PipelineLayoutDescriptor{
+		Label:            "test",
+		BindGroupLayouts: layouts,
+	}
+	err := ValidatePipelineLayoutDescriptor(desc, limits)
+	if err != nil {
+		t.Fatalf("expected nil error for valid descriptor with %d bind group layouts, got: %v",
+			limits.MaxBindGroups, err)
+	}
+}
+
+func TestValidatePipelineLayoutDescriptor_Empty(t *testing.T) {
+	desc := &hal.PipelineLayoutDescriptor{
+		Label:            "test",
+		BindGroupLayouts: nil,
+	}
+	err := ValidatePipelineLayoutDescriptor(desc, gputypes.DefaultLimits())
+	if err != nil {
+		t.Fatalf("expected nil error for empty bind group layouts, got: %v", err)
+	}
+}
+
+func TestValidatePipelineLayoutDescriptor_TooManyGroups(t *testing.T) {
+	limits := gputypes.DefaultLimits()
+	layouts := make([]hal.BindGroupLayout, limits.MaxBindGroups+1)
+	for i := range layouts {
+		layouts[i] = mockBindGroupLayout{}
+	}
+	desc := &hal.PipelineLayoutDescriptor{
+		Label:            "test",
+		BindGroupLayouts: layouts,
+	}
+	err := ValidatePipelineLayoutDescriptor(desc, limits)
+	if err == nil {
+		t.Fatal("expected error for too many bind group layouts")
+	}
+	var cple *CreatePipelineLayoutError
+	if !errors.As(err, &cple) {
+		t.Fatalf("expected CreatePipelineLayoutError, got %T", err)
+	}
+	if cple.Kind != CreatePipelineLayoutErrorTooManyGroups {
+		t.Errorf("expected TooManyGroups, got %v", cple.Kind)
+	}
+	if cple.Count != int(limits.MaxBindGroups)+1 {
+		t.Errorf("expected Count %d, got %d", limits.MaxBindGroups+1, cple.Count)
+	}
+	if cple.MaxGroups != limits.MaxBindGroups {
+		t.Errorf("expected MaxGroups %d, got %d", limits.MaxBindGroups, cple.MaxGroups)
+	}
+}
+
+// --- ValidateRenderPipelineDescriptor format type guard tests ---
+
+func TestValidateRenderPipelineDescriptor_ColorTargetDepthFormat(t *testing.T) {
+	depthFormats := []gputypes.TextureFormat{
+		gputypes.TextureFormatDepth16Unorm,
+		gputypes.TextureFormatDepth24Plus,
+		gputypes.TextureFormatDepth24PlusStencil8,
+		gputypes.TextureFormatDepth32Float,
+		gputypes.TextureFormatDepth32FloatStencil8,
+		gputypes.TextureFormatStencil8,
+	}
+
+	for _, f := range depthFormats {
+		t.Run(f.String(), func(t *testing.T) {
+			desc := &hal.RenderPipelineDescriptor{
+				Label: "test",
+				Vertex: hal.VertexState{
+					Module:     mockShaderModule{},
+					EntryPoint: "vs_main",
+				},
+				Fragment: &hal.FragmentState{
+					Module:     mockShaderModule{},
+					EntryPoint: "fs_main",
+					Targets:    []gputypes.ColorTargetState{{Format: f}},
+				},
+				Multisample: gputypes.MultisampleState{Count: 1},
+			}
+			err := ValidateRenderPipelineDescriptor(desc, gputypes.DefaultLimits())
+			if err == nil {
+				t.Fatalf("expected error for depth/stencil format %s as color target", f)
+			}
+			var crpe *CreateRenderPipelineError
+			if !errors.As(err, &crpe) {
+				t.Fatalf("expected CreateRenderPipelineError, got %T", err)
+			}
+			if crpe.Kind != CreateRenderPipelineErrorColorTargetDepthFormat {
+				t.Errorf("expected ColorTargetDepthFormat, got %v", crpe.Kind)
+			}
+			if crpe.TargetIndex != 0 {
+				t.Errorf("expected TargetIndex 0, got %d", crpe.TargetIndex)
+			}
+			if !strings.Contains(crpe.Error(), "color aspect") {
+				t.Errorf("expected error to mention 'color aspect', got %q", crpe.Error())
+			}
+		})
+	}
+}
+
+func TestValidateRenderPipelineDescriptor_ColorTargetDepthFormat_SecondTarget(t *testing.T) {
+	desc := &hal.RenderPipelineDescriptor{
+		Label: "test",
+		Vertex: hal.VertexState{
+			Module:     mockShaderModule{},
+			EntryPoint: "vs_main",
+		},
+		Fragment: &hal.FragmentState{
+			Module:     mockShaderModule{},
+			EntryPoint: "fs_main",
+			Targets: []gputypes.ColorTargetState{
+				{Format: gputypes.TextureFormatRGBA8Unorm},   // valid color format
+				{Format: gputypes.TextureFormatDepth32Float}, // invalid: depth format
+			},
+		},
+		Multisample: gputypes.MultisampleState{Count: 1},
+	}
+	err := ValidateRenderPipelineDescriptor(desc, gputypes.DefaultLimits())
+	if err == nil {
+		t.Fatal("expected error for depth format as second color target")
+	}
+	var crpe *CreateRenderPipelineError
+	if !errors.As(err, &crpe) {
+		t.Fatalf("expected CreateRenderPipelineError, got %T", err)
+	}
+	if crpe.Kind != CreateRenderPipelineErrorColorTargetDepthFormat {
+		t.Errorf("expected ColorTargetDepthFormat, got %v", crpe.Kind)
+	}
+	if crpe.TargetIndex != 1 {
+		t.Errorf("expected TargetIndex 1, got %d", crpe.TargetIndex)
+	}
+}
+
+func TestValidateRenderPipelineDescriptor_DepthStencilColorFormat(t *testing.T) {
+	colorFormats := []gputypes.TextureFormat{
+		gputypes.TextureFormatRGBA8Unorm,
+		gputypes.TextureFormatBGRA8Unorm,
+		gputypes.TextureFormatR8Unorm,
+		gputypes.TextureFormatRGBA16Float,
+	}
+
+	for _, f := range colorFormats {
+		t.Run(f.String(), func(t *testing.T) {
+			desc := &hal.RenderPipelineDescriptor{
+				Label: "test",
+				Vertex: hal.VertexState{
+					Module:     mockShaderModule{},
+					EntryPoint: "vs_main",
+				},
+				DepthStencil: &hal.DepthStencilState{
+					Format: f, // color format used as depth/stencil — invalid
+				},
+				Multisample: gputypes.MultisampleState{Count: 1},
+			}
+			err := ValidateRenderPipelineDescriptor(desc, gputypes.DefaultLimits())
+			if err == nil {
+				t.Fatalf("expected error for color format %s as depth/stencil", f)
+			}
+			var crpe *CreateRenderPipelineError
+			if !errors.As(err, &crpe) {
+				t.Fatalf("expected CreateRenderPipelineError, got %T", err)
+			}
+			if crpe.Kind != CreateRenderPipelineErrorDepthStencilColorFormat {
+				t.Errorf("expected DepthStencilColorFormat, got %v", crpe.Kind)
+			}
+			if !strings.Contains(crpe.Error(), "not a depth/stencil format") {
+				t.Errorf("expected error to mention 'not a depth/stencil format', got %q", crpe.Error())
+			}
+		})
+	}
+}
+
+func TestValidateRenderPipelineDescriptor_ValidDepthStencil(t *testing.T) {
+	depthFormats := []gputypes.TextureFormat{
+		gputypes.TextureFormatDepth16Unorm,
+		gputypes.TextureFormatDepth24Plus,
+		gputypes.TextureFormatDepth24PlusStencil8,
+		gputypes.TextureFormatDepth32Float,
+		gputypes.TextureFormatDepth32FloatStencil8,
+		gputypes.TextureFormatStencil8,
+	}
+
+	for _, f := range depthFormats {
+		t.Run(f.String(), func(t *testing.T) {
+			desc := &hal.RenderPipelineDescriptor{
+				Label: "test",
+				Vertex: hal.VertexState{
+					Module:     mockShaderModule{},
+					EntryPoint: "vs_main",
+				},
+				DepthStencil: &hal.DepthStencilState{
+					Format: f, // valid depth/stencil format
+				},
+				Multisample: gputypes.MultisampleState{Count: 1},
+			}
+			err := ValidateRenderPipelineDescriptor(desc, gputypes.DefaultLimits())
+			if err != nil {
+				t.Fatalf("expected nil error for valid depth/stencil format %s, got: %v", f, err)
+			}
+		})
+	}
+}
+
+func TestValidateRenderPipelineDescriptor_ValidColorTargetFormats(t *testing.T) {
+	colorFormats := []gputypes.TextureFormat{
+		gputypes.TextureFormatRGBA8Unorm,
+		gputypes.TextureFormatBGRA8Unorm,
+		gputypes.TextureFormatR8Unorm,
+		gputypes.TextureFormatRGBA16Float,
+		gputypes.TextureFormatRGBA32Float,
+	}
+
+	for _, f := range colorFormats {
+		t.Run(f.String(), func(t *testing.T) {
+			desc := &hal.RenderPipelineDescriptor{
+				Label: "test",
+				Vertex: hal.VertexState{
+					Module:     mockShaderModule{},
+					EntryPoint: "vs_main",
+				},
+				Fragment: &hal.FragmentState{
+					Module:     mockShaderModule{},
+					EntryPoint: "fs_main",
+					Targets:    []gputypes.ColorTargetState{{Format: f}},
+				},
+				Multisample: gputypes.MultisampleState{Count: 1},
+			}
+			err := ValidateRenderPipelineDescriptor(desc, gputypes.DefaultLimits())
+			if err != nil {
+				t.Fatalf("expected nil error for valid color format %s, got: %v", f, err)
+			}
+		})
 	}
 }
 
@@ -1082,6 +1428,16 @@ func TestCreateRenderPipelineError_Error(t *testing.T) {
 			err:      &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorTooManyColorTargets, Label: "test", TargetCount: 10, MaxTargets: 8},
 			contains: "exceeds maximum",
 		},
+		{
+			name:     "color target depth format",
+			err:      &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorColorTargetDepthFormat, Label: "test", TargetIndex: 0, Format: "Depth32Float"},
+			contains: "color aspect",
+		},
+		{
+			name:     "depth stencil color format",
+			err:      &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorDepthStencilColorFormat, Label: "test", Format: "RGBA8Unorm"},
+			contains: "not a depth/stencil format",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1152,6 +1508,42 @@ func TestCreateComputePipelineError_Error(t *testing.T) {
 	}
 }
 
+func TestCreatePipelineLayoutError_Error(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      *CreatePipelineLayoutError
+		contains string
+	}{
+		{
+			name:     "too many groups",
+			err:      &CreatePipelineLayoutError{Kind: CreatePipelineLayoutErrorTooManyGroups, Label: "test", Count: 5, MaxGroups: 4},
+			contains: "exceeds device limit",
+		},
+		{
+			name:     "HAL error",
+			err:      &CreatePipelineLayoutError{Kind: CreatePipelineLayoutErrorHAL, Label: "test", HALError: errors.New("backend")},
+			contains: "HAL error",
+		},
+		{
+			name:     "unnamed label",
+			err:      &CreatePipelineLayoutError{Kind: CreatePipelineLayoutErrorTooManyGroups, Label: "", Count: 8, MaxGroups: 4},
+			contains: "<unnamed>",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if msg == "" {
+				t.Error("Error message should not be empty")
+			}
+			if !strings.Contains(msg, tt.contains) {
+				t.Errorf("expected error to contain %q, got %q", tt.contains, msg)
+			}
+		})
+	}
+}
+
 func TestCreateBindGroupLayoutError_Error(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1184,9 +1576,455 @@ func TestCreateBindGroupLayoutError_Error(t *testing.T) {
 }
 
 func TestCreateBindGroupError_Error(t *testing.T) {
-	err := &CreateBindGroupError{Kind: CreateBindGroupErrorMissingLayout, Label: "test"}
-	msg := err.Error()
-	if !strings.Contains(msg, "must not be nil") {
-		t.Errorf("expected error to contain 'must not be nil', got %q", msg)
+	tests := []struct {
+		name     string
+		err      *CreateBindGroupError
+		contains string
+	}{
+		{
+			name:     "missing layout",
+			err:      &CreateBindGroupError{Kind: CreateBindGroupErrorMissingLayout, Label: "test"},
+			contains: "must not be nil",
+		},
+		{
+			name:     "bindings num mismatch",
+			err:      &CreateBindGroupError{Kind: CreateBindGroupErrorBindingsNumMismatch, Label: "test", Expected: 4, Actual: 3},
+			contains: "does not match",
+		},
+		{
+			name:     "missing binding declaration",
+			err:      &CreateBindGroupError{Kind: CreateBindGroupErrorMissingBindingDeclaration, Label: "test", Binding: 5},
+			contains: "binding 5",
+		},
+		{
+			name:     "duplicate binding",
+			err:      &CreateBindGroupError{Kind: CreateBindGroupErrorDuplicateBinding, Label: "test", Binding: 2},
+			contains: "binding 2",
+		},
+		{
+			name:     "buffer usage mismatch",
+			err:      &CreateBindGroupError{Kind: CreateBindGroupErrorBufferUsageMismatch, Label: "test", Binding: 0, ExpectedUsage: 0x40, ActualUsage: 0x80},
+			contains: "usage mismatch",
+		},
+		{
+			name:     "buffer offset alignment",
+			err:      &CreateBindGroupError{Kind: CreateBindGroupErrorBufferOffsetAlignment, Label: "test", Binding: 1, Offset: 100, Alignment: 256},
+			contains: "not aligned",
+		},
+		{
+			name:     "buffer binding size too large",
+			err:      &CreateBindGroupError{Kind: CreateBindGroupErrorBufferBindingSizeTooLarge, Label: "test", Binding: 0, Size: 100000, MaxSize: 65536},
+			contains: "exceeds maximum",
+		},
+		{
+			name:     "buffer bounds overflow",
+			err:      &CreateBindGroupError{Kind: CreateBindGroupErrorBufferBoundsOverflow, Label: "test", Binding: 0, Offset: 100, Size: 200, BufferSize: 256},
+			contains: "overflows",
+		},
+		{
+			name:     "buffer binding zero size",
+			err:      &CreateBindGroupError{Kind: CreateBindGroupErrorBufferBindingZeroSize, Label: "test", Binding: 0},
+			contains: "zero",
+		},
+		{
+			name:     "storage buffer size alignment",
+			err:      &CreateBindGroupError{Kind: CreateBindGroupErrorStorageBufferSizeAlignment, Label: "test", Binding: 0, Size: 13},
+			contains: "not a multiple of 4",
+		},
+		{
+			name:     "HAL error",
+			err:      &CreateBindGroupError{Kind: CreateBindGroupErrorHAL, Label: "test", HALError: errors.New("backend")},
+			contains: "HAL error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if msg == "" {
+				t.Error("Error message should not be empty")
+			}
+			if !strings.Contains(msg, tt.contains) {
+				t.Errorf("expected error to contain %q, got %q", tt.contains, msg)
+			}
+		})
+	}
+}
+
+// --- ValidateBindGroupDescriptor buffer validation tests (VAL-A2) ---
+
+// validBindGroupBufferSetup returns a valid bind group descriptor, layout entries,
+// buffer infos, and limits for buffer validation tests. The setup has a single
+// uniform buffer binding at slot 0.
+func validBindGroupBufferSetup() (
+	*hal.BindGroupDescriptor,
+	[]gputypes.BindGroupLayoutEntry,
+	[]BindGroupBufferInfo,
+	gputypes.Limits,
+) {
+	limits := gputypes.DefaultLimits()
+	layoutEntries := []gputypes.BindGroupLayoutEntry{
+		{
+			Binding: 0,
+			Buffer: &gputypes.BufferBindingLayout{
+				Type: gputypes.BufferBindingTypeUniform,
+			},
+		},
+	}
+	desc := &hal.BindGroupDescriptor{
+		Label:  "test",
+		Layout: mockBindGroupLayout{},
+		Entries: []gputypes.BindGroupEntry{
+			{Binding: 0},
+		},
+	}
+	bufferInfos := []BindGroupBufferInfo{
+		{
+			Binding:    0,
+			Usage:      gputypes.BufferUsageUniform,
+			BufferSize: 1024,
+			Offset:     0,
+			Size:       256,
+		},
+	}
+	return desc, layoutEntries, bufferInfos, limits
+}
+
+func TestValidateBindGroupDescriptor_BufferValid(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err != nil {
+		t.Fatalf("expected nil error for valid buffer binding, got: %v", err)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferValidImplicitSize(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	// Size == 0 means "rest of buffer from offset".
+	bufferInfos[0].Size = 0
+	bufferInfos[0].Offset = 256
+	bufferInfos[0].BufferSize = 1024
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err != nil {
+		t.Fatalf("expected nil error for valid implicit-size buffer binding, got: %v", err)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferUsageMismatch_UniformAsStorage(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	// Layout wants uniform, but buffer only has storage usage.
+	bufferInfos[0].Usage = gputypes.BufferUsageStorage
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err == nil {
+		t.Fatal("expected error for buffer usage mismatch")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorBufferUsageMismatch {
+		t.Errorf("expected BufferUsageMismatch, got %v", cbge.Kind)
+	}
+	if cbge.Binding != 0 {
+		t.Errorf("expected Binding=0, got %d", cbge.Binding)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferUsageMismatch_StorageAsUniform(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	// Change layout to storage binding.
+	layoutEntries[0].Buffer.Type = gputypes.BufferBindingTypeStorage
+	// Buffer only has uniform usage, not storage.
+	bufferInfos[0].Usage = gputypes.BufferUsageUniform
+	bufferInfos[0].Size = 64 // multiple of 4 to avoid storage alignment error
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err == nil {
+		t.Fatal("expected error for storage binding with uniform-only buffer")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorBufferUsageMismatch {
+		t.Errorf("expected BufferUsageMismatch, got %v", cbge.Kind)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferOffsetMisaligned_Uniform(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	// Default MinUniformBufferOffsetAlignment is 256. Use offset 100.
+	bufferInfos[0].Offset = 100
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err == nil {
+		t.Fatal("expected error for misaligned uniform buffer offset")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorBufferOffsetAlignment {
+		t.Errorf("expected BufferOffsetAlignment, got %v", cbge.Kind)
+	}
+	if cbge.Offset != 100 {
+		t.Errorf("expected Offset=100, got %d", cbge.Offset)
+	}
+	if cbge.Alignment != 256 {
+		t.Errorf("expected Alignment=256, got %d", cbge.Alignment)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferOffsetMisaligned_Storage(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	layoutEntries[0].Buffer.Type = gputypes.BufferBindingTypeStorage
+	bufferInfos[0].Usage = gputypes.BufferUsageStorage
+	bufferInfos[0].Offset = 128 // 128 is not aligned to 256 (MinStorageBufferOffsetAlignment)
+	bufferInfos[0].Size = 128
+	bufferInfos[0].BufferSize = 1024
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err == nil {
+		t.Fatal("expected error for misaligned storage buffer offset")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorBufferOffsetAlignment {
+		t.Errorf("expected BufferOffsetAlignment, got %v", cbge.Kind)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferOffsetAligned(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	// 256 is exactly aligned to MinUniformBufferOffsetAlignment (256).
+	bufferInfos[0].Offset = 256
+	bufferInfos[0].Size = 256
+	bufferInfos[0].BufferSize = 1024
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err != nil {
+		t.Fatalf("expected nil error for aligned offset, got: %v", err)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferBindingSizeTooLarge_Uniform(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	// DefaultLimits MaxUniformBufferBindingSize is 65536. Use a larger size.
+	bufferInfos[0].Size = 65537
+	bufferInfos[0].BufferSize = 1 << 20 // 1 MiB buffer to avoid bounds error
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err == nil {
+		t.Fatal("expected error for binding size exceeding max uniform buffer binding size")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorBufferBindingSizeTooLarge {
+		t.Errorf("expected BufferBindingSizeTooLarge, got %v", cbge.Kind)
+	}
+	if cbge.MaxSize != 65536 {
+		t.Errorf("expected MaxSize=65536, got %d", cbge.MaxSize)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferBindingSizeTooLarge_Storage(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	layoutEntries[0].Buffer.Type = gputypes.BufferBindingTypeStorage
+	bufferInfos[0].Usage = gputypes.BufferUsageStorage
+	// DefaultLimits MaxStorageBufferBindingSize is 134217728 (128 MiB).
+	// Use a size that exceeds it and is 4-byte aligned.
+	bufferInfos[0].Size = 134217732     // 128 MiB + 4
+	bufferInfos[0].BufferSize = 1 << 28 // 256 MiB buffer
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err == nil {
+		t.Fatal("expected error for binding size exceeding max storage buffer binding size")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorBufferBindingSizeTooLarge {
+		t.Errorf("expected BufferBindingSizeTooLarge, got %v", cbge.Kind)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferBoundsOverflow_ExplicitSize(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	// offset=512, size=600, buffer=1024: 512+600=1112 > 1024
+	bufferInfos[0].Offset = 512
+	bufferInfos[0].Size = 600
+	bufferInfos[0].BufferSize = 1024
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err == nil {
+		t.Fatal("expected error for buffer bounds overflow")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorBufferBoundsOverflow {
+		t.Errorf("expected BufferBoundsOverflow, got %v", cbge.Kind)
+	}
+	if cbge.Offset != 512 {
+		t.Errorf("expected Offset=512, got %d", cbge.Offset)
+	}
+	if cbge.Size != 600 {
+		t.Errorf("expected Size=600, got %d", cbge.Size)
+	}
+	if cbge.BufferSize != 1024 {
+		t.Errorf("expected BufferSize=1024, got %d", cbge.BufferSize)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferBoundsOverflow_ImplicitSize(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	// Size=0 (implicit), offset > bufferSize
+	bufferInfos[0].Size = 0
+	bufferInfos[0].Offset = 2048
+	bufferInfos[0].BufferSize = 1024
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err == nil {
+		t.Fatal("expected error for buffer offset beyond buffer end with implicit size")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	// Offset > BufferSize: effectiveSize = 0, caught by zero-size check before bounds check.
+	if cbge.Kind != CreateBindGroupErrorBufferBindingZeroSize {
+		t.Errorf("expected BufferBindingZeroSize (offset beyond buffer), got %v", cbge.Kind)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferBindingZeroSize_ExplicitZeroBuffer(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	// Buffer of size 0 with implicit size binding: effective size = 0.
+	bufferInfos[0].Size = 0
+	bufferInfos[0].Offset = 0
+	bufferInfos[0].BufferSize = 0
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err == nil {
+		t.Fatal("expected error for zero effective binding size")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorBufferBindingZeroSize {
+		t.Errorf("expected BufferBindingZeroSize, got %v", cbge.Kind)
+	}
+}
+
+func TestValidateBindGroupDescriptor_StorageBufferSizeNotMultipleOf4(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	layoutEntries[0].Buffer.Type = gputypes.BufferBindingTypeStorage
+	bufferInfos[0].Usage = gputypes.BufferUsageStorage
+	bufferInfos[0].Size = 13 // not a multiple of 4
+	bufferInfos[0].BufferSize = 1024
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err == nil {
+		t.Fatal("expected error for storage buffer size not multiple of 4")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorStorageBufferSizeAlignment {
+		t.Errorf("expected StorageBufferSizeAlignment, got %v", cbge.Kind)
+	}
+	if cbge.Size != 13 {
+		t.Errorf("expected Size=13, got %d", cbge.Size)
+	}
+}
+
+func TestValidateBindGroupDescriptor_StorageBufferSizeMultipleOf4_ReadOnly(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	layoutEntries[0].Buffer.Type = gputypes.BufferBindingTypeReadOnlyStorage
+	bufferInfos[0].Usage = gputypes.BufferUsageStorage
+	bufferInfos[0].Size = 15 // not a multiple of 4
+	bufferInfos[0].BufferSize = 1024
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err == nil {
+		t.Fatal("expected error for read-only storage buffer size not multiple of 4")
+	}
+	var cbge *CreateBindGroupError
+	if !errors.As(err, &cbge) {
+		t.Fatalf("expected CreateBindGroupError, got %T", err)
+	}
+	if cbge.Kind != CreateBindGroupErrorStorageBufferSizeAlignment {
+		t.Errorf("expected StorageBufferSizeAlignment, got %v", cbge.Kind)
+	}
+}
+
+func TestValidateBindGroupDescriptor_StorageBufferValid(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	layoutEntries[0].Buffer.Type = gputypes.BufferBindingTypeStorage
+	bufferInfos[0].Usage = gputypes.BufferUsageStorage
+	bufferInfos[0].Size = 256 // aligned, multiple of 4, within limits
+	bufferInfos[0].Offset = 0
+	bufferInfos[0].BufferSize = 1024
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err != nil {
+		t.Fatalf("expected nil error for valid storage buffer binding, got: %v", err)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferNoBufferLayoutEntry(t *testing.T) {
+	// Buffer info provided for a binding whose layout entry is a sampler, not a buffer.
+	// The buffer validation should skip this entry gracefully.
+	layoutEntries := []gputypes.BindGroupLayoutEntry{
+		{
+			Binding: 0,
+			Sampler: &gputypes.SamplerBindingLayout{
+				Type: gputypes.SamplerBindingTypeFiltering,
+			},
+		},
+	}
+	desc := &hal.BindGroupDescriptor{
+		Label:  "test",
+		Layout: mockBindGroupLayout{},
+		Entries: []gputypes.BindGroupEntry{
+			{Binding: 0},
+		},
+	}
+	bufferInfos := []BindGroupBufferInfo{
+		{
+			Binding:    0,
+			Usage:      gputypes.BufferUsageUniform,
+			BufferSize: 1024,
+			Offset:     0,
+			Size:       256,
+		},
+	}
+	limits := gputypes.DefaultLimits()
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err != nil {
+		t.Fatalf("expected nil error when buffer info binding has no buffer layout, got: %v", err)
+	}
+}
+
+func TestValidateBindGroupDescriptor_BufferBoundsExact(t *testing.T) {
+	desc, layoutEntries, bufferInfos, limits := validBindGroupBufferSetup()
+	// Exact fit: offset + size == bufferSize
+	bufferInfos[0].Offset = 0
+	bufferInfos[0].Size = 1024
+	bufferInfos[0].BufferSize = 1024
+
+	err := ValidateBindGroupDescriptor(desc, layoutEntries, bufferInfos, limits)
+	if err != nil {
+		t.Fatalf("expected nil error for exact-fit buffer binding, got: %v", err)
 	}
 }

--- a/device_native.go
+++ b/device_native.go
@@ -309,6 +309,10 @@ func (d *Device) CreatePipelineLayout(desc *PipelineLayoutDescriptor) (*Pipeline
 		BindGroupLayouts: halLayouts,
 	}
 
+	if err := core.ValidatePipelineLayoutDescriptor(halDesc, d.core.Limits); err != nil {
+		return nil, err
+	}
+
 	halLayout, err := halDevice.CreatePipelineLayout(halDesc)
 	if err != nil {
 		return nil, fmt.Errorf("wgpu: failed to create pipeline layout: %w", err)
@@ -358,6 +362,24 @@ func (d *Device) CreateBindGroup(desc *BindGroupDescriptor) (*BindGroup, error) 
 		Entries: halEntries,
 	}
 
+	// Build buffer metadata for core validation.
+	var bufferInfos []core.BindGroupBufferInfo
+	for _, entry := range desc.Entries {
+		if entry.Buffer != nil {
+			bufferInfos = append(bufferInfos, core.BindGroupBufferInfo{
+				Binding:    entry.Binding,
+				Usage:      entry.Buffer.Usage(),
+				BufferSize: entry.Buffer.Size(),
+				Offset:     entry.Offset,
+				Size:       entry.Size,
+			})
+		}
+	}
+
+	if err := core.ValidateBindGroupDescriptor(halDesc, desc.Layout.entries, bufferInfos, d.core.Limits); err != nil {
+		return nil, err
+	}
+
 	halGroup, err := halDevice.CreateBindGroup(halDesc)
 	if err != nil {
 		return nil, fmt.Errorf("wgpu: failed to create bind group: %w", err)
@@ -392,6 +414,9 @@ func (d *Device) CreateBindGroup(desc *BindGroupDescriptor) (*BindGroup, error) 
 		})
 	}
 
+	// Collect buffer and texture references for submit-time validation (VAL-A6).
+	boundBuffers, boundTextures := collectBindGroupResources(desc.Entries)
+
 	bg := &BindGroup{
 		hal:                    halGroup,
 		device:                 d,
@@ -399,6 +424,8 @@ func (d *Device) CreateBindGroup(desc *BindGroupDescriptor) (*BindGroup, error) 
 		layout:                 desc.Layout,
 		lateBufferBindingInfos: lateInfos,
 		ref:                    core.NewResourceRef("BindGroup:"+desc.Label, nil),
+		boundBuffers:           boundBuffers,
+		boundTextures:          boundTextures,
 	}
 
 	// Safety net: if the bind group is garbage collected without Release(),
@@ -406,6 +433,24 @@ func (d *Device) CreateBindGroup(desc *BindGroupDescriptor) (*BindGroup, error) 
 	bg.cleanup = registerBindGroupCleanup(bg, d, desc.Label)
 
 	return bg, nil
+}
+
+// collectBindGroupResources extracts buffer and texture references from bind
+// group entries for submit-time validation (VAL-A6). Matches Rust wgpu-core
+// where bind group creation stores resource references that are later checked
+// via trackers.buffers/textures.used_resources() in validate_command_buffer.
+func collectBindGroupResources(entries []BindGroupEntry) ([]*Buffer, []*Texture) {
+	var buffers []*Buffer
+	var textures []*Texture
+	for i := range entries {
+		if entries[i].Buffer != nil {
+			buffers = append(buffers, entries[i].Buffer)
+		}
+		if entries[i].TextureView != nil && entries[i].TextureView.texture != nil {
+			textures = append(textures, entries[i].TextureView.texture)
+		}
+	}
+	return buffers, textures
 }
 
 // buildBindGroupEntryMap builds a lookup map from binding index to BindGroupEntry

--- a/encoder_native.go
+++ b/encoder_native.go
@@ -28,6 +28,17 @@ type CommandEncoder struct {
 	// On Finish(), ownership transfers to the CommandBuffer for post-GPU recycling.
 	// On DiscardEncoding(), the encoder is reset and returned to the pool immediately.
 	halEncoder hal.CommandEncoder
+
+	// usedBuffers tracks root-level buffers referenced during encoding for
+	// submit-time validation (VAL-A6). At Submit, each buffer is checked for
+	// destroyed/mapped state. Using a map for O(1) deduplication — the same
+	// buffer may be set as vertex, index, and bind group buffer in a single pass.
+	usedBuffers map[*Buffer]struct{}
+
+	// usedTextures tracks root-level textures referenced during encoding for
+	// submit-time validation (VAL-A6). At Submit, each texture is checked for
+	// destroyed state.
+	usedTextures map[*Texture]struct{}
 }
 
 // setError records a deferred error on the underlying command encoder.
@@ -47,6 +58,30 @@ func (e *CommandEncoder) trackRef(ref *core.ResourceRef) {
 		ref.Clone()
 		e.trackedRefs = append(e.trackedRefs, ref)
 	}
+}
+
+// trackBuffer records a buffer reference for submit-time validation (VAL-A6).
+// The map is lazily initialized to avoid allocation when no buffers are used.
+func (e *CommandEncoder) trackBuffer(buf *Buffer) {
+	if buf == nil {
+		return
+	}
+	if e.usedBuffers == nil {
+		e.usedBuffers = make(map[*Buffer]struct{})
+	}
+	e.usedBuffers[buf] = struct{}{}
+}
+
+// trackTexture records a texture reference for submit-time validation (VAL-A6).
+// The map is lazily initialized to avoid allocation when no textures are used.
+func (e *CommandEncoder) trackTexture(tex *Texture) {
+	if tex == nil {
+		return
+	}
+	if e.usedTextures == nil {
+		e.usedTextures = make(map[*Texture]struct{})
+	}
+	e.usedTextures[tex] = struct{}{}
 }
 
 // BeginRenderPass begins a render pass.
@@ -103,6 +138,8 @@ func (e *CommandEncoder) CopyBufferToBuffer(src *Buffer, srcOffset uint64, dst *
 	}
 	e.trackRef(src.core.Ref)
 	e.trackRef(dst.core.Ref)
+	e.trackBuffer(src)
+	e.trackBuffer(dst)
 	raw := e.core.RawEncoder()
 	if raw == nil {
 		return
@@ -131,6 +168,8 @@ func (e *CommandEncoder) CopyTextureToBuffer(src *Texture, dst *Buffer, regions 
 		e.setError(fmt.Errorf("wgpu: CommandEncoder.CopyTextureToBuffer: destination buffer is nil"))
 		return
 	}
+	e.trackTexture(src)
+	e.trackBuffer(dst)
 	raw := e.core.RawEncoder()
 	if raw == nil {
 		return
@@ -160,6 +199,8 @@ func (e *CommandEncoder) CopyTextureToTexture(src, dst *Texture, regions []Textu
 		e.setError(fmt.Errorf("wgpu: CommandEncoder.CopyTextureToTexture: destination texture is nil"))
 		return
 	}
+	e.trackTexture(src)
+	e.trackTexture(dst)
 	raw := e.core.RawEncoder()
 	if raw == nil {
 		return
@@ -263,13 +304,17 @@ func (e *CommandEncoder) Finish() (*CommandBuffer, error) {
 	}
 
 	cb := &CommandBuffer{
-		core:        coreCmdBuffer,
-		device:      e.device,
-		trackedRefs: e.trackedRefs,
-		halEncoder:  e.halEncoder,
+		core:         coreCmdBuffer,
+		device:       e.device,
+		trackedRefs:  e.trackedRefs,
+		halEncoder:   e.halEncoder,
+		usedBuffers:  e.usedBuffers,
+		usedTextures: e.usedTextures,
 	}
 	e.trackedRefs = nil
-	e.halEncoder = nil // ownership transferred
+	e.halEncoder = nil   // ownership transferred
+	e.usedBuffers = nil  // ownership transferred
+	e.usedTextures = nil // ownership transferred
 	return cb, nil
 }
 
@@ -339,6 +384,24 @@ type CommandBuffer struct {
 	// Matches Rust wgpu-core where the encoder travels:
 	// CommandEncoder -> CommandBuffer -> EncoderInFlight -> GPU done -> pool
 	halEncoder hal.CommandEncoder
+
+	// usedBuffers tracks all buffers referenced during encoding (VAL-A6).
+	// Validated at Submit time: destroyed or mapped buffers cause an error.
+	// Matches Rust wgpu-core's cmd_buf_data.trackers.buffers.used_resources()
+	// (device/queue.rs:1780-1787).
+	usedBuffers map[*Buffer]struct{}
+
+	// usedTextures tracks all textures referenced during encoding (VAL-A6).
+	// Validated at Submit time: destroyed textures cause an error.
+	// Matches Rust wgpu-core's cmd_buf_data.trackers.textures.used_resources()
+	// (device/queue.rs:1791-1808).
+	usedTextures map[*Texture]struct{}
+
+	// submitted is set to true after this command buffer has been submitted
+	// to a queue. A command buffer cannot be submitted twice.
+	// Matches Rust wgpu-core's CommandBuffer::take_finished() which consumes
+	// the buffer, preventing reuse.
+	submitted bool
 }
 
 // Release releases a CommandBuffer that will NOT be submitted to the GPU.

--- a/error.go
+++ b/error.go
@@ -30,6 +30,90 @@ var (
 	ErrNoBackends = errors.New("wgpu: no backends registered (import a backend package)")
 )
 
+// Draw-time validation sentinel errors.
+// These are wrapped with additional context (e.g., method name) and surfaced
+// as deferred errors on Finish(). Use errors.Is() to match programmatically.
+//
+// Matches Rust wgpu-core DrawError / DispatchError variants
+// (command/render.rs:542-593, command/compute.rs:278-284).
+var (
+	// ErrDrawMissingPipeline is returned when Draw/DrawIndexed/DrawIndirect is
+	// called before SetPipeline on a render pass encoder.
+	ErrDrawMissingPipeline = errors.New("wgpu: draw called without SetPipeline")
+
+	// ErrDrawMissingBindGroup is returned when a draw command is issued but not
+	// all bind groups required by the current pipeline have been set.
+	ErrDrawMissingBindGroup = errors.New("wgpu: draw called with missing bind group")
+
+	// ErrDrawIncompatibleBindGroup is returned when a draw command is issued but
+	// the bind group set at a slot has an incompatible layout with the pipeline.
+	ErrDrawIncompatibleBindGroup = errors.New("wgpu: draw called with incompatible bind group layout")
+
+	// ErrDrawMissingVertexBuffer is returned when a draw command is issued but
+	// fewer vertex buffers have been set than the pipeline requires.
+	ErrDrawMissingVertexBuffer = errors.New("wgpu: draw called with insufficient vertex buffers")
+
+	// ErrDrawMissingIndexBuffer is returned when DrawIndexed or
+	// DrawIndexedIndirect is called before SetIndexBuffer.
+	ErrDrawMissingIndexBuffer = errors.New("wgpu: DrawIndexed called without SetIndexBuffer")
+
+	// ErrDrawMissingBlendConstant is returned when a draw command is issued
+	// but the pipeline uses BlendFactorConstant and SetBlendConstant was not called.
+	ErrDrawMissingBlendConstant = errors.New("wgpu: draw called without SetBlendConstant (pipeline uses constant blend factor)")
+
+	// ErrDrawLateBufferTooSmall is returned when a buffer bound via SetBindGroup
+	// is smaller than the shader-required minimum for a binding whose layout
+	// has MinBindingSize == 0.
+	ErrDrawLateBufferTooSmall = errors.New("wgpu: bound buffer smaller than shader-required minimum")
+
+	// ErrDispatchMissingPipeline is returned when Dispatch/DispatchIndirect is
+	// called before SetPipeline on a compute pass encoder.
+	ErrDispatchMissingPipeline = errors.New("wgpu: dispatch called without SetPipeline")
+
+	// ErrDispatchMissingBindGroup is returned when a dispatch command is issued
+	// but not all bind groups required by the current pipeline have been set.
+	ErrDispatchMissingBindGroup = errors.New("wgpu: dispatch called with missing bind group")
+
+	// ErrDispatchIncompatibleBindGroup is returned when a dispatch command is
+	// issued but the bind group set at a slot has an incompatible layout.
+	ErrDispatchIncompatibleBindGroup = errors.New("wgpu: dispatch called with incompatible bind group layout")
+
+	// ErrDispatchLateBufferTooSmall is returned when a buffer bound via
+	// SetBindGroup is smaller than the shader-required minimum for a dispatch.
+	ErrDispatchLateBufferTooSmall = errors.New("wgpu: dispatch: bound buffer smaller than shader-required minimum")
+
+	// ErrDispatchWorkgroupCountExceeded is returned when Dispatch is called with
+	// workgroup counts exceeding the device limit.
+	ErrDispatchWorkgroupCountExceeded = errors.New("wgpu: dispatch workgroup count exceeds device limit")
+)
+
+// Queue.Submit validation sentinel errors (VAL-A6).
+// Returned when Submit detects that a command buffer references resources in
+// an invalid state. These match Rust wgpu-core QueueSubmitError variants
+// (device/queue.rs:484-516).
+var (
+	// ErrSubmitBufferDestroyed is returned when a submitted command buffer
+	// references a buffer that has been released/destroyed.
+	// Matches Rust QueueSubmitError::DestroyedResource for buffers.
+	ErrSubmitBufferDestroyed = errors.New("wgpu: Submit: command buffer references destroyed buffer")
+
+	// ErrSubmitBufferMapped is returned when a submitted command buffer
+	// references a buffer that is currently mapped. Submitting GPU commands
+	// that read/write a mapped buffer is a data race.
+	// Matches Rust QueueSubmitError::BufferStillMapped.
+	ErrSubmitBufferMapped = errors.New("wgpu: Submit: command buffer references mapped buffer")
+
+	// ErrSubmitTextureDestroyed is returned when a submitted command buffer
+	// references a texture that has been released/destroyed.
+	// Matches Rust QueueSubmitError::DestroyedResource for textures.
+	ErrSubmitTextureDestroyed = errors.New("wgpu: Submit: command buffer references destroyed texture")
+
+	// ErrSubmitCommandBufferInvalid is returned when a command buffer has
+	// already been submitted or was never properly finished.
+	// Matches Rust QueueSubmitError::CommandEncoder for invalid command buffers.
+	ErrSubmitCommandBufferInvalid = errors.New("wgpu: Submit: command buffer is invalid (already submitted or encoding error)")
+)
+
 // Re-export error types from core.
 type GPUError = core.GPUError
 type ErrorFilter = core.ErrorFilter

--- a/error_browser.go
+++ b/error_browser.go
@@ -31,6 +31,22 @@ var (
 	ErrTimeout = errors.New("wgpu: timeout")
 )
 
+// Draw-time validation sentinel errors.
+var (
+	ErrDrawMissingPipeline            = errors.New("wgpu: draw called without SetPipeline")
+	ErrDrawMissingBindGroup           = errors.New("wgpu: draw called with missing bind group")
+	ErrDrawIncompatibleBindGroup      = errors.New("wgpu: draw called with incompatible bind group layout")
+	ErrDrawMissingVertexBuffer        = errors.New("wgpu: draw called with insufficient vertex buffers")
+	ErrDrawMissingIndexBuffer         = errors.New("wgpu: DrawIndexed called without SetIndexBuffer")
+	ErrDrawMissingBlendConstant       = errors.New("wgpu: draw called without SetBlendConstant (pipeline uses constant blend factor)")
+	ErrDrawLateBufferTooSmall         = errors.New("wgpu: bound buffer smaller than shader-required minimum")
+	ErrDispatchMissingPipeline        = errors.New("wgpu: dispatch called without SetPipeline")
+	ErrDispatchMissingBindGroup       = errors.New("wgpu: dispatch called with missing bind group")
+	ErrDispatchIncompatibleBindGroup  = errors.New("wgpu: dispatch called with incompatible bind group layout")
+	ErrDispatchLateBufferTooSmall     = errors.New("wgpu: dispatch: bound buffer smaller than shader-required minimum")
+	ErrDispatchWorkgroupCountExceeded = errors.New("wgpu: dispatch workgroup count exceeds device limit")
+)
+
 // GPUError represents a GPU error.
 type GPUError struct {
 	Message string

--- a/export_test.go
+++ b/export_test.go
@@ -2,7 +2,10 @@
 
 package wgpu
 
-import "github.com/gogpu/wgpu/core"
+import (
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/core"
+)
 
 // SetTestRequiredVertexBuffers sets the requiredVertexBuffers field for testing.
 // This method is only available in test builds.
@@ -58,4 +61,26 @@ func (g *BindGroup) TestBindGroupReleased() bool {
 		return false
 	}
 	return g.released.Load()
+}
+
+// SetTestBindGroupLayouts sets the bindGroupLayouts field on a RenderPipeline for testing.
+func (p *RenderPipeline) SetTestBindGroupLayouts(layouts []*BindGroupLayout) {
+	p.bindGroupLayouts = layouts
+	p.bindGroupCount = uint32(len(layouts))
+}
+
+// SetTestBindGroupLayouts sets the bindGroupLayouts field on a ComputePipeline for testing.
+func (p *ComputePipeline) SetTestBindGroupLayouts(layouts []*BindGroupLayout) {
+	p.bindGroupLayouts = layouts
+	p.bindGroupCount = uint32(len(layouts))
+}
+
+// SetTestEntries sets the entries field on a BindGroupLayout for testing.
+func (l *BindGroupLayout) SetTestEntries(entries []gputypes.BindGroupLayoutEntry) {
+	l.entries = entries
+}
+
+// SetTestLayout sets the layout field on a BindGroup for testing.
+func (g *BindGroup) SetTestLayout(layout *BindGroupLayout) {
+	g.layout = layout
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.5.0
 	github.com/gogpu/gputypes v0.5.0
-	github.com/gogpu/naga v0.17.6
+	github.com/gogpu/naga v0.17.8
 	golang.org/x/sys v0.43.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.17.6 h1:Wh0MbP8wo9+eA1p8yKhDw8lvi+LykMzdJu4bGepstxg=
-github.com/gogpu/naga v0.17.6/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.17.8 h1:twxjkEMd4wL+ayIOb/U4jglQ37pHAcDv4sKAWbaXaQI=
+github.com/gogpu/naga v0.17.8/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/queue_native.go
+++ b/queue_native.go
@@ -49,6 +49,20 @@ func (q *Queue) Submit(commandBuffers ...*CommandBuffer) (uint64, error) {
 		}
 	}
 
+	// --- VAL-A6: Submit-time resource state validation ---
+	// Matches Rust wgpu-core validate_command_buffer (device/queue.rs:1764-1828).
+	// Each command buffer is checked for: valid state, buffer destroyed/mapped,
+	// texture destroyed.
+	for i, cb := range commandBuffers {
+		if cb == nil {
+			return 0, fmt.Errorf("wgpu: command buffer at index %d is nil", i)
+		}
+		if err := validateCommandBufferForSubmit(cb, i); err != nil {
+			return 0, err
+		}
+	}
+	// --- end VAL-A6 ---
+
 	// Build combined command buffer list: pending first, then user buffers.
 	var allBuffers []hal.CommandBuffer
 	if pendingCmdBuf != nil {
@@ -58,10 +72,7 @@ func (q *Queue) Submit(commandBuffers ...*CommandBuffer) (uint64, error) {
 		allBuffers = make([]hal.CommandBuffer, 0, len(commandBuffers))
 	}
 
-	for i, cb := range commandBuffers {
-		if cb == nil {
-			return 0, fmt.Errorf("wgpu: command buffer at index %d is nil", i)
-		}
+	for _, cb := range commandBuffers {
 		allBuffers = append(allBuffers, cb.halBuffer())
 	}
 
@@ -123,6 +134,13 @@ func (q *Queue) postSubmit(subIdx uint64, commandBuffers []*CommandBuffer) {
 		return
 	}
 
+	// Mark all command buffers as submitted to prevent double-submit (VAL-A6).
+	for _, cb := range commandBuffers {
+		if cb != nil {
+			cb.submitted = true
+		}
+	}
+
 	// Collect tracked refs from command buffers and associate with this submission.
 	// Phase 2: per-command-buffer resource tracking — refs are Drop'd when GPU completes.
 	var allRefs []*core.ResourceRef
@@ -182,10 +200,54 @@ func (q *Queue) Poll() uint64 {
 // directly via HAL without staging — GPU copy into upload heap is undefined
 // behavior on DX12 (upload heap is GENERIC_READ, read-only to GPU).
 // See BUG-DX12-003.
+//
+// Validation (VAL-A1, WebGPU spec §21.1):
+//   - Buffer must not be currently mapped
+//   - Buffer must have CopyDst usage
+//   - offset must be 4-byte aligned
+//   - data size must be 4-byte aligned
+//   - offset + data size must not exceed buffer size
+//
+// Matches Rust wgpu-core queue.rs:647-672 (validate_write_buffer_impl).
 func (q *Queue) WriteBuffer(buffer *Buffer, offset uint64, data []byte) error {
 	if q.hal == nil || buffer == nil {
 		return fmt.Errorf("wgpu: WriteBuffer: queue or buffer is nil")
 	}
+
+	// --- VAL-A1: bounds + state validation (before HAL access) ---
+
+	// 1. Buffer must not be mapped (write to mapped buffer = data race).
+	// Rust: !matches!(&*buffer.map_state.lock(), BufferMapState::Idle)
+	if buffer.MapState() != MapStateUnmapped {
+		return fmt.Errorf("wgpu: WriteBuffer: buffer is currently mapped")
+	}
+
+	// 2. Buffer must have COPY_DST usage.
+	// Rust: buffer.check_usage(wgt::BufferUsages::COPY_DST)
+	if buffer.Usage()&BufferUsageCopyDst == 0 {
+		return fmt.Errorf("wgpu: WriteBuffer: buffer missing CopyDst usage")
+	}
+
+	// 3. Offset must be 4-byte aligned (COPY_BUFFER_ALIGNMENT = 4).
+	// Rust: buffer_offset % wgt::COPY_BUFFER_ALIGNMENT != 0
+	if offset%4 != 0 {
+		return fmt.Errorf("wgpu: WriteBuffer: offset %d not 4-byte aligned", offset)
+	}
+
+	// 4. Data size must be 4-byte aligned.
+	// Rust: buffer_size.get() % wgt::COPY_BUFFER_ALIGNMENT != 0
+	dataSize := uint64(len(data))
+	if dataSize%4 != 0 {
+		return fmt.Errorf("wgpu: WriteBuffer: data size %d not 4-byte aligned", dataSize)
+	}
+
+	// 5. Write must not exceed buffer bounds.
+	// Rust: buffer_offset + buffer_size.get() > buffer.size
+	if offset+dataSize > buffer.Size() {
+		return fmt.Errorf("wgpu: WriteBuffer: offset %d + size %d exceeds buffer size %d", offset, dataSize, buffer.Size())
+	}
+
+	// --- end VAL-A1 ---
 
 	halBuffer := buffer.halBuffer()
 	if halBuffer == nil {
@@ -270,6 +332,52 @@ func (q *Queue) destroyQueue() *core.DestroyQueue {
 	if q.device != nil && q.device.core != nil {
 		return q.device.core.DestroyQueueRef()
 	}
+	return nil
+}
+
+// validateCommandBufferForSubmit checks that a command buffer and all its
+// referenced resources are in a valid state for submission.
+//
+// This is the Go equivalent of Rust wgpu-core's validate_command_buffer
+// (device/queue.rs:1764-1828). It checks:
+//   - Command buffer has not already been submitted (double-submit prevention)
+//   - All referenced buffers are not destroyed/released
+//   - All referenced buffers are not mapped (mapped buffer in GPU commands = data race)
+//   - All referenced textures are not destroyed/released
+//
+// The index parameter identifies which command buffer in the Submit() call
+// failed validation, for clearer error messages.
+func validateCommandBufferForSubmit(cb *CommandBuffer, index int) error {
+	// 1. Check double-submit.
+	if cb.submitted {
+		return fmt.Errorf("wgpu: Submit: command buffer at index %d: %w",
+			index, ErrSubmitCommandBufferInvalid)
+	}
+
+	// 2. Check referenced buffers (matches Rust queue.rs:1780-1787).
+	for buf := range cb.usedBuffers {
+		// Check destroyed/released.
+		if buf.released != nil && buf.released.Load() {
+			return fmt.Errorf("wgpu: Submit: command buffer at index %d references released buffer %q: %w",
+				index, buf.Label(), ErrSubmitBufferDestroyed)
+		}
+
+		// Check mapped state.
+		// Rust: BufferMapState::Idle is the only valid state for submit.
+		if buf.MapState() != MapStateUnmapped {
+			return fmt.Errorf("wgpu: Submit: command buffer at index %d references mapped buffer %q: %w",
+				index, buf.Label(), ErrSubmitBufferMapped)
+		}
+	}
+
+	// 3. Check referenced textures (matches Rust queue.rs:1791-1808).
+	for tex := range cb.usedTextures {
+		if tex.released {
+			return fmt.Errorf("wgpu: Submit: command buffer at index %d references released texture: %w",
+				index, ErrSubmitTextureDestroyed)
+		}
+	}
+
 	return nil
 }
 

--- a/queue_test.go
+++ b/queue_test.go
@@ -1,0 +1,346 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gogpu/wgpu"
+)
+
+// =============================================================================
+// VAL-A1: Queue.WriteBuffer bounds validation
+// WebGPU spec §21.1, Rust wgpu-core queue.rs:647-672
+// =============================================================================
+
+// TestWriteBufferValid verifies the happy path: a 4-byte-aligned write
+// within bounds to a CopyDst buffer succeeds.
+func TestWriteBufferValid(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a1-valid",
+		Size:  64,
+		Usage: wgpu.BufferUsageVertex | wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	data := make([]byte, 16)
+	if err := device.Queue().WriteBuffer(buf, 0, data); err != nil {
+		t.Fatalf("WriteBuffer should succeed: %v", err)
+	}
+}
+
+// TestWriteBufferValidWithOffset verifies a write at a non-zero aligned
+// offset within bounds succeeds.
+func TestWriteBufferValidWithOffset(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a1-offset",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	data := make([]byte, 8)
+	if err := device.Queue().WriteBuffer(buf, 32, data); err != nil {
+		t.Fatalf("WriteBuffer at offset 32 should succeed: %v", err)
+	}
+}
+
+// TestWriteBufferValidExactFit verifies a write that fills the buffer
+// exactly succeeds.
+func TestWriteBufferValidExactFit(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a1-exact",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	data := make([]byte, 64)
+	if err := device.Queue().WriteBuffer(buf, 0, data); err != nil {
+		t.Fatalf("WriteBuffer exact fit should succeed: %v", err)
+	}
+}
+
+// TestWriteBufferMissingCopyDst verifies that writing to a buffer
+// without CopyDst usage returns an error.
+func TestWriteBufferMissingCopyDst(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a1-no-copydst",
+		Size:  64,
+		Usage: wgpu.BufferUsageVertex, // no CopyDst
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	data := make([]byte, 4)
+	err = device.Queue().WriteBuffer(buf, 0, data)
+	if err == nil {
+		t.Fatal("WriteBuffer should fail: buffer missing CopyDst usage")
+	}
+	if !strings.Contains(err.Error(), "CopyDst") {
+		t.Errorf("error should mention CopyDst, got: %v", err)
+	}
+}
+
+// TestWriteBufferOffsetNotAligned verifies that a non-4-byte-aligned
+// offset is rejected.
+func TestWriteBufferOffsetNotAligned(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a1-offset-align",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	data := make([]byte, 4)
+	err = device.Queue().WriteBuffer(buf, 3, data)
+	if err == nil {
+		t.Fatal("WriteBuffer should fail: offset 3 not 4-byte aligned")
+	}
+	if !strings.Contains(err.Error(), "not 4-byte aligned") {
+		t.Errorf("error should mention alignment, got: %v", err)
+	}
+}
+
+// TestWriteBufferDataSizeNotAligned verifies that a data slice whose
+// length is not a multiple of 4 is rejected.
+func TestWriteBufferDataSizeNotAligned(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a1-data-align",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	data := make([]byte, 5) // 5 is not 4-byte aligned
+	err = device.Queue().WriteBuffer(buf, 0, data)
+	if err == nil {
+		t.Fatal("WriteBuffer should fail: data size 5 not 4-byte aligned")
+	}
+	if !strings.Contains(err.Error(), "data size") && !strings.Contains(err.Error(), "not 4-byte aligned") {
+		t.Errorf("error should mention data size alignment, got: %v", err)
+	}
+}
+
+// TestWriteBufferExceedsSize verifies that a write that overflows the
+// buffer bounds is rejected.
+func TestWriteBufferExceedsSize(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a1-overflow",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	data := make([]byte, 32)
+	err = device.Queue().WriteBuffer(buf, 48, data)
+	if err == nil {
+		t.Fatal("WriteBuffer should fail: offset 48 + size 32 > buffer size 64")
+	}
+	if !strings.Contains(err.Error(), "exceeds buffer size") {
+		t.Errorf("error should mention exceeds buffer size, got: %v", err)
+	}
+}
+
+// TestWriteBufferExceedsSizeExactBoundary verifies that writing exactly
+// past the last byte is rejected (offset == buffer.Size()).
+func TestWriteBufferExceedsSizeExactBoundary(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a1-boundary",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	data := make([]byte, 4)
+	err = device.Queue().WriteBuffer(buf, 64, data) // offset at end
+	if err == nil {
+		t.Fatal("WriteBuffer should fail: offset 64 + size 4 > buffer size 64")
+	}
+	if !strings.Contains(err.Error(), "exceeds buffer size") {
+		t.Errorf("error should mention exceeds buffer size, got: %v", err)
+	}
+}
+
+// TestWriteBufferMappedAtCreation verifies that writing to a buffer
+// that was created with MappedAtCreation=true is rejected.
+func TestWriteBufferMappedAtCreation(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "val-a1-mapped",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapRead | wgpu.BufferUsageCopyDst,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// Buffer is mapped at creation -- WriteBuffer must fail.
+	data := make([]byte, 4)
+	err = device.Queue().WriteBuffer(buf, 0, data)
+	if err == nil {
+		t.Fatal("WriteBuffer should fail: buffer is currently mapped")
+	}
+	if !strings.Contains(err.Error(), "mapped") {
+		t.Errorf("error should mention mapped, got: %v", err)
+	}
+}
+
+// TestWriteBufferNilBuffer verifies that passing a nil buffer returns
+// an error (pre-existing check, not VAL-A1, but guards the new code path).
+func TestWriteBufferNilBuffer(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	q := device.Queue()
+	if q == nil {
+		t.Skip("no queue")
+	}
+
+	data := make([]byte, 4)
+	err := q.WriteBuffer(nil, 0, data)
+	if err == nil {
+		t.Fatal("WriteBuffer(nil buffer) should fail")
+	}
+}
+
+// TestWriteBufferEmptyData verifies that writing an empty slice (len 0)
+// succeeds. Zero-size is 4-byte aligned (0 % 4 == 0) and 0 + 0 <= size.
+func TestWriteBufferEmptyData(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a1-empty",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// Empty write should pass all validation checks.
+	if err := device.Queue().WriteBuffer(buf, 0, nil); err != nil {
+		t.Fatalf("WriteBuffer with empty data should succeed: %v", err)
+	}
+}
+
+// TestWriteBufferTableDriven exercises multiple offset/size/alignment
+// combinations in a single table-driven test.
+func TestWriteBufferTableDriven(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a1-table",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	tests := []struct {
+		name    string
+		offset  uint64
+		size    int
+		wantErr string // substring expected in error, "" = no error
+	}{
+		{"offset=0 size=4", 0, 4, ""},
+		{"offset=4 size=4", 4, 4, ""},
+		{"offset=60 size=4", 60, 4, ""}, // exactly fills last 4 bytes
+		{"offset=0 size=64", 0, 64, ""}, // full buffer
+		{"offset=0 size=0", 0, 0, ""},   // empty write
+		{"offset=1 size=4", 1, 4, "not 4-byte aligned"},
+		{"offset=2 size=4", 2, 4, "not 4-byte aligned"},
+		{"offset=0 size=3", 0, 3, "not 4-byte aligned"},
+		{"offset=0 size=1", 0, 1, "not 4-byte aligned"},
+		{"offset=0 size=68", 0, 68, "exceeds buffer size"},
+		{"offset=64 size=4", 64, 4, "exceeds buffer size"},
+		{"offset=48 size=20", 48, 20, "exceeds buffer size"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := make([]byte, tt.size)
+			err := device.Queue().WriteBuffer(buf, tt.offset, data)
+			if tt.wantErr == "" { //nolint:nestif // table-driven test validation
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+				}
+			}
+		})
+	}
+}

--- a/renderpass_native.go
+++ b/renderpass_native.go
@@ -3,6 +3,7 @@
 package wgpu
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/gogpu/wgpu/core"
@@ -90,6 +91,13 @@ func (p *RenderPassEncoder) SetBindGroup(index uint32, group *BindGroup, offsets
 	p.binder.assign(index, group.layout)
 	p.binder.assignBindGroup(index, group)
 	p.trackRef(group.ref)
+	// Track bind group resources for submit-time validation (VAL-A6).
+	for _, buf := range group.boundBuffers {
+		p.encoder.trackBuffer(buf)
+	}
+	for _, tex := range group.boundTextures {
+		p.encoder.trackTexture(tex)
+	}
 	raw := p.core.RawPass()
 	if raw != nil && group.hal != nil {
 		raw.SetBindGroup(index, group.hal, offsets)
@@ -106,6 +114,7 @@ func (p *RenderPassEncoder) SetVertexBuffer(slot uint32, buffer *Buffer, offset 
 		p.vertexBufferCount = slot + 1
 	}
 	p.trackRef(buffer.core.Ref)
+	p.encoder.trackBuffer(buffer)
 	p.core.SetVertexBuffer(slot, buffer.coreBuffer(), offset)
 }
 
@@ -117,6 +126,7 @@ func (p *RenderPassEncoder) SetIndexBuffer(buffer *Buffer, format IndexFormat, o
 	}
 	p.indexBufferSet = true
 	p.trackRef(buffer.core.Ref)
+	p.encoder.trackBuffer(buffer)
 	p.core.SetIndexBuffer(buffer.coreBuffer(), format, offset)
 }
 
@@ -144,26 +154,39 @@ func (p *RenderPassEncoder) SetStencilReference(reference uint32) {
 // validateDrawState checks that a pipeline has been set, all bind groups
 // are compatible, and enough vertex buffers have been set before a draw call.
 // Returns true if validation passes, false if an error was recorded.
+//
+// Each validation failure wraps a typed sentinel error so that callers can
+// use errors.Is() to identify the failure category programmatically.
+// Matches Rust wgpu-core State::is_ready (command/render.rs:542-593).
 func (p *RenderPassEncoder) validateDrawState(method string) bool {
 	if !p.pipelineSet {
-		p.encoder.setError(fmt.Errorf("wgpu: RenderPass.%s: no pipeline set (call SetPipeline first)", method))
+		p.encoder.setError(fmt.Errorf("wgpu: RenderPass.%s: no pipeline set (call SetPipeline first): %w",
+			method, ErrDrawMissingPipeline))
 		return false
 	}
 	if err := p.binder.checkCompatibility(); err != nil {
-		p.encoder.setError(fmt.Errorf("wgpu: RenderPass.%s: %w", method, err))
+		// Wrap the binder error with the appropriate draw-time sentinel
+		// so errors.Is works for both the specific binder cause and the
+		// public draw-time category.
+		sentinel := ErrDrawMissingBindGroup
+		if errors.Is(err, errBindGroupIncompatible) {
+			sentinel = ErrDrawIncompatibleBindGroup
+		}
+		p.encoder.setError(fmt.Errorf("wgpu: RenderPass.%s: %w: %w", method, sentinel, err))
 		return false
 	}
 	if p.vertexBufferCount < p.requiredVertexBuffers {
 		p.encoder.setError(fmt.Errorf(
-			"wgpu: RenderPass.%s: pipeline requires %d vertex buffer(s) but only %d set",
+			"wgpu: RenderPass.%s: pipeline requires %d vertex buffer(s) but only %d set: %w",
 			method, p.requiredVertexBuffers, p.vertexBufferCount,
+			ErrDrawMissingVertexBuffer,
 		))
 		return false
 	}
 	if p.blendConstantRequired && !p.blendConstantSet {
 		p.encoder.setError(fmt.Errorf(
-			"wgpu: RenderPass.%s: blend constant needs to be set (pipeline uses BlendFactorConstant)",
-			method,
+			"wgpu: RenderPass.%s: %w",
+			method, ErrDrawMissingBlendConstant,
 		))
 		return false
 	}
@@ -171,7 +194,7 @@ func (p *RenderPassEncoder) validateDrawState(method string) bool {
 	// for bindings with MinBindingSize == 0. Matches Rust wgpu-core's is_ready()
 	// call to check_late_buffer_bindings before draw (render.rs:542-545).
 	if err := p.binder.checkLateBufferBindings(); err != nil {
-		p.encoder.setError(fmt.Errorf("wgpu: RenderPass.%s: %w", method, err))
+		p.encoder.setError(fmt.Errorf("wgpu: RenderPass.%s: %w: %w", method, ErrDrawLateBufferTooSmall, err))
 		return false
 	}
 	return true
@@ -191,7 +214,8 @@ func (p *RenderPassEncoder) DrawIndexed(indexCount, instanceCount, firstIndex ui
 		return
 	}
 	if !p.indexBufferSet {
-		p.encoder.setError(fmt.Errorf("wgpu: RenderPass.DrawIndexed: no index buffer set (call SetIndexBuffer first)"))
+		p.encoder.setError(fmt.Errorf("wgpu: RenderPass.DrawIndexed: no index buffer set (call SetIndexBuffer first): %w",
+			ErrDrawMissingIndexBuffer))
 		return
 	}
 	p.core.DrawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)
@@ -207,6 +231,7 @@ func (p *RenderPassEncoder) DrawIndirect(buffer *Buffer, offset uint64) {
 		return
 	}
 	p.trackRef(buffer.core.Ref)
+	p.encoder.trackBuffer(buffer)
 	p.core.DrawIndirect(buffer.coreBuffer(), offset)
 }
 
@@ -216,7 +241,8 @@ func (p *RenderPassEncoder) DrawIndexedIndirect(buffer *Buffer, offset uint64) {
 		return
 	}
 	if !p.indexBufferSet {
-		p.encoder.setError(fmt.Errorf("wgpu: RenderPass.DrawIndexedIndirect: no index buffer set (call SetIndexBuffer first)"))
+		p.encoder.setError(fmt.Errorf("wgpu: RenderPass.DrawIndexedIndirect: no index buffer set (call SetIndexBuffer first): %w",
+			ErrDrawMissingIndexBuffer))
 		return
 	}
 	if buffer == nil {
@@ -224,6 +250,7 @@ func (p *RenderPassEncoder) DrawIndexedIndirect(buffer *Buffer, offset uint64) {
 		return
 	}
 	p.trackRef(buffer.core.Ref)
+	p.encoder.trackBuffer(buffer)
 	p.core.DrawIndexedIndirect(buffer.coreBuffer(), offset)
 }
 

--- a/submit_validation_test.go
+++ b/submit_validation_test.go
@@ -1,0 +1,374 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gogpu/wgpu"
+)
+
+// =============================================================================
+// VAL-A6: Queue.Submit resource state validation
+// WebGPU spec §21.2, Rust wgpu-core device/queue.rs:1764-1828
+// =============================================================================
+
+// TestSubmitWithDestroyedBuffer verifies that submitting a command buffer that
+// references a released buffer returns ErrSubmitBufferDestroyed.
+// Matches Rust QueueSubmitError::DestroyedResource for buffers.
+func TestSubmitWithDestroyedBuffer(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	srcBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a6-destroyed-src",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer src: %v", err)
+	}
+
+	dstBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a6-destroyed-dst",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer dst: %v", err)
+	}
+	defer dstBuf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	// Use the buffer in a copy command to track it.
+	enc.CopyBufferToBuffer(srcBuf, 0, dstBuf, 0, 64)
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Release the source buffer AFTER encoding but BEFORE submit.
+	srcBuf.Release()
+
+	_, err = device.Queue().Submit(cmdBuf)
+	if err == nil {
+		t.Fatal("Submit should fail: command buffer references destroyed buffer")
+	}
+	if !errors.Is(err, wgpu.ErrSubmitBufferDestroyed) {
+		t.Errorf("expected ErrSubmitBufferDestroyed, got: %v", err)
+	}
+}
+
+// TestSubmitWithMappedBuffer verifies that submitting a command buffer that
+// references a mapped buffer returns ErrSubmitBufferMapped.
+// Matches Rust QueueSubmitError::BufferStillMapped.
+func TestSubmitWithMappedBuffer(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	mappedBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "val-a6-mapped-buf",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer mapped: %v", err)
+	}
+	defer mappedBuf.Release()
+
+	dstBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a6-mapped-dst",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer dst: %v", err)
+	}
+	defer dstBuf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	// Use the mapped buffer as copy source to track it.
+	enc.CopyBufferToBuffer(mappedBuf, 0, dstBuf, 0, 64)
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Buffer is still mapped (MappedAtCreation, never unmapped).
+	_, err = device.Queue().Submit(cmdBuf)
+	if err == nil {
+		t.Fatal("Submit should fail: command buffer references mapped buffer")
+	}
+	if !errors.Is(err, wgpu.ErrSubmitBufferMapped) {
+		t.Errorf("expected ErrSubmitBufferMapped, got: %v", err)
+	}
+}
+
+// TestSubmitWithDestroyedTexture verifies that submitting a command buffer that
+// references a released texture returns ErrSubmitTextureDestroyed.
+// Matches Rust QueueSubmitError::DestroyedResource for textures.
+func TestSubmitWithDestroyedTexture(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "val-a6-destroyed-tex",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageCopySrc | wgpu.TextureUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+
+	dstBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a6-dst-buf",
+		Size:  256,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer dstBuf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	// Use the texture in a copy command to track it.
+	enc.CopyTextureToBuffer(tex, dstBuf, []wgpu.BufferTextureCopy{
+		{
+			TextureBase: wgpu.ImageCopyTexture{
+				Texture: tex,
+				Origin:  wgpu.Origin3D{X: 0, Y: 0, Z: 0},
+			},
+			Size: wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+			BufferLayout: wgpu.ImageDataLayout{
+				Offset:       0,
+				BytesPerRow:  16,
+				RowsPerImage: 4,
+			},
+		},
+	})
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Release the texture AFTER encoding but BEFORE submit.
+	tex.Release()
+
+	_, err = device.Queue().Submit(cmdBuf)
+	if err == nil {
+		t.Fatal("Submit should fail: command buffer references destroyed texture")
+	}
+	if !errors.Is(err, wgpu.ErrSubmitTextureDestroyed) {
+		t.Errorf("expected ErrSubmitTextureDestroyed, got: %v", err)
+	}
+}
+
+// TestSubmitValidResources verifies that Submit succeeds when all referenced
+// resources are in valid state (not destroyed, not mapped).
+func TestSubmitValidResources(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	srcBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a6-valid-src",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer src: %v", err)
+	}
+	defer srcBuf.Release()
+
+	dstBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a6-valid-dst",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer dst: %v", err)
+	}
+	defer dstBuf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	enc.CopyBufferToBuffer(srcBuf, 0, dstBuf, 0, 64)
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// All resources valid — Submit should succeed.
+	_, err = device.Queue().Submit(cmdBuf)
+	if err != nil {
+		t.Fatalf("Submit should succeed: %v", err)
+	}
+}
+
+// TestSubmitDoubleSubmit verifies that submitting the same command buffer
+// twice returns ErrSubmitCommandBufferInvalid.
+// Matches Rust wgpu-core CommandBuffer::take_finished() which consumes
+// the buffer, preventing reuse.
+func TestSubmitDoubleSubmit(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	srcBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a6-double-src",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer src: %v", err)
+	}
+	defer srcBuf.Release()
+
+	dstBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a6-double-dst",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer dst: %v", err)
+	}
+	defer dstBuf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	enc.CopyBufferToBuffer(srcBuf, 0, dstBuf, 0, 64)
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// First submit — should succeed.
+	_, err = device.Queue().Submit(cmdBuf)
+	if err != nil {
+		t.Fatalf("first Submit should succeed: %v", err)
+	}
+
+	// Second submit — should fail.
+	_, err = device.Queue().Submit(cmdBuf)
+	if err == nil {
+		t.Fatal("second Submit should fail: command buffer already submitted")
+	}
+	if !errors.Is(err, wgpu.ErrSubmitCommandBufferInvalid) {
+		t.Errorf("expected ErrSubmitCommandBufferInvalid, got: %v", err)
+	}
+}
+
+// TestSubmitAfterBufferRelease verifies that releasing a buffer and then
+// submitting a command buffer that used it returns ErrSubmitBufferDestroyed.
+// This is the same as TestSubmitWithDestroyedBuffer but uses Release() which
+// is the public API for destruction.
+func TestSubmitAfterBufferRelease(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	srcBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a6-release-src",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer src: %v", err)
+	}
+
+	dstBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a6-release-dst",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer dst: %v", err)
+	}
+	defer dstBuf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	enc.CopyBufferToBuffer(srcBuf, 0, dstBuf, 0, 64)
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Release (not Destroy) — should still be caught.
+	srcBuf.Release()
+
+	_, err = device.Queue().Submit(cmdBuf)
+	if err == nil {
+		t.Fatal("Submit should fail: command buffer references released buffer")
+	}
+	if !errors.Is(err, wgpu.ErrSubmitBufferDestroyed) {
+		t.Errorf("expected ErrSubmitBufferDestroyed, got: %v", err)
+	}
+}
+
+// TestSubmitEmptyCommandBuffer verifies that submitting an empty command buffer
+// (no resources referenced) succeeds.
+func TestSubmitEmptyCommandBuffer(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// No resources — should succeed.
+	_, err = device.Queue().Submit(cmdBuf)
+	if err != nil {
+		t.Fatalf("Submit empty command buffer should succeed: %v", err)
+	}
+}
+
+// TestSubmitNoCommandBuffers verifies that submitting zero command buffers
+// succeeds (flushes pending writes only).
+func TestSubmitNoCommandBuffers(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	_, err := device.Queue().Submit()
+	if err != nil {
+		t.Fatalf("Submit() with no command buffers should succeed: %v", err)
+	}
+}

--- a/wgpu_test.go
+++ b/wgpu_test.go
@@ -2328,3 +2328,308 @@ func TestCreateComputePipelineWorkgroupSizeValid(t *testing.T) {
 	}
 	pipeline.Release()
 }
+
+// =============================================================================
+// VAL-A3: Draw-time sentinel errors — errors.Is() support
+// =============================================================================
+
+func TestDrawMissingPipelineSentinel(t *testing.T) {
+	device, encoder, pass := newEncoderWithRenderPass(t)
+	defer device.Release()
+
+	pass.Draw(3, 1, 0, 0) // no pipeline set
+	_ = pass.End()
+
+	_, err := encoder.Finish()
+	if err == nil {
+		t.Fatal("Finish() should return error when Draw called without SetPipeline")
+	}
+	if !errors.Is(err, wgpu.ErrDrawMissingPipeline) {
+		t.Errorf("error should match ErrDrawMissingPipeline via errors.Is, got: %v", err)
+	}
+}
+
+func TestDrawMissingBindGroupSentinel(t *testing.T) {
+	device, encoder, pass := newEncoderWithRenderPass(t)
+	defer device.Release()
+
+	// Pipeline with 1 bind group layout (index 0).
+	layout := &wgpu.BindGroupLayout{}
+	pipeline := &wgpu.RenderPipeline{}
+	pipeline.SetTestRequiredVertexBuffers(0)
+	pipeline.SetTestBindGroupLayouts([]*wgpu.BindGroupLayout{layout})
+	pass.SetPipeline(pipeline)
+
+	// No bind group at index 0.
+	pass.Draw(3, 1, 0, 0)
+	_ = pass.End()
+
+	_, err := encoder.Finish()
+	if err == nil {
+		t.Fatal("Finish() should return error when Draw called without required bind group")
+	}
+	if !errors.Is(err, wgpu.ErrDrawMissingBindGroup) {
+		t.Errorf("error should match ErrDrawMissingBindGroup via errors.Is, got: %v", err)
+	}
+}
+
+func TestDrawIncompatibleBindGroupSentinel(t *testing.T) {
+	device, encoder, pass := newEncoderWithRenderPass(t)
+	defer device.Release()
+
+	expectedLayout := &wgpu.BindGroupLayout{}
+	expectedLayout.SetTestEntries([]gputypes.BindGroupLayoutEntry{
+		{Binding: 0, Visibility: gputypes.ShaderStageVertex},
+	})
+	wrongLayout := &wgpu.BindGroupLayout{}
+	wrongLayout.SetTestEntries([]gputypes.BindGroupLayoutEntry{
+		{Binding: 0, Visibility: gputypes.ShaderStageFragment},
+	})
+
+	pipeline := &wgpu.RenderPipeline{}
+	pipeline.SetTestRequiredVertexBuffers(0)
+	pipeline.SetTestBindGroupLayouts([]*wgpu.BindGroupLayout{expectedLayout})
+	pass.SetPipeline(pipeline)
+
+	// Set a bind group with incompatible layout.
+	group := &wgpu.BindGroup{}
+	group.SetTestLayout(wrongLayout)
+	pass.SetBindGroup(0, group, nil)
+
+	pass.Draw(3, 1, 0, 0)
+	_ = pass.End()
+
+	_, err := encoder.Finish()
+	if err == nil {
+		t.Fatal("Finish() should return error when Draw called with incompatible bind group")
+	}
+	if !errors.Is(err, wgpu.ErrDrawIncompatibleBindGroup) {
+		t.Errorf("error should match ErrDrawIncompatibleBindGroup via errors.Is, got: %v", err)
+	}
+}
+
+func TestDrawMissingVertexBufferSentinel(t *testing.T) {
+	device, encoder, pass := newEncoderWithRenderPass(t)
+	defer device.Release()
+
+	pipeline := &wgpu.RenderPipeline{}
+	pipeline.SetTestRequiredVertexBuffers(2) // needs 2
+	pass.SetPipeline(pipeline)
+
+	// Set only 1 vertex buffer.
+	buf, bufErr := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "vb",
+		Size:  64,
+		Usage: wgpu.BufferUsageVertex,
+	})
+	if bufErr != nil {
+		t.Fatalf("CreateBuffer: %v", bufErr)
+	}
+	defer buf.Release()
+	pass.SetVertexBuffer(0, buf, 0)
+
+	pass.Draw(3, 1, 0, 0)
+	_ = pass.End()
+
+	_, err := encoder.Finish()
+	if err == nil {
+		t.Fatal("Finish() should return error when not enough vertex buffers are set")
+	}
+	if !errors.Is(err, wgpu.ErrDrawMissingVertexBuffer) {
+		t.Errorf("error should match ErrDrawMissingVertexBuffer via errors.Is, got: %v", err)
+	}
+}
+
+func TestDrawMissingIndexBufferSentinel(t *testing.T) {
+	device, encoder, pass := newEncoderWithRenderPass(t)
+	defer device.Release()
+
+	pipeline := &wgpu.RenderPipeline{}
+	pipeline.SetTestRequiredVertexBuffers(0)
+	pass.SetPipeline(pipeline)
+
+	pass.DrawIndexed(3, 1, 0, 0, 0) // no index buffer
+	_ = pass.End()
+
+	_, err := encoder.Finish()
+	if err == nil {
+		t.Fatal("Finish() should return error when DrawIndexed called without SetIndexBuffer")
+	}
+	if !errors.Is(err, wgpu.ErrDrawMissingIndexBuffer) {
+		t.Errorf("error should match ErrDrawMissingIndexBuffer via errors.Is, got: %v", err)
+	}
+}
+
+func TestDrawMissingIndexBufferIndirectSentinel(t *testing.T) {
+	device, encoder, pass := newEncoderWithRenderPass(t)
+	defer device.Release()
+
+	pipeline := &wgpu.RenderPipeline{}
+	pipeline.SetTestRequiredVertexBuffers(0)
+	pass.SetPipeline(pipeline)
+
+	buf, bufErr := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "indirect-buf",
+		Size:  20,
+		Usage: wgpu.BufferUsageIndirect,
+	})
+	if bufErr != nil {
+		t.Fatalf("CreateBuffer: %v", bufErr)
+	}
+	defer buf.Release()
+
+	pass.DrawIndexedIndirect(buf, 0) // no index buffer
+	_ = pass.End()
+
+	_, err := encoder.Finish()
+	if err == nil {
+		t.Fatal("Finish() should return error when DrawIndexedIndirect called without SetIndexBuffer")
+	}
+	if !errors.Is(err, wgpu.ErrDrawMissingIndexBuffer) {
+		t.Errorf("error should match ErrDrawMissingIndexBuffer via errors.Is, got: %v", err)
+	}
+}
+
+func TestDispatchMissingPipelineSentinel(t *testing.T) {
+	device, encoder, pass := newEncoderWithComputePass(t)
+	defer device.Release()
+
+	pass.Dispatch(1, 1, 1) // no pipeline set
+	_ = pass.End()
+
+	_, err := encoder.Finish()
+	if err == nil {
+		t.Fatal("Finish() should return error when Dispatch called without SetPipeline")
+	}
+	if !errors.Is(err, wgpu.ErrDispatchMissingPipeline) {
+		t.Errorf("error should match ErrDispatchMissingPipeline via errors.Is, got: %v", err)
+	}
+}
+
+func TestDispatchMissingBindGroupSentinel(t *testing.T) {
+	device, encoder, pass := newEncoderWithComputePass(t)
+	defer device.Release()
+
+	layout := &wgpu.BindGroupLayout{}
+	pipeline := &wgpu.ComputePipeline{}
+	pipeline.SetTestBindGroupLayouts([]*wgpu.BindGroupLayout{layout})
+	pass.SetPipeline(pipeline)
+
+	// No bind group at index 0.
+	pass.Dispatch(1, 1, 1)
+	_ = pass.End()
+
+	_, err := encoder.Finish()
+	if err == nil {
+		t.Fatal("Finish() should return error when Dispatch called without required bind group")
+	}
+	if !errors.Is(err, wgpu.ErrDispatchMissingBindGroup) {
+		t.Errorf("error should match ErrDispatchMissingBindGroup via errors.Is, got: %v", err)
+	}
+}
+
+func TestDispatchIncompatibleBindGroupSentinel(t *testing.T) {
+	device, encoder, pass := newEncoderWithComputePass(t)
+	defer device.Release()
+
+	expectedLayout := &wgpu.BindGroupLayout{}
+	expectedLayout.SetTestEntries([]gputypes.BindGroupLayoutEntry{
+		{Binding: 0, Visibility: gputypes.ShaderStageCompute},
+	})
+	wrongLayout := &wgpu.BindGroupLayout{}
+	wrongLayout.SetTestEntries([]gputypes.BindGroupLayoutEntry{
+		{Binding: 0, Visibility: gputypes.ShaderStageFragment},
+	})
+
+	pipeline := &wgpu.ComputePipeline{}
+	pipeline.SetTestBindGroupLayouts([]*wgpu.BindGroupLayout{expectedLayout})
+	pass.SetPipeline(pipeline)
+
+	group := &wgpu.BindGroup{}
+	group.SetTestLayout(wrongLayout)
+	pass.SetBindGroup(0, group, nil)
+
+	pass.Dispatch(1, 1, 1)
+	_ = pass.End()
+
+	_, err := encoder.Finish()
+	if err == nil {
+		t.Fatal("Finish() should return error when Dispatch called with incompatible bind group")
+	}
+	if !errors.Is(err, wgpu.ErrDispatchIncompatibleBindGroup) {
+		t.Errorf("error should match ErrDispatchIncompatibleBindGroup via errors.Is, got: %v", err)
+	}
+}
+
+func TestDispatchWorkgroupCountSentinel(t *testing.T) {
+	device, encoder, pass := newEncoderWithComputePass(t)
+	defer device.Release()
+
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "sentinel-shader",
+		WGSL:  "@compute @workgroup_size(1) fn main() {}",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer shader.Release()
+
+	pipeline, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Label:      "sentinel-pipeline",
+		Module:     shader,
+		EntryPoint: "main",
+	})
+	if err != nil {
+		t.Skipf("CreateComputePipeline not supported: %v", err)
+	}
+	defer pipeline.Release()
+
+	pass.SetPipeline(pipeline)
+	pass.Dispatch(100000, 1, 1) // exceeds default limit 65535
+	_ = pass.End()
+
+	_, err = encoder.Finish()
+	if err == nil {
+		t.Fatal("Finish() should return error when dispatch workgroup count exceeds limit")
+	}
+	if !errors.Is(err, wgpu.ErrDispatchWorkgroupCountExceeded) {
+		t.Errorf("error should match ErrDispatchWorkgroupCountExceeded via errors.Is, got: %v", err)
+	}
+}
+
+// TestDrawSentinelErrorsAreDistinct verifies that all draw/dispatch sentinel
+// errors are distinct values (not accidentally aliased).
+func TestDrawSentinelErrorsAreDistinct(t *testing.T) {
+	sentinels := []struct {
+		name string
+		err  error
+	}{
+		{"ErrDrawMissingPipeline", wgpu.ErrDrawMissingPipeline},
+		{"ErrDrawMissingBindGroup", wgpu.ErrDrawMissingBindGroup},
+		{"ErrDrawIncompatibleBindGroup", wgpu.ErrDrawIncompatibleBindGroup},
+		{"ErrDrawMissingVertexBuffer", wgpu.ErrDrawMissingVertexBuffer},
+		{"ErrDrawMissingIndexBuffer", wgpu.ErrDrawMissingIndexBuffer},
+		{"ErrDrawMissingBlendConstant", wgpu.ErrDrawMissingBlendConstant},
+		{"ErrDrawLateBufferTooSmall", wgpu.ErrDrawLateBufferTooSmall},
+		{"ErrDispatchMissingPipeline", wgpu.ErrDispatchMissingPipeline},
+		{"ErrDispatchMissingBindGroup", wgpu.ErrDispatchMissingBindGroup},
+		{"ErrDispatchIncompatibleBindGroup", wgpu.ErrDispatchIncompatibleBindGroup},
+		{"ErrDispatchLateBufferTooSmall", wgpu.ErrDispatchLateBufferTooSmall},
+		{"ErrDispatchWorkgroupCountExceeded", wgpu.ErrDispatchWorkgroupCountExceeded},
+	}
+
+	for i, a := range sentinels {
+		if a.err == nil {
+			t.Errorf("%s is nil", a.name)
+			continue
+		}
+		if a.err.Error() == "" {
+			t.Errorf("%s has empty error message", a.name)
+		}
+		for j, b := range sentinels {
+			if i != j && errors.Is(a.err, b.err) {
+				t.Errorf("%s and %s should be distinct errors", a.name, b.name)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

**WebGPU validation Phase A — crash prevention.** 18 P0 checks matching Rust wgpu-core, preventing GPU crashes from invalid API usage. Coverage: 22% → 37%.

- **VAL-A1:** Queue.WriteBuffer bounds (mapped, COPY_DST, alignment, bounds)
- **VAL-A2:** CreateBindGroup buffer validation (usage, offset alignment, size limits, bounds)
- **VAL-A3:** Draw-time typed sentinel errors — 12 sentinels with `errors.Is()`, error chain through `Finish()`
- **VAL-A4:** CreatePipelineLayout bind group count limit
- **VAL-A5:** Format type guards (color vs depth/stencil)
- **VAL-A6:** Queue.Submit resource state (destroyed/mapped buffers, destroyed textures, double-submit)
- **naga** v0.17.6 → v0.17.8

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] `gofmt -l .` — clean
- [ ] CI