### PR TITLE
fix(hal/metal/device.go): `[*Device.CreateComputePipeline]` and `[*Device.CreateRenderPipeline]` resolves translated entrypoint name by `[naga.TranslationInfo]`

### DIFF
--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -486,7 +486,7 @@ func (d *Device) CreateShaderModule(desc *hal.ShaderModuleDescriptor) (hal.Shade
 		workgroupSizes := extractWorkgroupSizes(irModule)
 
 		// Compile IR to MSL
-		mslSource, _, err := msl.Compile(irModule, msl.DefaultOptions())
+		mslSource, info, err := msl.Compile(irModule, msl.DefaultOptions())
 		if err != nil {
 			return nil, fmt.Errorf("metal: failed to compile to MSL: %w", err)
 		}
@@ -522,15 +522,16 @@ func (d *Device) CreateShaderModule(desc *hal.ShaderModuleDescriptor) (hal.Shade
 		)
 
 		return &ShaderModule{
-			source:         desc.Source,
-			library:        library,
-			device:         d,
-			workgroupSizes: workgroupSizes,
+			source:                    desc.Source,
+			library:                   library,
+			device:                    d,
+			workgroupSizes:            workgroupSizes,
+			translatedEntrypointNames: info.EntryPointNames,
 		}, nil
 	}
 
 	// No WGSL source - just store the descriptor for later
-	return &ShaderModule{source: desc.Source, device: d}, nil
+	return &ShaderModule{source: desc.Source, device: d, translatedEntrypointNames: map[string]string{}}, nil
 }
 
 func formatNSError(errObj ID) string {
@@ -601,12 +602,18 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 		Release(label)
 	}
 
+	// Resolve translated entrypoint name
+	entrypointName := desc.Vertex.EntryPoint
+	if translated, ok := fragmentModule.translatedEntrypointNames[entrypointName]; ok {
+		entrypointName = translated
+	}
+
 	// Get vertex function from library
-	vertexFuncName := NSString(desc.Vertex.EntryPoint)
+	vertexFuncName := NSString(entrypointName)
 	vertexFunc := MsgSend(vertexModule.library, Sel("newFunctionWithName:"), uintptr(vertexFuncName))
 	Release(vertexFuncName)
 	if vertexFunc == 0 {
-		return nil, fmt.Errorf("metal: vertex function '%s' not found", desc.Vertex.EntryPoint)
+		return nil, fmt.Errorf("metal: vertex function '%s' not found", entrypointName)
 	}
 	defer Release(vertexFunc)
 
