### PR TITLE
v0.26.12: core/ test coverage 73.9% → 85.5% (COV-004)

### DIFF
--- a/core/buffer_mapping_test.go
+++ b/core/buffer_mapping_test.go
@@ -1,0 +1,605 @@
+//go:build !(js && wasm)
+
+package core
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gogpu/gputypes"
+)
+
+// =============================================================================
+// BufferMapError
+// =============================================================================
+
+func TestBufferMapError_AllKinds(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     *BufferMapError
+		wantSub string
+	}{
+		{
+			name:    "AlreadyPending",
+			err:     &BufferMapError{Kind: BufferMapErrKindAlreadyPending},
+			wantSub: "already pending",
+		},
+		{
+			name:    "AlreadyMapped",
+			err:     &BufferMapError{Kind: BufferMapErrKindAlreadyMapped},
+			wantSub: "already mapped",
+		},
+		{
+			name:    "NotMapped",
+			err:     &BufferMapError{Kind: BufferMapErrKindNotMapped},
+			wantSub: "not mapped",
+		},
+		{
+			name:    "Alignment",
+			err:     &BufferMapError{Kind: BufferMapErrKindAlignment},
+			wantSub: "not aligned",
+		},
+		{
+			name:    "InvalidMode",
+			err:     &BufferMapError{Kind: BufferMapErrKindInvalidMode},
+			wantSub: "MAP_READ/MAP_WRITE",
+		},
+		{
+			name:    "RangeOverflow",
+			err:     &BufferMapError{Kind: BufferMapErrKindRangeOverflow},
+			wantSub: "exceeds buffer size",
+		},
+		{
+			name:    "Canceled",
+			err:     &BufferMapError{Kind: BufferMapErrKindCancelled},
+			wantSub: "canceled",
+		},
+		{
+			name:    "Destroyed",
+			err:     &BufferMapError{Kind: BufferMapErrKindDestroyed},
+			wantSub: "destroyed",
+		},
+		{
+			name:    "DeviceLost",
+			err:     &BufferMapError{Kind: BufferMapErrKindDeviceLost},
+			wantSub: "device lost",
+		},
+		{
+			name:    "RangeOverlap",
+			err:     &BufferMapError{Kind: BufferMapErrKindRangeOverlap},
+			wantSub: "overlaps",
+		},
+		{
+			name:    "RangeDetached",
+			err:     &BufferMapError{Kind: BufferMapErrKindRangeDetached},
+			wantSub: "detached",
+		},
+		{
+			name:    "HAL",
+			err:     &BufferMapError{Kind: BufferMapErrKindHAL},
+			wantSub: "HAL error",
+		},
+		{
+			name:    "Unknown",
+			err:     &BufferMapError{Kind: BufferMapErrorKind(255)},
+			wantSub: "unknown error",
+		},
+		{
+			name:    "NilReceiver",
+			err:     nil,
+			wantSub: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if tt.wantSub == "" {
+				if msg != "" {
+					t.Errorf("Error() = %q, want empty", msg)
+				}
+				return
+			}
+			if !strings.Contains(msg, tt.wantSub) {
+				t.Errorf("Error() = %q, want substring %q", msg, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestBufferMapError_WithWrapped(t *testing.T) {
+	inner := errors.New("underlying HAL failure")
+	e := &BufferMapError{Kind: BufferMapErrKindHAL, Wrapped: inner}
+
+	msg := e.Error()
+	if !strings.Contains(msg, "underlying HAL failure") {
+		t.Errorf("Error() = %q, want wrapped message", msg)
+	}
+
+	if !errors.Is(e.Unwrap(), inner) {
+		t.Error("Unwrap() did not return wrapped error")
+	}
+}
+
+func TestBufferMapError_UnwrapNil(t *testing.T) {
+	e := &BufferMapError{Kind: BufferMapErrKindCancelled}
+	if e.Unwrap() != nil {
+		t.Error("Unwrap() should return nil when no wrapped error")
+	}
+}
+
+// =============================================================================
+// MapWaiter
+// =============================================================================
+
+func TestMapWaiter_SignalThenWait(t *testing.T) {
+	w := newMapWaiter()
+
+	// Signal success before Wait.
+	w.Signal(nil)
+
+	err := w.Wait()
+	if err != nil {
+		t.Errorf("Wait() returned error after successful signal: %v", err)
+	}
+
+	done, errStatus := w.Status()
+	if !done {
+		t.Error("Status() should report done after Signal")
+	}
+	if errStatus != nil {
+		t.Errorf("Status() error = %v, want nil", errStatus)
+	}
+}
+
+func TestMapWaiter_SignalErrorThenWait(t *testing.T) {
+	w := newMapWaiter()
+
+	mapErr := &BufferMapError{Kind: BufferMapErrKindDestroyed}
+	w.Signal(mapErr)
+
+	err := w.Wait()
+	if err == nil {
+		t.Fatal("Wait() should return error")
+	}
+	if err.Kind != BufferMapErrKindDestroyed {
+		t.Errorf("Wait() error Kind = %v, want Destroyed", err.Kind)
+	}
+}
+
+func TestMapWaiter_ConcurrentWait(t *testing.T) {
+	w := newMapWaiter()
+
+	var wg sync.WaitGroup
+	errs := make([]*BufferMapError, 5)
+
+	// Launch 5 goroutines all waiting.
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = w.Wait()
+		}(i)
+	}
+
+	// Give goroutines time to start waiting.
+	time.Sleep(10 * time.Millisecond)
+
+	// Signal -- all should wake up.
+	w.Signal(nil)
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Errorf("goroutine %d got error: %v", i, err)
+		}
+	}
+}
+
+func TestMapWaiter_Reset(t *testing.T) {
+	w := newMapWaiter()
+
+	// First cycle: signal then confirm done.
+	w.Signal(nil)
+	done, _ := w.Status()
+	if !done {
+		t.Fatal("should be done after Signal")
+	}
+
+	// Reset should clear the done state.
+	w.Reset()
+	done, _ = w.Status()
+	if done {
+		t.Error("should not be done after Reset")
+	}
+
+	// Second cycle: signal again.
+	mapErr := &BufferMapError{Kind: BufferMapErrKindCancelled}
+	w.Signal(mapErr)
+
+	err := w.Wait()
+	if err == nil || err.Kind != BufferMapErrKindCancelled {
+		t.Errorf("second cycle Wait() = %v, want Canceled", err)
+	}
+}
+
+// =============================================================================
+// BeginMap state machine
+// =============================================================================
+
+func newTestBuffer(usage gputypes.BufferUsage, size uint64) *Buffer {
+	return &Buffer{
+		usage:       usage,
+		size:        size,
+		mapState:    BufferMapStateIdle,
+		mapDataSlot: &mapDataSlot{},
+	}
+}
+
+func TestBeginMap_Success(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+
+	err := buf.BeginMap(MapModeInternalRead, 0, 1024)
+	if err != nil {
+		t.Fatalf("BeginMap() returned error: %v", err)
+	}
+	if buf.CurrentMapState() != BufferMapStatePending {
+		t.Errorf("state = %v, want Pending", buf.CurrentMapState())
+	}
+}
+
+func TestBeginMap_Destroyed(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	buf.mapState = BufferMapStateDestroyed
+
+	err := buf.BeginMap(MapModeInternalRead, 0, 1024)
+	if err == nil || err.Kind != BufferMapErrKindDestroyed {
+		t.Errorf("BeginMap() on destroyed buffer = %v, want Destroyed", err)
+	}
+}
+
+func TestBeginMap_AlreadyPending(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	buf.mapState = BufferMapStatePending
+
+	err := buf.BeginMap(MapModeInternalRead, 0, 1024)
+	if err == nil || err.Kind != BufferMapErrKindAlreadyPending {
+		t.Errorf("BeginMap() on pending buffer = %v, want AlreadyPending", err)
+	}
+}
+
+func TestBeginMap_AlreadyMapped(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	buf.mapState = BufferMapStateMapped
+
+	err := buf.BeginMap(MapModeInternalRead, 0, 1024)
+	if err == nil || err.Kind != BufferMapErrKindAlreadyMapped {
+		t.Errorf("BeginMap() on mapped buffer = %v, want AlreadyMapped", err)
+	}
+}
+
+func TestBeginMap_AlignmentErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		offset uint64
+		size   uint64
+	}{
+		{"offset not 8-aligned", 7, 4},
+		{"size not 4-aligned", 0, 5},
+		{"both misaligned", 3, 7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+			err := buf.BeginMap(MapModeInternalRead, tt.offset, tt.size)
+			if err == nil || err.Kind != BufferMapErrKindAlignment {
+				t.Errorf("BeginMap(%d, %d) = %v, want Alignment", tt.offset, tt.size, err)
+			}
+		})
+	}
+}
+
+func TestBeginMap_RangeOverflow(t *testing.T) {
+	tests := []struct {
+		name   string
+		offset uint64
+		size   uint64
+	}{
+		{"offset > buffer size", 2048, 8},
+		{"size > buffer size", 0, 2048},
+		{"offset+size > buffer size", 512, 1024},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+			err := buf.BeginMap(MapModeInternalRead, tt.offset, tt.size)
+			if err == nil || err.Kind != BufferMapErrKindRangeOverflow {
+				t.Errorf("BeginMap(%d, %d) = %v, want RangeOverflow", tt.offset, tt.size, err)
+			}
+		})
+	}
+}
+
+func TestBeginMap_InvalidMode(t *testing.T) {
+	tests := []struct {
+		name  string
+		usage gputypes.BufferUsage
+		mode  MapModeInternal
+	}{
+		{"read without MAP_READ", gputypes.BufferUsageMapWrite, MapModeInternalRead},
+		{"write without MAP_WRITE", gputypes.BufferUsageMapRead, MapModeInternalWrite},
+		{"zero mode", gputypes.BufferUsageMapRead, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf := newTestBuffer(tt.usage, 1024)
+			err := buf.BeginMap(tt.mode, 0, 1024)
+			if err == nil || err.Kind != BufferMapErrKindInvalidMode {
+				t.Errorf("BeginMap() = %v, want InvalidMode", err)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// MarkDestroyed
+// =============================================================================
+
+func TestMarkDestroyed_IdleToDestroyed(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	buf.MarkDestroyed()
+	if buf.CurrentMapState() != BufferMapStateDestroyed {
+		t.Errorf("state = %v, want Destroyed", buf.CurrentMapState())
+	}
+}
+
+func TestMarkDestroyed_PendingSignalsWaiter(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+
+	// Enter Pending state.
+	err := buf.BeginMap(MapModeInternalRead, 0, 1024)
+	if err != nil {
+		t.Fatalf("BeginMap failed: %v", err)
+	}
+
+	// The waiter should be signaled with Destroyed.
+	waiter := buf.Waiter()
+	buf.MarkDestroyed()
+
+	mapErr := waiter.Wait()
+	if mapErr == nil || mapErr.Kind != BufferMapErrKindDestroyed {
+		t.Errorf("waiter got %v, want Destroyed", mapErr)
+	}
+}
+
+func TestMarkDestroyed_Idempotent(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	buf.MarkDestroyed()
+	buf.MarkDestroyed() // second call should be safe
+	if buf.CurrentMapState() != BufferMapStateDestroyed {
+		t.Errorf("state = %v after double MarkDestroyed, want Destroyed", buf.CurrentMapState())
+	}
+}
+
+// =============================================================================
+// UnmapBuffer
+// =============================================================================
+
+func TestUnmapBuffer_FromMapped(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "TestDevice")
+	buf := NewBuffer(mockBuffer{}, device, gputypes.BufferUsageMapRead, 1024, "test")
+
+	// Manually set to Mapped state for testing unmap.
+	md := buf.ensureMapData()
+	md.mu.Lock()
+	buf.mapState = BufferMapStateMapped
+	md.pendingOffset = 0
+	md.pendingSize = 1024
+	md.pendingMode = MapModeInternalRead
+	md.mu.Unlock()
+
+	guard := device.SnatchLock().Read()
+	mapErr := buf.UnmapBuffer(guard, *device.raw.Get(guard))
+	guard.Release()
+
+	if mapErr != nil {
+		t.Errorf("UnmapBuffer() from Mapped = %v, want nil", mapErr)
+	}
+	if buf.CurrentMapState() != BufferMapStateIdle {
+		t.Errorf("state = %v after Unmap, want Idle", buf.CurrentMapState())
+	}
+}
+
+func TestUnmapBuffer_FromPending(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "TestDevice")
+	buf := NewBuffer(mockBuffer{}, device, gputypes.BufferUsageMapRead, 1024, "test")
+
+	// Enter Pending.
+	err := buf.BeginMap(MapModeInternalRead, 0, 1024)
+	if err != nil {
+		t.Fatalf("BeginMap failed: %v", err)
+	}
+
+	waiter := buf.Waiter()
+	guard := device.SnatchLock().Read()
+	mapErr := buf.UnmapBuffer(guard, *device.raw.Get(guard))
+	guard.Release()
+
+	if mapErr != nil {
+		t.Errorf("UnmapBuffer() from Pending = %v, want nil", mapErr)
+	}
+	if buf.CurrentMapState() != BufferMapStateIdle {
+		t.Errorf("state = %v after Unmap, want Idle", buf.CurrentMapState())
+	}
+
+	// Waiter should receive Canceled.
+	wErr := waiter.Wait()
+	if wErr == nil || wErr.Kind != BufferMapErrKindCancelled {
+		t.Errorf("waiter got %v, want Canceled", wErr)
+	}
+}
+
+func TestUnmapBuffer_FromIdle(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	// nil guard/device are ok here since the function checks state first.
+	mapErr := buf.UnmapBuffer(SnatchGuard{}, nil)
+	if mapErr == nil || mapErr.Kind != BufferMapErrKindNotMapped {
+		t.Errorf("UnmapBuffer() from Idle = %v, want NotMapped", mapErr)
+	}
+}
+
+func TestUnmapBuffer_FromDestroyed(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	buf.mapState = BufferMapStateDestroyed
+	mapErr := buf.UnmapBuffer(SnatchGuard{}, nil)
+	if mapErr == nil || mapErr.Kind != BufferMapErrKindDestroyed {
+		t.Errorf("UnmapBuffer() from Destroyed = %v, want Destroyed", mapErr)
+	}
+}
+
+// =============================================================================
+// TryRegisterMappedRange
+// =============================================================================
+
+func TestTryRegisterMappedRange_Success(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	md := buf.ensureMapData()
+	md.mu.Lock()
+	buf.mapState = BufferMapStateMapped
+	md.pendingOffset = 0
+	md.pendingSize = 1024
+	md.mu.Unlock()
+
+	err := buf.TryRegisterMappedRange(0, 256)
+	if err != nil {
+		t.Fatalf("TryRegisterMappedRange(0, 256) failed: %v", err)
+	}
+
+	// Register another non-overlapping range.
+	err = buf.TryRegisterMappedRange(256, 256)
+	if err != nil {
+		t.Fatalf("TryRegisterMappedRange(256, 256) failed: %v", err)
+	}
+}
+
+func TestTryRegisterMappedRange_NotMapped(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	err := buf.TryRegisterMappedRange(0, 256)
+	if err == nil || err.Kind != BufferMapErrKindNotMapped {
+		t.Errorf("TryRegisterMappedRange on Idle buffer = %v, want NotMapped", err)
+	}
+}
+
+func TestTryRegisterMappedRange_OutOfBounds(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	md := buf.ensureMapData()
+	md.mu.Lock()
+	buf.mapState = BufferMapStateMapped
+	md.pendingOffset = 256
+	md.pendingSize = 256
+	md.mu.Unlock()
+
+	// Before the mapped region.
+	err := buf.TryRegisterMappedRange(0, 128)
+	if err == nil || err.Kind != BufferMapErrKindRangeOverflow {
+		t.Errorf("range before mapped region = %v, want RangeOverflow", err)
+	}
+
+	// After the mapped region.
+	err = buf.TryRegisterMappedRange(600, 128)
+	if err == nil || err.Kind != BufferMapErrKindRangeOverflow {
+		t.Errorf("range after mapped region = %v, want RangeOverflow", err)
+	}
+}
+
+func TestTryRegisterMappedRange_Overlap(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	md := buf.ensureMapData()
+	md.mu.Lock()
+	buf.mapState = BufferMapStateMapped
+	md.pendingOffset = 0
+	md.pendingSize = 1024
+	md.mu.Unlock()
+
+	err := buf.TryRegisterMappedRange(0, 512)
+	if err != nil {
+		t.Fatalf("first registration failed: %v", err)
+	}
+
+	// Overlapping range.
+	err = buf.TryRegisterMappedRange(256, 512)
+	if err == nil || err.Kind != BufferMapErrKindRangeOverlap {
+		t.Errorf("overlapping range = %v, want RangeOverlap", err)
+	}
+}
+
+// =============================================================================
+// MappingInfo
+// =============================================================================
+
+func mappingInfoOK(buf *Buffer) bool {
+	_, _, _, ok := buf.MappingInfo() //nolint:dogsled // test helper wraps multi-return
+	return ok
+}
+
+func TestMappingInfo_NotMapped(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	if mappingInfoOK(buf) {
+		t.Error("MappingInfo() should return ok=false for idle buffer")
+	}
+}
+
+func TestMappingInfo_NilMapData(t *testing.T) {
+	// Buffer without ever initializing map data.
+	buf := &Buffer{mapState: BufferMapStateIdle}
+	if mappingInfoOK(buf) {
+		t.Error("MappingInfo() should return ok=false when mapData is nil")
+	}
+}
+
+// =============================================================================
+// CurrentMapState
+// =============================================================================
+
+func TestCurrentMapState_NoMapData(t *testing.T) {
+	buf := &Buffer{mapState: BufferMapStateIdle}
+	if buf.CurrentMapState() != BufferMapStateIdle {
+		t.Errorf("CurrentMapState() = %v, want Idle", buf.CurrentMapState())
+	}
+}
+
+func TestCurrentMapState_WithMapData(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	// Initialize map data.
+	buf.ensureMapData()
+	if buf.CurrentMapState() != BufferMapStateIdle {
+		t.Errorf("CurrentMapState() = %v, want Idle", buf.CurrentMapState())
+	}
+}
+
+// =============================================================================
+// Generation
+// =============================================================================
+
+func TestGeneration_NilMapData(t *testing.T) {
+	buf := &Buffer{mapState: BufferMapStateIdle}
+	if buf.Generation() != 0 {
+		t.Errorf("Generation() = %d, want 0 for nil mapData", buf.Generation())
+	}
+}
+
+func TestGeneration_Increments(t *testing.T) {
+	buf := newTestBuffer(gputypes.BufferUsageMapRead, 1024)
+	gen0 := buf.Generation()
+
+	// MarkDestroyed bumps generation.
+	buf.MarkDestroyed()
+	gen1 := buf.Generation()
+	if gen1 <= gen0 {
+		t.Errorf("Generation after MarkDestroyed = %d, want > %d", gen1, gen0)
+	}
+}

--- a/core/device_poll_test.go
+++ b/core/device_poll_test.go
@@ -1,0 +1,231 @@
+//go:build !(js && wasm)
+
+package core
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+)
+
+// =============================================================================
+// deviceMapTracker / RegisterPendingMap / PollMaps
+// =============================================================================
+
+func TestRegisterPendingMap_Basic(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "PollTest")
+
+	buf := NewBuffer(mockBuffer{}, device, gputypes.BufferUsageMapRead, 256, "buf")
+	err := buf.BeginMap(MapModeInternalRead, 0, 256)
+	if err != nil {
+		t.Fatalf("BeginMap failed: %v", err)
+	}
+
+	device.RegisterPendingMap(1, buf)
+
+	if !device.HasPendingMaps() {
+		t.Error("HasPendingMaps() should return true after RegisterPendingMap")
+	}
+	if device.MaxKnownSubmissionIndex() != 1 {
+		t.Errorf("MaxKnownSubmissionIndex() = %d, want 1", device.MaxKnownSubmissionIndex())
+	}
+}
+
+func TestPollMaps_ResolvesCompletedSubmissions(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "PollTest")
+
+	buf := NewBuffer(mockBuffer{}, device, gputypes.BufferUsageMapRead, 256, "buf")
+	err := buf.BeginMap(MapModeInternalRead, 0, 256)
+	if err != nil {
+		t.Fatalf("BeginMap failed: %v", err)
+	}
+
+	device.RegisterPendingMap(1, buf)
+
+	// Poll with completedIdx >= 1 should resolve the map.
+	didWork := device.PollMaps(1)
+	if !didWork {
+		t.Error("PollMaps(1) should have resolved pending maps")
+	}
+
+	// Buffer should now be Mapped (ResolveMap was called by PollMaps).
+	if buf.CurrentMapState() != BufferMapStateMapped {
+		t.Errorf("buffer state = %v after PollMaps, want Mapped", buf.CurrentMapState())
+	}
+
+	// No more pending maps.
+	if device.HasPendingMaps() {
+		t.Error("HasPendingMaps() should return false after all maps resolved")
+	}
+}
+
+func TestPollMaps_SkipsFutureSubmissions(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "PollTest")
+
+	buf := NewBuffer(mockBuffer{}, device, gputypes.BufferUsageMapRead, 256, "buf")
+	err := buf.BeginMap(MapModeInternalRead, 0, 256)
+	if err != nil {
+		t.Fatalf("BeginMap failed: %v", err)
+	}
+
+	device.RegisterPendingMap(5, buf)
+
+	// Poll with completedIdx < 5 should NOT resolve the map.
+	didWork := device.PollMaps(3)
+	if didWork {
+		t.Error("PollMaps(3) should not resolve submission 5")
+	}
+	if buf.CurrentMapState() != BufferMapStatePending {
+		t.Errorf("buffer state = %v, want Pending (not resolved yet)", buf.CurrentMapState())
+	}
+	if !device.HasPendingMaps() {
+		t.Error("HasPendingMaps() should still return true")
+	}
+}
+
+func TestPollMaps_MultipleSubmissions(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "PollTest")
+
+	buf1 := NewBuffer(mockBuffer{}, device, gputypes.BufferUsageMapRead, 256, "buf1")
+	buf2 := NewBuffer(mockBuffer{}, device, gputypes.BufferUsageMapRead, 256, "buf2")
+	buf3 := NewBuffer(mockBuffer{}, device, gputypes.BufferUsageMapRead, 256, "buf3")
+
+	_ = buf1.BeginMap(MapModeInternalRead, 0, 256)
+	_ = buf2.BeginMap(MapModeInternalRead, 0, 256)
+	_ = buf3.BeginMap(MapModeInternalRead, 0, 256)
+
+	device.RegisterPendingMap(1, buf1)
+	device.RegisterPendingMap(2, buf2)
+	device.RegisterPendingMap(3, buf3)
+
+	if device.MaxKnownSubmissionIndex() != 3 {
+		t.Errorf("MaxKnownSubmissionIndex() = %d, want 3", device.MaxKnownSubmissionIndex())
+	}
+
+	// Resolve only up to submission 2.
+	device.PollMaps(2)
+
+	if buf1.CurrentMapState() != BufferMapStateMapped {
+		t.Error("buf1 should be Mapped (submission 1 completed)")
+	}
+	if buf2.CurrentMapState() != BufferMapStateMapped {
+		t.Error("buf2 should be Mapped (submission 2 completed)")
+	}
+	if buf3.CurrentMapState() != BufferMapStatePending {
+		t.Error("buf3 should still be Pending (submission 3 not completed)")
+	}
+}
+
+func TestPollMaps_NilTrackerNoWork(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "PollTest")
+
+	// No maps registered -- PollMaps should be a no-op.
+	didWork := device.PollMaps(100)
+	if didWork {
+		t.Error("PollMaps on device with no pending maps should return false")
+	}
+}
+
+func TestHasPendingMaps_NoTracker(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "PollTest")
+
+	if device.HasPendingMaps() {
+		t.Error("HasPendingMaps() should return false for new device")
+	}
+}
+
+func TestMaxKnownSubmissionIndex_NoTracker(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "PollTest")
+
+	if device.MaxKnownSubmissionIndex() != 0 {
+		t.Errorf("MaxKnownSubmissionIndex() = %d, want 0", device.MaxKnownSubmissionIndex())
+	}
+}
+
+func TestRegisterPendingMap_FreeListRecycling(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "PollTest")
+
+	// Cycle 1: register and poll to recycle the slice.
+	buf1 := NewBuffer(mockBuffer{}, device, gputypes.BufferUsageMapRead, 256, "buf1")
+	_ = buf1.BeginMap(MapModeInternalRead, 0, 256)
+	device.RegisterPendingMap(1, buf1)
+	device.PollMaps(1)
+
+	// Cycle 2: register at a different index -- should reuse the recycled slice.
+	buf2 := NewBuffer(mockBuffer{}, device, gputypes.BufferUsageMapRead, 256, "buf2")
+	_ = buf2.BeginMap(MapModeInternalRead, 0, 256)
+	device.RegisterPendingMap(2, buf2)
+	device.PollMaps(2)
+
+	if buf2.CurrentMapState() != BufferMapStateMapped {
+		t.Errorf("buf2 state = %v, want Mapped (recycled slice path)", buf2.CurrentMapState())
+	}
+}
+
+func TestPollMaps_NilBufferSkipped(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "PollTest")
+
+	// Manually register a nil buffer -- should not panic.
+	device.RegisterPendingMap(1, nil)
+	didWork := device.PollMaps(1)
+	if !didWork {
+		t.Error("PollMaps should report work even for nil buffer (bucket drained)")
+	}
+}
+
+func TestRegisterPendingMap_SubmissionIndexZero(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "PollTest")
+
+	buf := NewBuffer(mockBuffer{}, device, gputypes.BufferUsageMapRead, 256, "buf")
+	_ = buf.BeginMap(MapModeInternalRead, 0, 256)
+
+	// Index 0 is the "never submitted" path.
+	device.RegisterPendingMap(0, buf)
+
+	didWork := device.PollMaps(0)
+	if !didWork {
+		t.Error("PollMaps(0) should resolve index=0 entries")
+	}
+	if buf.CurrentMapState() != BufferMapStateMapped {
+		t.Errorf("state = %v, want Mapped", buf.CurrentMapState())
+	}
+}
+
+func TestHalDeviceHandle(t *testing.T) {
+	halDevice := &mockHALDevice{}
+	device := NewDevice(halDevice, &Adapter{}, gputypes.Features(0), gputypes.DefaultLimits(), "Test")
+
+	hd, ok := device.HalDeviceHandle()
+	if !ok {
+		t.Fatal("HalDeviceHandle() should return ok=true for valid device")
+	}
+	if hd == nil {
+		t.Error("HalDeviceHandle() returned nil device")
+	}
+
+	// Destroy the device.
+	device.Destroy()
+
+	_, ok = device.HalDeviceHandle()
+	if ok {
+		t.Error("HalDeviceHandle() should return ok=false after device destroyed")
+	}
+}
+
+func TestHalDeviceHandle_NoHAL(t *testing.T) {
+	device := &Device{}
+	_, ok := device.HalDeviceHandle()
+	if ok {
+		t.Error("HalDeviceHandle() should return ok=false for device without HAL")
+	}
+}

