### PR TITLE
v0.26.11: DX12 indirect dispatch/draw (BUG-DX12-012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.11] - 2026-04-30
+
+### Fixed
+
+- **DX12: DispatchIndirect, DrawIndirect, DrawIndexedIndirect** (BUG-DX12-012) — all three
+  were no-op stubs. Implemented via `ID3D12GraphicsCommandList::ExecuteIndirect` with
+  pre-created `ID3D12CommandSignature` objects (Rust wgpu-hal pattern). Three command
+  signatures created at device init: dispatch (12B stride), draw (16B), draw indexed (20B).
+  DX12 was the only GPU backend with stub indirect methods — now all 4 GPU backends
+  (Vulkan, Metal, GLES, DX12) have full indirect dispatch/draw support.
+
 ## [0.26.10] - 2026-04-30
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,6 +143,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.26.11** | 2026-04 | **DX12 indirect dispatch/draw** — ExecuteIndirect + CommandSignature (was last GPU backend with stubs) |
 | **v0.26.10** | 2026-04 | **Validation Phase B** — 5 P1 correctness checks (MinBindingSize, index format mismatch, indirect bounds, depth/stencil aspects, BindGroup Submit). Coverage 37% → 45%. |
 | **v0.26.9** | 2026-04 | **Validation Phase A** — 18 P0 crash prevention checks (WriteBuffer bounds, BindGroup buffer, draw-time state, PipelineLayout, format guards, Submit resource state). Coverage 22% → 37%. |
 | **v0.25.6** | 2026-04 | Vulkan command buffer free list (VK-CMD-001): batch alloc, pool reset, enterprise parity |

--- a/docs/COMPUTE-BACKENDS.md
+++ b/docs/COMPUTE-BACKENDS.md
@@ -40,6 +40,7 @@ Vulkan provides the most complete compute shader implementation:
 - **Shader compilation:** WGSL -> HLSL -> DXBC via FXC (default), or WGSL -> DXIL direct via `gogpu/naga/dxil` (`GOGPU_DX12_DXIL=1`, SM 6.0+, no external dependencies).
 - **Timestamp queries:** `CreateQuerySet` currently returns `ErrTimestampsNotSupported`. The underlying D3D12 API supports timestamp queries via `ID3D12Device::CreateQueryHeap` with `D3D12_QUERY_TYPE_TIMESTAMP` and `ID3D12GraphicsCommandList::EndQuery` + `ResolveQueryData`. Implementation is planned.
 - **Workgroup size limits:** Maximum 1024 invocations per workgroup (D3D12 spec).
+- **Indirect dispatch:** `DispatchIndirect` via `ExecuteIndirect` with pre-created `ID3D12CommandSignature` (dispatch args: 3 × uint32 = 12 bytes). Also supports `DrawIndirect` (16B) and `DrawIndexedIndirect` (20B).
 - **Root signature:** Compute pipelines use a separate root signature from graphics pipelines. Descriptor heaps are bound lazily on first `SetBindGroup` call.
 
 ### DX12-Specific Notes

--- a/hal/dx12/command.go
+++ b/hal/dx12/command.go
@@ -809,29 +809,33 @@ func (e *RenderPassEncoder) DrawIndexed(indexCount, instanceCount, firstIndex ui
 }
 
 // DrawIndirect draws primitives with GPU-generated parameters.
+// The buffer must contain a D3D12_DRAW_ARGUMENTS struct at the given offset
+// (vertexCountPerInstance, instanceCount, startVertexLocation, startInstanceLocation — 16 bytes).
 func (e *RenderPassEncoder) DrawIndirect(buffer hal.Buffer, offset uint64) {
 	buf, ok := buffer.(*Buffer)
 	if !ok || !e.encoder.isRecording {
 		return
 	}
 
-	// Note: ExecuteIndirect requires a pre-created ID3D12CommandSignature.
-	// For now, this is a stub
-	_ = buf
-	_ = offset
+	e.encoder.cmdList.ExecuteIndirect(
+		e.encoder.device.cmdSignatures.draw,
+		1, buf.raw, offset, nil, 0,
+	)
 }
 
 // DrawIndexedIndirect draws indexed primitives with GPU-generated parameters.
+// The buffer must contain a D3D12_DRAW_INDEXED_ARGUMENTS struct at the given offset
+// (indexCountPerInstance, instanceCount, startIndexLocation, baseVertexLocation, startInstanceLocation — 20 bytes).
 func (e *RenderPassEncoder) DrawIndexedIndirect(buffer hal.Buffer, offset uint64) {
 	buf, ok := buffer.(*Buffer)
 	if !ok || !e.encoder.isRecording {
 		return
 	}
 
-	// Note: ExecuteIndirect requires a pre-created ID3D12CommandSignature.
-	// For now, this is a stub
-	_ = buf
-	_ = offset
+	e.encoder.cmdList.ExecuteIndirect(
+		e.encoder.device.cmdSignatures.drawIndexed,
+		1, buf.raw, offset, nil, 0,
+	)
 }
 
 // ExecuteBundle executes a pre-recorded render bundle.