@@ -624,11 +631,17 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 
 	// Get and set fragment function if present
 	if fragmentModule != nil && desc.Fragment != nil {
-		fragmentFuncName := NSString(desc.Fragment.EntryPoint)
+		// Resolve translated entrypoint name
+		entrypointName := desc.Fragment.EntryPoint
+		if translated, ok := fragmentModule.translatedEntrypointNames[entrypointName]; ok {
+			entrypointName = translated
+		}
+
+		fragmentFuncName := NSString(entrypointName)
 		fragmentFunc := MsgSend(fragmentModule.library, Sel("newFunctionWithName:"), uintptr(fragmentFuncName))
 		Release(fragmentFuncName)
 		if fragmentFunc == 0 {
-			return nil, fmt.Errorf("metal: fragment function '%s' not found", desc.Fragment.EntryPoint)
+			return nil, fmt.Errorf("metal: fragment function '%s' not found", entrypointName)
 		}
 		defer Release(fragmentFunc)
 
@@ -796,12 +809,18 @@ func (d *Device) CreateComputePipeline(desc *hal.ComputePipelineDescriptor) (hal
 		return nil, fmt.Errorf("metal: invalid compute shader module")
 	}
 
+	// Resolve translated entrypoint name
+	entrypointName := desc.Compute.EntryPoint
+	if translated, ok := computeModule.translatedEntrypointNames[entrypointName]; ok {
+		entrypointName = translated
+	}
+
 	// Get compute function from library
-	funcName := NSString(desc.Compute.EntryPoint)
+	funcName := NSString(entrypointName)
 	computeFunc := MsgSend(computeModule.library, Sel("newFunctionWithName:"), uintptr(funcName))
 	Release(funcName)
 	if computeFunc == 0 {
-		return nil, fmt.Errorf("metal: compute function '%s' not found", desc.Compute.EntryPoint)
+		return nil, fmt.Errorf("metal: compute function '%s' not found", entrypointName)
 	}
 	defer Release(computeFunc)
 
@@ -823,7 +842,7 @@ func (d *Device) CreateComputePipeline(desc *hal.ComputePipelineDescriptor) (hal
 	}
 
 	// Get workgroup size from shader module metadata
-	workgroupSize := getWorkgroupSize(computeModule, desc.Compute.EntryPoint)
+	workgroupSize := getWorkgroupSize(computeModule, entrypointName)
 
 	hal.Logger().Debug("metal: compute pipeline created",
 		"entryPoint", desc.Compute.EntryPoint,

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -522,16 +522,16 @@ func (d *Device) CreateShaderModule(desc *hal.ShaderModuleDescriptor) (hal.Shade
 		)
 
 		return &ShaderModule{
-			source:                    desc.Source,
-			library:                   library,
-			device:                    d,
-			workgroupSizes:            workgroupSizes,
-			translatedEntrypointNames: info.EntryPointNames,
+			source:          desc.Source,
+			library:         library,
+			device:          d,
+			workgroupSizes:  workgroupSizes,
+			entrypointNames: info.EntryPointNames,
 		}, nil
 	}
 
 	// No WGSL source - just store the descriptor for later
-	return &ShaderModule{source: desc.Source, device: d, translatedEntrypointNames: map[string]string{}}, nil
+	return &ShaderModule{source: desc.Source, device: d}, nil
 }
 
 func formatNSError(errObj ID) string {
@@ -604,7 +604,7 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 
 	// Resolve translated entrypoint name
 	entrypointName := desc.Vertex.EntryPoint
-	if translated, ok := fragmentModule.translatedEntrypointNames[entrypointName]; ok {
+	if translated, ok := vertexModule.entrypointNames[entrypointName]; ok {
 		entrypointName = translated
 	}
 
@@ -633,7 +633,7 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 	if fragmentModule != nil && desc.Fragment != nil {
 		// Resolve translated entrypoint name
 		entrypointName := desc.Fragment.EntryPoint
-		if translated, ok := fragmentModule.translatedEntrypointNames[entrypointName]; ok {
+		if translated, ok := fragmentModule.entrypointNames[entrypointName]; ok {
 			entrypointName = translated
 		}
 
@@ -811,7 +811,7 @@ func (d *Device) CreateComputePipeline(desc *hal.ComputePipelineDescriptor) (hal
 
 	// Resolve translated entrypoint name
 	entrypointName := desc.Compute.EntryPoint
-	if translated, ok := computeModule.translatedEntrypointNames[entrypointName]; ok {
+	if translated, ok := computeModule.entrypointNames[entrypointName]; ok {
 		entrypointName = translated
 	}
 
@@ -842,7 +842,7 @@ func (d *Device) CreateComputePipeline(desc *hal.ComputePipelineDescriptor) (hal
 	}
 
 	// Get workgroup size from shader module metadata
-	workgroupSize := getWorkgroupSize(computeModule, entrypointName)
+	workgroupSize := getWorkgroupSize(computeModule, desc.Compute.EntryPoint)
 
 	hal.Logger().Debug("metal: compute pipeline created",
 		"entryPoint", desc.Compute.EntryPoint,

--- a/hal/metal/resource.go
+++ b/hal/metal/resource.go
@@ -106,10 +106,11 @@ func (s *Sampler) NativeHandle() uintptr { return uintptr(s.raw) }
 
 // ShaderModule implements hal.ShaderModule for Metal.
 type ShaderModule struct {
-	source         hal.ShaderSource
-	library        ID // id<MTLLibrary>
-	device         *Device
-	workgroupSizes map[string][3]uint32 // entry point name -> workgroup size
+	source                    hal.ShaderSource
+	library                   ID // id<MTLLibrary>
+	device                    *Device
+	workgroupSizes            map[string][3]uint32 // entry point name -> workgroup size
+	translatedEntrypointNames map[string]string
 }
 
 // Destroy releases the shader module.

--- a/hal/metal/resource.go
+++ b/hal/metal/resource.go
@@ -106,11 +106,11 @@ func (s *Sampler) NativeHandle() uintptr { return uintptr(s.raw) }
 
 // ShaderModule implements hal.ShaderModule for Metal.
 type ShaderModule struct {
-	source                    hal.ShaderSource
-	library                   ID // id<MTLLibrary>
-	device                    *Device
-	workgroupSizes            map[string][3]uint32 // entry point name -> workgroup size
-	translatedEntrypointNames map[string]string
+	source          hal.ShaderSource
+	library         ID // id<MTLLibrary>
+	device          *Device
+	workgroupSizes  map[string][3]uint32 // entry point name -> workgroup size
+	entrypointNames map[string]string
 }
 
 // Destroy releases the shader module.


### PR DESCRIPTION
resolve #168

```
$ CGO_ENABLED=0 go run ./examples/compute-copy/
=== Compute Shader: Scaled Copy ===

1. Creating instance... OK
2. Requesting adapter... OK (Apple M4 Max)
3. Creating device... OK
4. Input: 1024 float32 elements, scale = 2.5
5. Creating buffers... OK
6. Creating compute pipeline... OK
7. Dispatching compute... OK
8. Reading results... OK

Sample results (first 8):
  [0] 1.0 * 2.5 = 2.5
  [1] 2.0 * 2.5 = 5.0
  [2] 3.0 * 2.5 = 7.5
  [3] 4.0 * 2.5 = 10.0
  [4] 5.0 * 2.5 = 12.5
  [5] 6.0 * 2.5 = 15.0
  [6] 7.0 * 2.5 = 17.5
  [7] 8.0 * 2.5 = 20.0

PASS: all 1024 elements match (tolerance=0.0010)
```