--- a/core/error_test.go
+++ b/core/error_test.go
@@ -1,0 +1,1076 @@
+//go:build !(js && wasm)
+
+package core
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// ValidationError — extended tests (basic Error/Unwrap in core_test.go)
+// =============================================================================
+
+func TestValidationError_WithoutField(t *testing.T) {
+	err := &ValidationError{Resource: "Texture", Message: "invalid"}
+	want := "Texture: invalid"
+	if got := err.Error(); got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestValidationError_UnwrapNil(t *testing.T) {
+	ve := &ValidationError{Resource: "Buffer", Message: "fail"}
+	if ve.Unwrap() != nil {
+		t.Error("Unwrap() should return nil when no cause")
+	}
+}
+
+func TestIsValidationError_Wrapped(t *testing.T) {
+	ve := &ValidationError{Resource: "X", Message: "Y"}
+	wrapped := fmt.Errorf("wrapped: %w", ve)
+
+	if !IsValidationError(wrapped) {
+		t.Error("IsValidationError should return true for wrapped ValidationError")
+	}
+}
+
+// =============================================================================
+// IDError — extended tests (basic Error/Unwrap in core_test.go)
+// =============================================================================
+
+func TestIDError_WithCause(t *testing.T) {
+	id := Zip(42, 7)
+	cause := fmt.Errorf("not found")
+	ie := NewIDError(id, "lookup failed", cause)
+
+	msg := ie.Error()
+	if !strings.Contains(msg, "42") || !strings.Contains(msg, "7") {
+		t.Errorf("IDError.Error() = %q, want index=42 and epoch=7", msg)
+	}
+	if !strings.Contains(msg, "lookup failed") {
+		t.Errorf("IDError.Error() missing message: %q", msg)
+	}
+	if !errors.Is(ie.Unwrap(), cause) {
+		t.Error("IDError.Unwrap() did not return cause")
+	}
+}
+
+func TestIsIDError_Wrapped(t *testing.T) {
+	ie := &IDError{Message: "test"}
+	wrapped := fmt.Errorf("w: %w", ie)
+	if !IsIDError(wrapped) {
+		t.Error("IsIDError should return true for wrapped IDError")
+	}
+	if IsIDError(fmt.Errorf("plain")) {
+		t.Error("IsIDError should return false for plain error")
+	}
+}
+
+// =============================================================================
+// LimitError — extended tests
+// =============================================================================
+
+func TestLimitError_FieldValues(t *testing.T) {
+	le := NewLimitError("Buffer", "maxBufferSize", 9999, 4096)
+	msg := le.Error()
+	if !strings.Contains(msg, "9999") || !strings.Contains(msg, "4096") {
+		t.Errorf("LimitError.Error() missing values: %q", msg)
+	}
+}
+
+func TestIsLimitError_Wrapped(t *testing.T) {
+	le := &LimitError{Limit: "x", Resource: "y"}
+	wrapped := fmt.Errorf("w: %w", le)
+	if !IsLimitError(wrapped) {
+		t.Error("IsLimitError should return true for wrapped LimitError")
+	}
+	if IsLimitError(fmt.Errorf("plain")) {
+		t.Error("IsLimitError should return false for plain error")
+	}
+}
+
+// =============================================================================
+// FeatureError — extended tests
+// =============================================================================
+
+func TestIsFeatureError_Wrapped(t *testing.T) {
+	fe := &FeatureError{Feature: "x", Resource: "y"}
+	wrapped := fmt.Errorf("w: %w", fe)
+	if !IsFeatureError(wrapped) {
+		t.Error("IsFeatureError should return true for wrapped FeatureError")
+	}
+	if IsFeatureError(fmt.Errorf("plain")) {
+		t.Error("IsFeatureError should return false for plain error")
+	}
+}
+
+// =============================================================================
+// CreateBufferError
+// =============================================================================
+
+func TestCreateBufferError_AllKinds(t *testing.T) {
+	halErr := fmt.Errorf("device lost")
+	tests := []struct {
+		name    string
+		err     *CreateBufferError
+		wantSub string
+	}{
+		{
+			name:    "ZeroSize",
+			err:     &CreateBufferError{Kind: CreateBufferErrorZeroSize, Label: "buf1"},
+			wantSub: "size must be greater than 0",
+		},
+		{
+			name:    "MaxBufferSize",
+			err:     &CreateBufferError{Kind: CreateBufferErrorMaxBufferSize, Label: "buf2", RequestedSize: 9999, MaxSize: 4096},
+			wantSub: "exceeds maximum",
+		},
+		{
+			name:    "EmptyUsage",
+			err:     &CreateBufferError{Kind: CreateBufferErrorEmptyUsage, Label: "buf3"},
+			wantSub: "usage must not be empty",
+		},
+		{
+			name:    "InvalidUsage",
+			err:     &CreateBufferError{Kind: CreateBufferErrorInvalidUsage, Label: "buf4"},
+			wantSub: "invalid usage flags",
+		},
+		{
+			name:    "MapReadWriteExclusive",
+			err:     &CreateBufferError{Kind: CreateBufferErrorMapReadWriteExclusive, Label: "buf5"},
+			wantSub: "mutually exclusive",
+		},
+		{
+			name:    "HAL",
+			err:     &CreateBufferError{Kind: CreateBufferErrorHAL, Label: "buf6", HALError: halErr},
+			wantSub: "HAL error",
+		},
+		{
+			name:    "Unknown",
+			err:     &CreateBufferError{Kind: CreateBufferErrorKind(99), Label: "buf7"},
+			wantSub: "unknown error",
+		},
+		{
+			name:    "EmptyLabel",
+			err:     &CreateBufferError{Kind: CreateBufferErrorZeroSize, Label: ""},
+			wantSub: unnamedLabel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if !strings.Contains(msg, tt.wantSub) {
+				t.Errorf("Error() = %q, want substring %q", msg, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestCreateBufferError_Unwrap(t *testing.T) {
+	halErr := fmt.Errorf("vk error")
+	e := &CreateBufferError{Kind: CreateBufferErrorHAL, HALError: halErr}
+	if !errors.Is(e.Unwrap(), halErr) {
+		t.Error("Unwrap() did not return HALError")
+	}
+
+	e2 := &CreateBufferError{Kind: CreateBufferErrorZeroSize}
+	if e2.Unwrap() != nil {
+		t.Error("Unwrap() should return nil when no HAL error")
+	}
+}
+
+func TestIsCreateBufferError(t *testing.T) {
+	cbe := &CreateBufferError{Kind: CreateBufferErrorZeroSize}
+	wrapped := fmt.Errorf("w: %w", cbe)
+	if !IsCreateBufferError(cbe) {
+		t.Error("should match direct")
+	}
+	if !IsCreateBufferError(wrapped) {
+		t.Error("should match wrapped")
+	}
+	if IsCreateBufferError(fmt.Errorf("plain")) {
+		t.Error("should not match plain error")
+	}
+}
+
+func TestCreateBufferError_ErrorsAs(t *testing.T) {
+	halErr := fmt.Errorf("device lost")
+	e := &CreateBufferError{Kind: CreateBufferErrorHAL, HALError: halErr}
+	wrapped := fmt.Errorf("create buffer: %w", e)
+
+	var cbe *CreateBufferError
+	if !errors.As(wrapped, &cbe) {
+		t.Fatal("errors.As should unwrap to CreateBufferError")
+	}
+	if cbe.Kind != CreateBufferErrorHAL {
+		t.Errorf("Kind = %v, want HAL", cbe.Kind)
+	}
+}
+
+// =============================================================================
+// CreateCommandEncoderError — extended (basic Unwrap in core_command_encoder_test.go)
+// =============================================================================
+
+func TestCreateCommandEncoderError_AllKinds(t *testing.T) {
+	halErr := fmt.Errorf("encoder fail")
+	tests := []struct {
+		name    string
+		err     *CreateCommandEncoderError
+		wantSub string
+	}{
+		{
+			name:    "HAL",
+			err:     &CreateCommandEncoderError{Kind: CreateCommandEncoderErrorHAL, Label: "enc1", HALError: halErr},
+			wantSub: "HAL error",
+		},
+		{
+			name:    "Unknown",
+			err:     &CreateCommandEncoderError{Kind: CreateCommandEncoderErrorKind(99), Label: "enc2"},
+			wantSub: "unknown error",
+		},
+		{
+			name:    "EmptyLabel",
+			err:     &CreateCommandEncoderError{Kind: CreateCommandEncoderErrorHAL, HALError: halErr},
+			wantSub: unnamedLabel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if !strings.Contains(msg, tt.wantSub) {
+				t.Errorf("Error() = %q, want substring %q", msg, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestIsCreateCommandEncoderError(t *testing.T) {
+	cee := &CreateCommandEncoderError{Kind: CreateCommandEncoderErrorHAL}
+	if !IsCreateCommandEncoderError(cee) {
+		t.Error("should match direct")
+	}
+	if !IsCreateCommandEncoderError(fmt.Errorf("w: %w", cee)) {
+		t.Error("should match wrapped")
+	}
+	if IsCreateCommandEncoderError(fmt.Errorf("plain")) {
+		t.Error("should not match plain error")
+	}
+}
+
+// =============================================================================
+// CreateTextureError
+// =============================================================================
+
+func TestCreateTextureError_AllKinds(t *testing.T) {
+	halErr := fmt.Errorf("vk texture fail")
+	tests := []struct {
+		name    string
+		err     *CreateTextureError
+		wantSub string
+	}{
+		{
+			name:    "ZeroDimension",
+			err:     &CreateTextureError{Kind: CreateTextureErrorZeroDimension, Label: "tex1", RequestedWidth: 0, RequestedHeight: 256, RequestedDepth: 1},
+			wantSub: "dimensions must be greater than 0",
+		},
+		{
+			name:    "MaxDimension",
+			err:     &CreateTextureError{Kind: CreateTextureErrorMaxDimension, Label: "tex2", RequestedWidth: 99999, MaxDimension: 8192},
+			wantSub: "exceeds maximum",
+		},
+		{
+			name:    "MaxArrayLayers",
+			err:     &CreateTextureError{Kind: CreateTextureErrorMaxArrayLayers, Label: "tex3", RequestedDepth: 500, MaxDimension: 256},
+			wantSub: "array layers",
+		},
+		{
+			name:    "InvalidMipLevelCount",
+			err:     &CreateTextureError{Kind: CreateTextureErrorInvalidMipLevelCount, Label: "tex4", RequestedMips: 20, MaxMips: 9},
+			wantSub: "mip level count",
+		},
+		{
+			name:    "InvalidSampleCount",
+			err:     &CreateTextureError{Kind: CreateTextureErrorInvalidSampleCount, Label: "tex5", RequestedSamples: 8},
+			wantSub: "invalid sample count",
+		},
+		{
+			name:    "MultisampleMipLevel",
+			err:     &CreateTextureError{Kind: CreateTextureErrorMultisampleMipLevel, Label: "tex6", RequestedMips: 4},
+			wantSub: "multisampled texture must have mip level count of 1",
+		},
+		{
+			name:    "MultisampleDimension",
+			err:     &CreateTextureError{Kind: CreateTextureErrorMultisampleDimension, Label: "tex7"},
+			wantSub: "multisampled texture must be 2D",
+		},
+		{
+			name:    "MultisampleArrayLayers",
+			err:     &CreateTextureError{Kind: CreateTextureErrorMultisampleArrayLayers, Label: "tex8", RequestedDepth: 4},
+			wantSub: "multisampled texture must have 1 array layer",
+		},
+		{
+			name:    "MultisampleStorageBinding",
+			err:     &CreateTextureError{Kind: CreateTextureErrorMultisampleStorageBinding, Label: "tex9"},
+			wantSub: "multisampled texture cannot have storage binding",
+		},
+		{
+			name:    "EmptyUsage",
+			err:     &CreateTextureError{Kind: CreateTextureErrorEmptyUsage, Label: "tex10"},
+			wantSub: "usage must not be empty",
+		},
+		{
+			name:    "InvalidUsage",
+			err:     &CreateTextureError{Kind: CreateTextureErrorInvalidUsage, Label: "tex11"},
+			wantSub: "invalid usage flags",
+		},
+		{
+			name:    "InvalidFormat",
+			err:     &CreateTextureError{Kind: CreateTextureErrorInvalidFormat, Label: "tex12"},
+			wantSub: "format must not be undefined",
+		},
+		{
+			name:    "InvalidDimension",
+			err:     &CreateTextureError{Kind: CreateTextureErrorInvalidDimension, Label: "tex13"},
+			wantSub: "dimension must not be undefined",
+		},
+		{
+			name:    "HAL",
+			err:     &CreateTextureError{Kind: CreateTextureErrorHAL, Label: "tex14", HALError: halErr},
+			wantSub: "HAL error",
+		},
+		{
+			name:    "Unknown",
+			err:     &CreateTextureError{Kind: CreateTextureErrorKind(99), Label: "tex15"},
+			wantSub: "unknown error",
+		},
+		{
+			name:    "EmptyLabel",
+			err:     &CreateTextureError{Kind: CreateTextureErrorZeroDimension},
+			wantSub: unnamedLabel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if !strings.Contains(msg, tt.wantSub) {
+				t.Errorf("Error() = %q, want substring %q", msg, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestCreateTextureError_Unwrap(t *testing.T) {
+	halErr := fmt.Errorf("texture hal fail")
+	e := &CreateTextureError{Kind: CreateTextureErrorHAL, HALError: halErr}
+	if !errors.Is(e.Unwrap(), halErr) {
+		t.Error("Unwrap() did not return HALError")
+	}
+	e2 := &CreateTextureError{Kind: CreateTextureErrorEmptyUsage}
+	if e2.Unwrap() != nil {
+		t.Error("Unwrap() should return nil when no HAL error")
+	}
+}
+
+func TestIsCreateTextureError(t *testing.T) {
+	cte := &CreateTextureError{Kind: CreateTextureErrorZeroDimension}
+	if !IsCreateTextureError(cte) {
+		t.Error("should match direct")
+	}
+	if !IsCreateTextureError(fmt.Errorf("w: %w", cte)) {
+		t.Error("should match wrapped")
+	}
+	if IsCreateTextureError(fmt.Errorf("plain")) {
+		t.Error("should not match plain error")
+	}
+}
+
+// =============================================================================
+// CreateSamplerError
+// =============================================================================
+
+func TestCreateSamplerError_AllKinds(t *testing.T) {
+	halErr := fmt.Errorf("sampler hal fail")
+	tests := []struct {
+		name    string
+		err     *CreateSamplerError
+		wantSub string
+	}{
+		{
+			name:    "InvalidLodMinClamp",
+			err:     &CreateSamplerError{Kind: CreateSamplerErrorInvalidLodMinClamp, Label: "s1", LodMinClamp: -1.0},
+			wantSub: "LodMinClamp must be >= 0",
+		},
+		{
+			name:    "InvalidLodMaxClamp",
+			err:     &CreateSamplerError{Kind: CreateSamplerErrorInvalidLodMaxClamp, Label: "s2", LodMinClamp: 5.0, LodMaxClamp: 2.0},
+			wantSub: "LodMaxClamp",
+		},
+		{
+			name:    "InvalidAnisotropy",
+			err:     &CreateSamplerError{Kind: CreateSamplerErrorInvalidAnisotropy, Label: "s3", Anisotropy: 0},
+			wantSub: "anisotropy must be >= 1",
+		},
+		{
+			name:    "AnisotropyRequiresLinearFiltering",
+			err:     &CreateSamplerError{Kind: CreateSamplerErrorAnisotropyRequiresLinearFiltering, Label: "s4", Anisotropy: 16},
+			wantSub: "requires linear",
+		},
+		{
+			name:    "HAL",
+			err:     &CreateSamplerError{Kind: CreateSamplerErrorHAL, Label: "s5", HALError: halErr},
+			wantSub: "HAL error",
+		},
+		{
+			name:    "Unknown",
+			err:     &CreateSamplerError{Kind: CreateSamplerErrorKind(99), Label: "s6"},
+			wantSub: "unknown error",
+		},
+		{
+			name:    "EmptyLabel",
+			err:     &CreateSamplerError{Kind: CreateSamplerErrorInvalidLodMinClamp},
+			wantSub: unnamedLabel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if !strings.Contains(msg, tt.wantSub) {
+				t.Errorf("Error() = %q, want substring %q", msg, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestCreateSamplerError_Unwrap(t *testing.T) {
+	halErr := fmt.Errorf("sampler fail")
+	e := &CreateSamplerError{Kind: CreateSamplerErrorHAL, HALError: halErr}
+	if !errors.Is(e.Unwrap(), halErr) {
+		t.Error("Unwrap() did not return HALError")
+	}
+}
+
+func TestIsCreateSamplerError(t *testing.T) {
+	cse := &CreateSamplerError{Kind: CreateSamplerErrorInvalidLodMinClamp}
+	if !IsCreateSamplerError(cse) {
+		t.Error("should match direct")
+	}
+	if !IsCreateSamplerError(fmt.Errorf("w: %w", cse)) {
+		t.Error("should match wrapped")
+	}
+	if IsCreateSamplerError(fmt.Errorf("plain")) {
+		t.Error("should not match plain error")
+	}
+}
+
+// =============================================================================
+// CreateShaderModuleError
+// =============================================================================
+
+func TestCreateShaderModuleError_AllKinds(t *testing.T) {
+	halErr := fmt.Errorf("compile fail")
+	tests := []struct {
+		name    string
+		err     *CreateShaderModuleError
+		wantSub string
+	}{
+		{
+			name:    "NoSource",
+			err:     &CreateShaderModuleError{Kind: CreateShaderModuleErrorNoSource, Label: "shader1"},
+			wantSub: "must provide either WGSL or SPIRV",
+		},
+		{
+			name:    "DualSource",
+			err:     &CreateShaderModuleError{Kind: CreateShaderModuleErrorDualSource, Label: "shader2"},
+			wantSub: "must not provide both",
+		},
+		{
+			name:    "HAL",
+			err:     &CreateShaderModuleError{Kind: CreateShaderModuleErrorHAL, Label: "shader3", HALError: halErr},
+			wantSub: "HAL error",
+		},
+		{
+			name:    "Unknown",
+			err:     &CreateShaderModuleError{Kind: CreateShaderModuleErrorKind(99), Label: "shader4"},
+			wantSub: "unknown error",
+		},
+		{
+			name:    "EmptyLabel",
+			err:     &CreateShaderModuleError{Kind: CreateShaderModuleErrorNoSource},
+			wantSub: unnamedLabel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if !strings.Contains(msg, tt.wantSub) {
+				t.Errorf("Error() = %q, want substring %q", msg, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestCreateShaderModuleError_Unwrap(t *testing.T) {
+	halErr := fmt.Errorf("shader compile")
+	e := &CreateShaderModuleError{Kind: CreateShaderModuleErrorHAL, HALError: halErr}
+	if !errors.Is(e.Unwrap(), halErr) {
+		t.Error("Unwrap() did not return HALError")
+	}
+}
+
+func TestIsCreateShaderModuleError(t *testing.T) {
+	csme := &CreateShaderModuleError{Kind: CreateShaderModuleErrorNoSource}
+	if !IsCreateShaderModuleError(csme) {
+		t.Error("should match direct")
+	}
+	if !IsCreateShaderModuleError(fmt.Errorf("w: %w", csme)) {
+		t.Error("should match wrapped")
+	}
+	if IsCreateShaderModuleError(fmt.Errorf("plain")) {
+		t.Error("should not match plain error")
+	}
+}
+
+// =============================================================================
+// CreateRenderPipelineError
+// =============================================================================
+
+func TestCreateRenderPipelineError_AllKinds(t *testing.T) {
+	halErr := fmt.Errorf("pipeline fail")
+	tests := []struct {
+		name    string
+		err     *CreateRenderPipelineError
+		wantSub string
+	}{
+		{
+			name:    "MissingVertexModule",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorMissingVertexModule, Label: "rp1"},
+			wantSub: "vertex shader module must not be nil",
+		},
+		{
+			name:    "MissingVertexEntryPoint",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorMissingVertexEntryPoint, Label: "rp2"},
+			wantSub: "vertex entry point must not be empty",
+		},
+		{
+			name:    "MissingFragmentModule",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorMissingFragmentModule, Label: "rp3"},
+			wantSub: "fragment shader module must not be nil",
+		},
+		{
+			name:    "MissingFragmentEntryPoint",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorMissingFragmentEntryPoint, Label: "rp4"},
+			wantSub: "fragment entry point must not be empty",
+		},
+		{
+			name:    "NoFragmentTargets",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorNoFragmentTargets, Label: "rp5"},
+			wantSub: "must have at least one color target",
+		},
+		{
+			name:    "TooManyColorTargets",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorTooManyColorTargets, Label: "rp6", TargetCount: 12, MaxTargets: 8},
+			wantSub: "exceeds maximum",
+		},
+		{
+			name:    "InvalidSampleCount",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorInvalidSampleCount, Label: "rp7", SampleCount: 3},
+			wantSub: "invalid sample count",
+		},
+		{
+			name:    "ColorTargetDepthFormat",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorColorTargetDepthFormat, Label: "rp8", TargetIndex: 0, Format: "Depth32Float"},
+			wantSub: "does not have a color aspect",
+		},
+		{
+			name:    "DepthStencilColorFormat",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorDepthStencilColorFormat, Label: "rp9", Format: "RGBA8Unorm"},
+			wantSub: "is not a depth/stencil format",
+		},
+		{
+			name:    "DepthFormatNoDepthAspect",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorDepthFormatNoDepthAspect, Label: "rp10", Format: "Stencil8"},
+			wantSub: "does not have a depth aspect",
+		},
+		{
+			name:    "DepthFormatNoStencilAspect",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorDepthFormatNoStencilAspect, Label: "rp11", Format: "Depth16Unorm"},
+			wantSub: "does not have a stencil aspect",
+		},
+		{
+			name:    "HAL",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorHAL, Label: "rp12", HALError: halErr},
+			wantSub: "HAL error",
+		},
+		{
+			name:    "Unknown",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorKind(99), Label: "rp13"},
+			wantSub: "unknown error",
+		},
+		{
+			name:    "EmptyLabel",
+			err:     &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorMissingVertexModule},
+			wantSub: unnamedLabel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if !strings.Contains(msg, tt.wantSub) {
+				t.Errorf("Error() = %q, want substring %q", msg, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestCreateRenderPipelineError_Unwrap(t *testing.T) {
+	halErr := fmt.Errorf("pipeline error")
+	e := &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorHAL, HALError: halErr}
+	if !errors.Is(e.Unwrap(), halErr) {
+		t.Error("Unwrap() did not return HALError")
+	}
+}
+
+func TestIsCreateRenderPipelineError(t *testing.T) {
+	crpe := &CreateRenderPipelineError{Kind: CreateRenderPipelineErrorMissingVertexModule}
+	if !IsCreateRenderPipelineError(crpe) {
+		t.Error("should match direct")
+	}
+	if !IsCreateRenderPipelineError(fmt.Errorf("w: %w", crpe)) {
+		t.Error("should match wrapped")
+	}
+	if IsCreateRenderPipelineError(fmt.Errorf("plain")) {
+		t.Error("should not match plain error")
+	}
+}
+
+// =============================================================================
+// CreateComputePipelineError
+// =============================================================================
+
+func TestCreateComputePipelineError_AllKinds(t *testing.T) {
+	halErr := fmt.Errorf("compute fail")
+	tests := []struct {
+		name    string
+		err     *CreateComputePipelineError
+		wantSub string
+	}{
+		{
+			name:    "MissingModule",
+			err:     &CreateComputePipelineError{Kind: CreateComputePipelineErrorMissingModule, Label: "cp1"},
+			wantSub: "compute shader module must not be nil",
+		},
+		{
+			name:    "MissingEntryPoint",
+			err:     &CreateComputePipelineError{Kind: CreateComputePipelineErrorMissingEntryPoint, Label: "cp2"},
+			wantSub: "compute entry point must not be empty",
+		},
+		{
+			name:    "HAL",
+			err:     &CreateComputePipelineError{Kind: CreateComputePipelineErrorHAL, Label: "cp3", HALError: halErr},
+			wantSub: "HAL error",
+		},
+		{
+			name:    "WorkgroupSizeExceeded",
+			err:     &CreateComputePipelineError{Kind: CreateComputePipelineErrorWorkgroupSizeExceeded, Label: "cp4", Dimension: "X", Size: 512, Limit: 256},
+			wantSub: "exceeds device limit",
+		},
+		{
+			name:    "WorkgroupSizeZero",
+			err:     &CreateComputePipelineError{Kind: CreateComputePipelineErrorWorkgroupSizeZero, Label: "cp5", Dimension: "Y"},
+			wantSub: "must not be zero",
+		},
+		{
+			name:    "TooManyInvocations",
+			err:     &CreateComputePipelineError{Kind: CreateComputePipelineErrorTooManyInvocations, Label: "cp6", TotalInvocations: 512, Limit: 256},
+			wantSub: "total workgroup invocations",
+		},
+		{
+			name:    "Unknown",
+			err:     &CreateComputePipelineError{Kind: CreateComputePipelineErrorKind(99), Label: "cp7"},
+			wantSub: "unknown error",
+		},
+		{
+			name:    "EmptyLabel",
+			err:     &CreateComputePipelineError{Kind: CreateComputePipelineErrorMissingModule},
+			wantSub: unnamedLabel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if !strings.Contains(msg, tt.wantSub) {
+				t.Errorf("Error() = %q, want substring %q", msg, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestCreateComputePipelineError_Unwrap(t *testing.T) {
+	halErr := fmt.Errorf("compute pipeline hal")
+	e := &CreateComputePipelineError{Kind: CreateComputePipelineErrorHAL, HALError: halErr}
+	if !errors.Is(e.Unwrap(), halErr) {
+		t.Error("Unwrap() did not return HALError")
+	}
+}
+
+func TestIsCreateComputePipelineError(t *testing.T) {
+	ccpe := &CreateComputePipelineError{Kind: CreateComputePipelineErrorMissingModule}
+	if !IsCreateComputePipelineError(ccpe) {
+		t.Error("should match direct")
+	}
+	if !IsCreateComputePipelineError(fmt.Errorf("w: %w", ccpe)) {
+		t.Error("should match wrapped")
+	}
+	if IsCreateComputePipelineError(fmt.Errorf("plain")) {
+		t.Error("should not match plain error")
+	}
+}
+
+// =============================================================================
+// CreateBindGroupLayoutError
+// =============================================================================
+
+func TestCreateBindGroupLayoutError_AllKinds(t *testing.T) {
+	halErr := fmt.Errorf("bgl hal fail")
+	tests := []struct {
+		name    string
+		err     *CreateBindGroupLayoutError
+		wantSub string
+	}{
+		{
+			name:    "DuplicateBinding",
+			err:     &CreateBindGroupLayoutError{Kind: CreateBindGroupLayoutErrorDuplicateBinding, Label: "bgl1", DuplicateBinding: 3},
+			wantSub: "duplicate binding number 3",
+		},
+		{
+			name:    "TooManyBindings",
+			err:     &CreateBindGroupLayoutError{Kind: CreateBindGroupLayoutErrorTooManyBindings, Label: "bgl2", BindingCount: 64, MaxBindings: 32},
+			wantSub: "exceeds maximum",
+		},
+		{
+			name:    "HAL",
+			err:     &CreateBindGroupLayoutError{Kind: CreateBindGroupLayoutErrorHAL, Label: "bgl3", HALError: halErr},
+			wantSub: "HAL error",
+		},
+		{
+			name:    "Unknown",
+			err:     &CreateBindGroupLayoutError{Kind: CreateBindGroupLayoutErrorKind(99), Label: "bgl4"},
+			wantSub: "unknown error",
+		},
+		{
+			name:    "EmptyLabel",
+			err:     &CreateBindGroupLayoutError{Kind: CreateBindGroupLayoutErrorDuplicateBinding, DuplicateBinding: 0},
+			wantSub: unnamedLabel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if !strings.Contains(msg, tt.wantSub) {
+				t.Errorf("Error() = %q, want substring %q", msg, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestCreateBindGroupLayoutError_Unwrap(t *testing.T) {
+	halErr := fmt.Errorf("bgl fail")
+	e := &CreateBindGroupLayoutError{Kind: CreateBindGroupLayoutErrorHAL, HALError: halErr}
+	if !errors.Is(e.Unwrap(), halErr) {
+		t.Error("Unwrap() did not return HALError")
+	}
+}
+
+func TestIsCreateBindGroupLayoutError(t *testing.T) {
+	cble := &CreateBindGroupLayoutError{Kind: CreateBindGroupLayoutErrorDuplicateBinding}
+	if !IsCreateBindGroupLayoutError(cble) {
+		t.Error("should match direct")
+	}
+	if !IsCreateBindGroupLayoutError(fmt.Errorf("w: %w", cble)) {
+		t.Error("should match wrapped")
+	}
+	if IsCreateBindGroupLayoutError(fmt.Errorf("plain")) {
+		t.Error("should not match plain error")
+	}
+}
+
+// =============================================================================
+// CreateBindGroupError
+// =============================================================================
+
+func TestCreateBindGroupError_AllKinds(t *testing.T) {
+	halErr := fmt.Errorf("bg hal fail")
+	tests := []struct {
+		name    string
+		err     *CreateBindGroupError
+		wantSub string
+	}{
+		{
+			name:    "MissingLayout",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorMissingLayout, Label: "bg1"},
+			wantSub: "layout must not be nil",
+		},
+		{
+			name:    "BindingsNumMismatch",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorBindingsNumMismatch, Label: "bg2", Expected: 3, Actual: 5},
+			wantSub: "does not match",
+		},
+		{
+			name:    "MissingBindingDeclaration",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorMissingBindingDeclaration, Label: "bg3", Binding: 7},
+			wantSub: "unable to find",
+		},
+		{
+			name:    "DuplicateBinding",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorDuplicateBinding, Label: "bg4", Binding: 2},
+			wantSub: "at least twice",
+		},
+		{
+			name:    "BufferUsageMismatch",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorBufferUsageMismatch, Label: "bg5", Binding: 0, ExpectedUsage: 0x40, ActualUsage: 0x20},
+			wantSub: "usage mismatch",
+		},
+		{
+			name:    "BufferOffsetAlignment",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorBufferOffsetAlignment, Label: "bg6", Binding: 1, Offset: 13, Alignment: 16},
+			wantSub: "not aligned",
+		},
+		{
+			name:    "BufferBindingSizeTooLarge",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorBufferBindingSizeTooLarge, Label: "bg7", Binding: 0, Size: 70000, MaxSize: 65536},
+			wantSub: "exceeds maximum",
+		},
+		{
+			name:    "BufferBoundsOverflow",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorBufferBoundsOverflow, Label: "bg8", Binding: 0, Offset: 100, Size: 200, BufferSize: 256},
+			wantSub: "overflows",
+		},
+		{
+			name:    "BufferBindingZeroSize",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorBufferBindingZeroSize, Label: "bg9", Binding: 0},
+			wantSub: "zero effective binding size",
+		},
+		{
+			name:    "StorageBufferSizeAlignment",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorStorageBufferSizeAlignment, Label: "bg10", Binding: 0, Size: 13},
+			wantSub: "not a multiple of 4",
+		},
+		{
+			name:    "MinBindingSizeMismatch",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorMinBindingSizeMismatch, Label: "bg11", Binding: 0, Size: 32, MinBindingSize: 64},
+			wantSub: "less than minimum",
+		},
+		{
+			name:    "HAL",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorHAL, Label: "bg12", HALError: halErr},
+			wantSub: "HAL error",
+		},
+		{
+			name:    "Unknown",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorKind(99), Label: "bg13"},
+			wantSub: "unknown error",
+		},
+		{
+			name:    "EmptyLabel",
+			err:     &CreateBindGroupError{Kind: CreateBindGroupErrorMissingLayout},
+			wantSub: unnamedLabel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if !strings.Contains(msg, tt.wantSub) {
+				t.Errorf("Error() = %q, want substring %q", msg, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestCreateBindGroupError_Unwrap(t *testing.T) {
+	halErr := fmt.Errorf("bg fail")
+	e := &CreateBindGroupError{Kind: CreateBindGroupErrorHAL, HALError: halErr}
+	if !errors.Is(e.Unwrap(), halErr) {
+		t.Error("Unwrap() did not return HALError")
+	}
+}
+
+func TestIsCreateBindGroupError(t *testing.T) {
+	cbge := &CreateBindGroupError{Kind: CreateBindGroupErrorMissingLayout}
+	if !IsCreateBindGroupError(cbge) {
+		t.Error("should match direct")
+	}
+	if !IsCreateBindGroupError(fmt.Errorf("w: %w", cbge)) {
+		t.Error("should match wrapped")
+	}
+	if IsCreateBindGroupError(fmt.Errorf("plain")) {
+		t.Error("should not match plain error")
+	}
+}
+
+// =============================================================================
+// CreatePipelineLayoutError
+// =============================================================================
+
+func TestCreatePipelineLayoutError_AllKinds(t *testing.T) {
+	halErr := fmt.Errorf("pl hal fail")
+	tests := []struct {
+		name    string
+		err     *CreatePipelineLayoutError
+		wantSub string
+	}{
+		{
+			name:    "TooManyGroups",
+			err:     &CreatePipelineLayoutError{Kind: CreatePipelineLayoutErrorTooManyGroups, Label: "pl1", Count: 8, MaxGroups: 4},
+			wantSub: "exceeds device limit",
+		},
+		{
+			name:    "HAL",
+			err:     &CreatePipelineLayoutError{Kind: CreatePipelineLayoutErrorHAL, Label: "pl2", HALError: halErr},
+			wantSub: "HAL error",
+		},
+		{
+			name:    "Unknown",
+			err:     &CreatePipelineLayoutError{Kind: CreatePipelineLayoutErrorKind(99), Label: "pl3"},
+			wantSub: "unknown error",
+		},
+		{
+			name:    "EmptyLabel",
+			err:     &CreatePipelineLayoutError{Kind: CreatePipelineLayoutErrorTooManyGroups, Count: 5, MaxGroups: 4},
+			wantSub: unnamedLabel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if !strings.Contains(msg, tt.wantSub) {
+				t.Errorf("Error() = %q, want substring %q", msg, tt.wantSub)
+			}
+		})
+	}
+}
+
+func TestCreatePipelineLayoutError_Unwrap(t *testing.T) {
+	halErr := fmt.Errorf("layout fail")
+	e := &CreatePipelineLayoutError{Kind: CreatePipelineLayoutErrorHAL, HALError: halErr}
+	if !errors.Is(e.Unwrap(), halErr) {
+		t.Error("Unwrap() did not return HALError")
+	}
+}
+
+func TestIsCreatePipelineLayoutError(t *testing.T) {
+	cple := &CreatePipelineLayoutError{Kind: CreatePipelineLayoutErrorTooManyGroups}
+	if !IsCreatePipelineLayoutError(cple) {
+		t.Error("should match direct")
+	}
+	if !IsCreatePipelineLayoutError(fmt.Errorf("w: %w", cple)) {
+		t.Error("should match wrapped")
+	}
+	if IsCreatePipelineLayoutError(fmt.Errorf("plain")) {
+		t.Error("should not match plain error")
+	}
+}
+
+// =============================================================================
+// EncoderStateError — extended (basic test in core_command_encoder_test.go)
+// =============================================================================
+
+func TestEncoderStateError_WithCause(t *testing.T) {
+	cause := fmt.Errorf("deferred validation failure")
+	e := &EncoderStateError{
+		Operation: "Draw",
+		Status:    CommandEncoderStatusError,
+		Cause:     cause,
+	}
+	msg := e.Error()
+	if !strings.Contains(msg, "Draw") {
+		t.Errorf("Error() missing operation: %q", msg)
+	}
+	if !strings.Contains(msg, "deferred validation failure") {
+		t.Errorf("Error() missing cause: %q", msg)
+	}
+	if !errors.Is(e.Unwrap(), cause) {
+		t.Error("Unwrap() did not return cause")
+	}
+}
+
+func TestEncoderStateError_WithoutCause(t *testing.T) {
+	e := &EncoderStateError{
+		Operation: "Finish",
+		Status:    CommandEncoderStatusLocked,
+	}
+	msg := e.Error()
+	if !strings.Contains(msg, "Finish") {
+		t.Errorf("Error() missing operation: %q", msg)
+	}
+	if !strings.Contains(msg, "Locked") {
+		t.Errorf("Error() missing status: %q", msg)
+	}
+	if e.Unwrap() != nil {
+		t.Error("Unwrap() should return nil when no cause")
+	}
+}
+
+func TestEncoderStateError_ErrorChaining(t *testing.T) {
+	// Verify errors.Is/errors.As work through the chain when
+	// an EncoderStateError wraps a cause via Unwrap.
+	rootCause := &CreateBufferError{Kind: CreateBufferErrorZeroSize, Label: "inner"}
+	ese := &EncoderStateError{
+		Operation: "CopyBuffer",
+		Status:    CommandEncoderStatusError,
+		Cause:     rootCause,
+	}
+
+	// errors.As through chain
+	var cbe *CreateBufferError
+	if !errors.As(ese, &cbe) {
+		t.Fatal("errors.As should find CreateBufferError through EncoderStateError chain")
+	}
+	if cbe.Kind != CreateBufferErrorZeroSize {
+		t.Errorf("Kind = %v, want ZeroSize", cbe.Kind)
+	}
+}
+
+// =============================================================================
+// Sentinel error identity tests
+// =============================================================================
+
+func TestSentinelErrorsDistinct(t *testing.T) {
+	// Verify sentinel errors are distinct and can be tested with errors.Is.
+	sentinels := []struct {
+		name string
+		err  error
+	}{
+		{"ErrInvalidID", ErrInvalidID},
+		{"ErrResourceNotFound", ErrResourceNotFound},
+		{"ErrEpochMismatch", ErrEpochMismatch},
+		{"ErrRegistryFull", ErrRegistryFull},
+		{"ErrResourceInUse", ErrResourceInUse},
+		{"ErrAlreadyDestroyed", ErrAlreadyDestroyed},
+		{"ErrDeviceLost", ErrDeviceLost},
+		{"ErrDeviceDestroyed", ErrDeviceDestroyed},
+		{"ErrResourceDestroyed", ErrResourceDestroyed},
+	}
+
+	for i, s := range sentinels {
+		t.Run(s.name, func(t *testing.T) {
+			// Each sentinel should have a non-empty message.
+			if s.err.Error() == "" {
+				t.Errorf("%s has empty Error()", s.name)
+			}
+			// Wrapped sentinel should be findable via errors.Is.
+			wrapped := fmt.Errorf("context: %w", s.err)
+			if !errors.Is(wrapped, s.err) {
+				t.Errorf("errors.Is failed to find %s through wrapping", s.name)
+			}
+			// Each sentinel should be distinct from all others.
+			for j, other := range sentinels {
+				if i != j && errors.Is(s.err, other.err) {
+					t.Errorf("%s should not match %s", s.name, other.name)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

**Real unit + regression tests for core/ — coverage 73.9% → 85.5% (+11.6pp)**

Not boilerplate — every test verifies actual behavior with meaningful assertions.

### New test files (1912 LOC)

- **`core/error_test.go`** (~600 LOC) — 10 error types: all Kind variants, `Unwrap`/`errors.Is`/`errors.As` chains, error message content, empty label fallback, sentinel distinctness
- **`core/buffer_mapping_test.go`** (~500 LOC) — MapWaiter lifecycle (signal/wait/cancel/reset), BeginMap rejection states (destroyed/pending/mapped), alignment errors, range overflow, MarkDestroyed during pending, UnmapBuffer transitions, TryRegisterMappedRange overlap, concurrent Wait (5 goroutines)
- **`core/device_poll_test.go`** (~200 LOC) — RegisterPendingMap, PollMaps submission resolution, HasPendingMaps, MaxKnownSubmissionIndex, free-list recycling, submission index 0 immediate resolution, HalDeviceHandle

## Test plan

- [x] `go test ./core/...` — all pass, 85.5% coverage
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] `gofmt -l .` — clean
- [ ] CI