@@ -945,16 +949,27 @@ func (e *ComputePassEncoder) Dispatch(x, y, z uint32) {
 }
 
 // DispatchIndirect dispatches compute work with GPU-generated parameters.
+// The buffer must contain a D3D12_DISPATCH_ARGUMENTS struct at the given offset
+// (threadGroupCountX, threadGroupCountY, threadGroupCountZ — 12 bytes).
 func (e *ComputePassEncoder) DispatchIndirect(buffer hal.Buffer, offset uint64) {
 	buf, ok := buffer.(*Buffer)
 	if !ok || !e.encoder.isRecording {
 		return
 	}
 
-	// Note: ExecuteIndirect requires a pre-created ID3D12CommandSignature.
-	// For now, this is a stub
-	_ = buf
-	_ = offset
+	e.encoder.cmdList.ExecuteIndirect(
+		e.encoder.device.cmdSignatures.dispatch,
+		1, buf.raw, offset, nil, 0,
+	)
+	e.insertUAVBarrier()
+
+	// Mark bound storage buffers as UNORDERED_ACCESS, matching Dispatch() pattern.
+	// After an indirect dispatch, storage buffers are left in UAV state for correct
+	// transition barriers on subsequent commands.
+	for _, b := range e.boundStorageBuffers {
+		b.currentState = d3d12.D3D12_RESOURCE_STATE_UNORDERED_ACCESS
+	}
+	e.boundStorageBuffers = e.boundStorageBuffers[:0]
 }
 
 // insertUAVBarrier inserts a global UAV barrier after a dispatch.

--- a/hal/dx12/d3d12/device.go
+++ b/hal/dx12/d3d12/device.go
@@ -1052,6 +1052,31 @@ func (c *ID3D12GraphicsCommandList) CopyTextureRegion(dst *D3D12_TEXTURE_COPY_LO
 	)
 }
 
+// ExecuteIndirect executes a command signature (indirect draw/dispatch).
+// countBuffer may be nil for single-command execution.
+// On amd64, uintptr is 64 bits so uint64 values pass through without splitting.
+func (c *ID3D12GraphicsCommandList) ExecuteIndirect(
+	commandSignature *ID3D12CommandSignature,
+	maxCommandCount uint32,
+	argumentBuffer *ID3D12Resource,
+	argumentBufferOffset uint64,
+	countBuffer *ID3D12Resource,
+	countBufferOffset uint64,
+) {
+	_, _, _ = syscall.Syscall9(
+		c.vtbl.ExecuteIndirect,
+		7,
+		uintptr(unsafe.Pointer(c)),
+		uintptr(unsafe.Pointer(commandSignature)),
+		uintptr(maxCommandCount),
+		uintptr(unsafe.Pointer(argumentBuffer)),
+		uintptr(argumentBufferOffset),
+		uintptr(unsafe.Pointer(countBuffer)),
+		uintptr(countBufferOffset),
+		0, 0,
+	)
+}
+
 // -----------------------------------------------------------------------------
 // ID3D12Fence methods
 // -----------------------------------------------------------------------------

--- a/hal/dx12/device.go
+++ b/hal/dx12/device.go
@@ -108,6 +108,22 @@ type Device struct {
 	// the wgpu log instead of being folded into E_INVALIDARG by D3D12
 	// pipeline creation. Opt-in via GOGPU_DX12_DXIL_VALIDATE=1.
 	dxilValidate bool
+
+	// Pre-created command signatures for indirect draw/dispatch.
+	// DX12 ExecuteIndirect requires an ID3D12CommandSignature that describes
+	// the indirect argument layout. These are created once at device init
+	// and shared across all encoders.
+	// Matches Rust wgpu-hal DeviceShared.cmd_signatures (dx12/mod.rs:683).
+	cmdSignatures commandSignatures
+}
+
+// commandSignatures holds pre-created ID3D12CommandSignature objects for
+// indirect draw and dispatch operations. Created once at device initialization.
+// Matches Rust wgpu-hal CommandSignatures (dx12/mod.rs:673-678).
+type commandSignatures struct {
+	draw        *d3d12.ID3D12CommandSignature
+	drawIndexed *d3d12.ID3D12CommandSignature
+	dispatch    *d3d12.ID3D12CommandSignature
 }
 
 // DescriptorHeap wraps a D3D12 descriptor heap with allocation tracking.
@@ -255,6 +271,15 @@ func newDevice(instance *Instance, adapterPtr unsafe.Pointer, featureLevel d3d12
 	// DXIL path uses naga dxil backend (SM 6.0, BYPASS hash) instead of HLSL->FXC.
 	dev.useDXIL = os.Getenv("GOGPU_DX12_DXIL") == "1"
 	dev.dxilValidate = os.Getenv("GOGPU_DX12_DXIL_VALIDATE") == "1"
+
+	// Create pre-built command signatures for indirect draw/dispatch.
+	// DX12 ExecuteIndirect requires an ID3D12CommandSignature that describes
+	// the indirect argument layout. Created once, shared across all encoders.
+	// Matches Rust wgpu-hal device init (dx12/device.rs:142-174).
+	if err := dev.createCommandSignatures(); err != nil {
+		dev.cleanup()
+		return nil, err
+	}
 
 	// Set a finalizer to ensure cleanup
 	runtime.SetFinalizer(dev, (*Device).Destroy)
@@ -419,6 +444,60 @@ func (d *Device) createFence() error {
 	d.fenceEvent = event
 	d.fenceValue = 0
 	return nil
+}
+
+// createCommandSignatures creates the three pre-built command signatures required
+// by ID3D12GraphicsCommandList::ExecuteIndirect for indirect draw/dispatch.
+// Each signature describes one indirect argument type with its byte stride:
+//   - dispatch:    D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH    (12 bytes: x, y, z uint32)
+//   - draw:        D3D12_INDIRECT_ARGUMENT_TYPE_DRAW        (16 bytes: vertexCount, instanceCount, firstVertex, firstInstance)
+//   - drawIndexed: D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED (20 bytes: indexCount, instanceCount, firstIndex, baseVertex, firstInstance)
+//
+// Matches Rust wgpu-hal DeviceShared initialization (dx12/device.rs:142-174).
+func (d *Device) createCommandSignatures() error {
+	var err error
+
+	// Dispatch: 3 x uint32 = 12 bytes (x, y, z thread group counts).
+	d.cmdSignatures.dispatch, err = d.createCommandSignature(
+		d3d12.D3D12_INDIRECT_ARGUMENT_TYPE_DISPATCH, 12,
+	)
+	if err != nil {
+		return fmt.Errorf("dx12: failed to create dispatch command signature: %w", err)
+	}
+
+	// Draw: 4 x uint32 = 16 bytes (vertexCount, instanceCount, firstVertex, firstInstance).
+	d.cmdSignatures.draw, err = d.createCommandSignature(
+		d3d12.D3D12_INDIRECT_ARGUMENT_TYPE_DRAW, 16,
+	)
+	if err != nil {
+		return fmt.Errorf("dx12: failed to create draw command signature: %w", err)
+	}
+
+	// DrawIndexed: 5 x uint32 = 20 bytes (indexCount, instanceCount, firstIndex, baseVertex, firstInstance).
+	d.cmdSignatures.drawIndexed, err = d.createCommandSignature(
+		d3d12.D3D12_INDIRECT_ARGUMENT_TYPE_DRAW_INDEXED, 20,
+	)
+	if err != nil {
+		return fmt.Errorf("dx12: failed to create draw indexed command signature: %w", err)
+	}
+
+	return nil
+}
+
+// createCommandSignature creates a single ID3D12CommandSignature for the given
+// indirect argument type and byte stride. Uses pRootSignature=nil since these
+// are simple single-argument signatures with no root parameter changes.
+func (d *Device) createCommandSignature(argType d3d12.D3D12_INDIRECT_ARGUMENT_TYPE, byteStride uint32) (*d3d12.ID3D12CommandSignature, error) {
+	argDesc := d3d12.D3D12_INDIRECT_ARGUMENT_DESC{
+		Type: argType,
+	}
+	desc := d3d12.D3D12_COMMAND_SIGNATURE_DESC{
+		ByteStride:       byteStride,
+		NumArgumentDescs: 1,
+		ArgumentDescs:    &argDesc,
+		NodeMask:         0,
+	}
+	return d.raw.CreateCommandSignature(&desc, nil)
 }
 
 // waitForGPU blocks until all GPU work completes.
@@ -810,6 +889,20 @@ func (d *Device) cleanup() {
 	if d.emptyRootSignature != nil {
 		d.emptyRootSignature.Release()
 		d.emptyRootSignature = nil
+	}
+
+	// Release indirect command signatures.
+	if d.cmdSignatures.dispatch != nil {
+		d.cmdSignatures.dispatch.Release()
+		d.cmdSignatures.dispatch = nil
+	}
+	if d.cmdSignatures.draw != nil {
+		d.cmdSignatures.draw.Release()
+		d.cmdSignatures.draw = nil
+	}
+	if d.cmdSignatures.drawIndexed != nil {
+		d.cmdSignatures.drawIndexed.Release()
+		d.cmdSignatures.drawIndexed = nil
 	}
 
 	if d.fenceEvent != 0 {


### PR DESCRIPTION
## Summary

- **DX12: DispatchIndirect, DrawIndirect, DrawIndexedIndirect** — all three were no-op stubs, now implemented via `ExecuteIndirect` with pre-created `ID3D12CommandSignature` objects (Rust wgpu-hal pattern)
- DX12 was the last GPU backend with stub indirect methods — all 4 GPU backends now have full support
- Three command signatures at device init: dispatch (12B), draw (16B), draw indexed (20B)

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] `gofmt -l .` — clean
- [x] Validated against Rust wgpu-hal `dx12/device.rs:142-174`, `dx12/command.rs:1599-1630`
- [ ] CI