### PR TITLE
v0.26.12: test coverage boost, Metal entry point fix, naga v0.17.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.26.12] - 2026-04-30
+## [0.26.12] - 2026-05-01
 
 ### Added
 
@@ -19,8 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Metal: entry point name resolution** (#168, PR #167 by @k-chimi) — naga MSL renames
+  reserved words (`main` → `main_`), but the Metal HAL used the original name to look up
+  functions in MTLLibrary. Now stores `TranslationInfo.EntryPointNames` from naga compile
+  and uses the translated name at pipeline creation. Applies to vertex, fragment, and compute.
 - **Codecov ignore patterns** — `hal/**/*` format did not exclude GPU backends from coverage
   calculation. Changed to `hal/` (matching gogpu pattern). Badge now reflects testable code only.
+
+### Dependencies
+
+- **naga** v0.17.8 → **v0.17.10**
 
 ## [0.26.11] - 2026-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.26.12] - 2026-04-30
+
+### Added
+
+- **Test coverage boost** (COV-004) — 8 new test files, ~160 test functions:
+  - `core/error_test.go` — 10 error types: all Kind variants, Unwrap/errors.Is/errors.As chains
+  - `core/buffer_mapping_test.go` — MapWaiter lifecycle, BeginMap states, concurrent Wait
+  - `core/device_poll_test.go` — deviceMapTracker, PollMaps, submission resolution
+  - Root package: device lifecycle, encoder tracking, mapping state machine, pipeline accessors,
+    wrap.go HAL constructors, fence CRUD, resource Release idempotency
+  - core/ coverage: 73.9% → 85.5%, root package: 69.1% → 78.4%
+
+### Fixed
+
+- **Codecov ignore patterns** — `hal/**/*` format did not exclude GPU backends from coverage
+  calculation. Changed to `hal/` (matching gogpu pattern). Badge now reflects testable code only.
+
 ## [0.26.11] - 2026-04-30
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,7 +143,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| **v0.26.12** | 2026-04 | **Test coverage boost** — core 85.5%, root 78.4%, codecov ignore fix |
+| **v0.26.12** | 2026-05 | **Test coverage** (core 85.5%, root 78.4%), Metal entry point fix (#168 by @k-chimi), naga v0.17.10 |
 | **v0.26.11** | 2026-04 | **DX12 indirect dispatch/draw** — ExecuteIndirect + CommandSignature (was last GPU backend with stubs) |
 | **v0.26.10** | 2026-04 | **Validation Phase B** — 5 P1 correctness checks (MinBindingSize, index format mismatch, indirect bounds, depth/stencil aspects, BindGroup Submit). Coverage 37% → 45%. |
 | **v0.26.9** | 2026-04 | **Validation Phase A** — 18 P0 crash prevention checks (WriteBuffer bounds, BindGroup buffer, draw-time state, PipelineLayout, format guards, Submit resource state). Coverage 22% → 37%. |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,6 +143,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.26.12** | 2026-04 | **Test coverage boost** — core 85.5%, root 78.4%, codecov ignore fix |
 | **v0.26.11** | 2026-04 | **DX12 indirect dispatch/draw** — ExecuteIndirect + CommandSignature (was last GPU backend with stubs) |
 | **v0.26.10** | 2026-04 | **Validation Phase B** — 5 P1 correctness checks (MinBindingSize, index format mismatch, indirect bounds, depth/stencil aspects, BindGroup Submit). Coverage 37% → 45%. |
 | **v0.26.9** | 2026-04 | **Validation Phase A** — 18 P0 crash prevention checks (WriteBuffer bounds, BindGroup buffer, draw-time state, PipelineLayout, format guards, Submit resource state). Coverage 22% → 37%. |

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,14 +14,10 @@ coverage:
 # Ignore paths from coverage calculation
 # HAL backend implementations require real GPU hardware and cannot be unit tested
 ignore:
-  - "hal/vulkan/**/*"
-  - "hal/metal/**/*"
-  - "hal/dx12/**/*"
-  - "hal/gles/**/*"
-  - "hal/software/**/*"
-  - "hal/noop/**/*"
-  - "examples/**/*"
-  - "cmd/**/*"
+  - "hal/"
+  - "examples/"
+  - "cmd/"
+  - "tmp/"
 
 # Go-specific parser settings
 parsers:

--- a/coverage_device_test.go
+++ b/coverage_device_test.go
@@ -1,0 +1,598 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+)
+
+// =============================================================================
+// Device.CreateBuffer — released device, nil desc, various usages
+// Covers device_native.go CreateBuffer guard clauses + happy paths
+// =============================================================================
+
+func TestCreateBufferReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	_, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "post-release",
+		Size:  64,
+		Usage: wgpu.BufferUsageVertex,
+	})
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("CreateBuffer after Release: got %v, want ErrReleased", err)
+	}
+}
+
+// =============================================================================
+// Device.CreateTexture — released device, nil desc
+// Covers device_native.go CreateTexture guard clauses
+// =============================================================================
+
+func TestCreateTextureReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	_, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "post-release",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageTextureBinding,
+	})
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("CreateTexture after Release: got %v, want ErrReleased", err)
+	}
+}
+
+// =============================================================================
+// Device.CreateSampler — released device, nil desc (creates default sampler)
+// Covers device_native.go CreateSampler guard clauses
+// =============================================================================
+
+func TestCreateSamplerReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	_, err := device.CreateSampler(&wgpu.SamplerDescriptor{Label: "post-release"})
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("CreateSampler after Release: got %v, want ErrReleased", err)
+	}
+}
+
+func TestCreateSamplerNilDescCreatesDefault(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	// nil descriptor should create a sampler with default parameters.
+	sampler, err := device.CreateSampler(nil)
+	if err != nil {
+		t.Fatalf("CreateSampler(nil): %v", err)
+	}
+	if sampler == nil {
+		t.Fatal("CreateSampler(nil) returned nil sampler")
+	}
+	sampler.Release()
+}
+
+// =============================================================================
+// Device.CreateShaderModule — released device, nil desc
+// Covers device_native.go CreateShaderModule guard clauses
+// =============================================================================
+
+func TestCreateShaderModuleReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	_, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "post-release",
+		WGSL:  "@vertex fn vs() -> @builtin(position) vec4f { return vec4f(0.0); }",
+	})
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("CreateShaderModule after Release: got %v, want ErrReleased", err)
+	}
+}
+
+// =============================================================================
+// Device.CreateBindGroupLayout — released device, nil desc
+// Covers device_native.go CreateBindGroupLayout guard clauses
+// =============================================================================
+
+func TestCreateBindGroupLayoutReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	_, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "post-release",
+	})
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("CreateBindGroupLayout after Release: got %v, want ErrReleased", err)
+	}
+}
+
+// =============================================================================
+// Device.CreatePipelineLayout — happy path with multiple bind group layouts
+// Covers device_native.go lines 286-331 (bindGroupLayouts copy, bindGroupCount)
+// =============================================================================
+
+func TestCreatePipelineLayoutWithLayouts(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	bgl1, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "pl-bgl-0",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout 0: %v", err)
+	}
+	defer bgl1.Release()
+
+	bgl2, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "pl-bgl-1",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: wgpu.ShaderStageVertex,
+				Buffer: &gputypes.BufferBindingLayout{
+					Type:           gputypes.BufferBindingTypeUniform,
+					MinBindingSize: 16,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout 1: %v", err)
+	}
+	defer bgl2.Release()
+
+	layout, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{
+		Label:            "two-group-layout",
+		BindGroupLayouts: []*wgpu.BindGroupLayout{bgl1, bgl2},
+	})
+	if err != nil {
+		t.Fatalf("CreatePipelineLayout: %v", err)
+	}
+	if layout == nil {
+		t.Fatal("CreatePipelineLayout returned nil")
+	}
+	layout.Release()
+}
+
+// =============================================================================
+// Device.CreateRenderPipeline — released device
+// Covers device_native.go CreateRenderPipeline guard clause
+// =============================================================================
+
+func TestCreateRenderPipelineReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	_, err := device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
+		Label: "post-release",
+	})
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("CreateRenderPipeline after Release: got %v, want ErrReleased", err)
+	}
+}
+
+// =============================================================================
+// Device.CreateComputePipeline — released device
+// Covers device_native.go CreateComputePipeline guard clause
+// =============================================================================
+
+func TestCreateComputePipelineReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	_, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Label:      "post-release",
+		EntryPoint: "main",
+	})
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("CreateComputePipeline after Release: got %v, want ErrReleased", err)
+	}
+}
+
+// =============================================================================
+// Device.CreateCommandEncoder — released device
+// Covers device_native.go CreateCommandEncoder guard clause
+// =============================================================================
+
+func TestCreateCommandEncoderReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	_, err := device.CreateCommandEncoder(nil)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("CreateCommandEncoder after Release: got %v, want ErrReleased", err)
+	}
+}
+
+func TestCreateCommandEncoderWithLabel(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{
+		Label: "labeled-encoder",
+	})
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder with label: %v", err)
+	}
+	if enc == nil {
+		t.Fatal("CreateCommandEncoder with label returned nil")
+	}
+	enc.DiscardEncoding()
+}
+
+// =============================================================================
+// Device.CreateBindGroup — with buffer resources + late binding info
+// Covers device_native.go CreateBindGroup lines 334-436
+// (collectBindGroupResources, buildBindGroupEntryMap, late buffer binding info)
+// =============================================================================
+
+func TestCreateBindGroupWithBufferResources(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "bg-resource-buf",
+		Size:  128,
+		Usage: wgpu.BufferUsageUniform | wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "bg-resource-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: wgpu.ShaderStageVertex,
+				Buffer: &gputypes.BufferBindingLayout{
+					Type:           gputypes.BufferBindingTypeUniform,
+					MinBindingSize: 128,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "bg-with-resources",
+		Layout: bgl,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: buf, Offset: 0, Size: 128},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	if bg == nil {
+		t.Fatal("CreateBindGroup returned nil")
+	}
+	bg.Release()
+}
+
+func TestCreateBindGroupWithLateBufferBindingInfo(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "late-bind-buf",
+		Size:  512,
+		Usage: wgpu.BufferUsageStorage | wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// MinBindingSize == 0 triggers late buffer binding info path.
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "late-bind-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: wgpu.ShaderStageCompute,
+				Buffer: &gputypes.BufferBindingLayout{
+					Type:           gputypes.BufferBindingTypeStorage,
+					MinBindingSize: 0, // late binding
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	// Size == 0 means "rest of buffer" path. Offset must be aligned to 256.
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "bg-late-binding",
+		Layout: bgl,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: buf, Offset: 256, Size: 0},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	if bg == nil {
+		t.Fatal("CreateBindGroup returned nil")
+	}
+	bg.Release()
+}
+
+func TestCreateBindGroupWithExplicitSize(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "explicit-size-buf",
+		Size:  256,
+		Usage: wgpu.BufferUsageStorage | wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "explicit-size-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: wgpu.ShaderStageCompute,
+				Buffer: &gputypes.BufferBindingLayout{
+					Type:           gputypes.BufferBindingTypeStorage,
+					MinBindingSize: 0,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	// Explicit Size > 0 — does not trigger "rest of buffer" path.
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "bg-explicit-size",
+		Layout: bgl,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: buf, Offset: 0, Size: 128},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	bg.Release()
+}
+
+func TestCreateBindGroupMultipleBufferEntries(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf1, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "multi-buf-1",
+		Size:  64,
+		Usage: wgpu.BufferUsageUniform | wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer 1: %v", err)
+	}
+	defer buf1.Release()
+
+	buf2, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "multi-buf-2",
+		Size:  128,
+		Usage: wgpu.BufferUsageStorage | wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer 2: %v", err)
+	}
+	defer buf2.Release()
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "multi-buf-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: wgpu.ShaderStageVertex,
+				Buffer: &gputypes.BufferBindingLayout{
+					Type:           gputypes.BufferBindingTypeUniform,
+					MinBindingSize: 64,
+				},
+			},
+			{
+				Binding:    1,
+				Visibility: wgpu.ShaderStageFragment,
+				Buffer: &gputypes.BufferBindingLayout{
+					Type:           gputypes.BufferBindingTypeReadOnlyStorage,
+					MinBindingSize: 128,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "bg-multi-buf",
+		Layout: bgl,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: buf1, Offset: 0, Size: 64},
+			{Binding: 1, Buffer: buf2, Offset: 0, Size: 128},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	bg.Release()
+}
+
+// =============================================================================
+// Device.CreateFence + operations — full lifecycle
+// Covers device_native.go lines 747-820 + fence.go
+// =============================================================================
+
+func TestFenceFullLifecycle(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+
+	// Check status.
+	_, err = device.GetFenceStatus(fence)
+	if err != nil {
+		t.Fatalf("GetFenceStatus: %v", err)
+	}
+
+	// Reset.
+	if err := device.ResetFence(fence); err != nil {
+		t.Fatalf("ResetFence: %v", err)
+	}
+
+	// Release via deprecated path.
+	device.DestroyFence(fence)
+}
+
+// =============================================================================
+// Device.GetSurfaceCapabilities — nil surface, released adapter
+// Covers adapter_native.go GetSurfaceCapabilities
+// =============================================================================
+
+func TestGetSurfaceCapabilitiesNilSurface(t *testing.T) {
+	_, adapter := newAdapter(t)
+	defer adapter.Release()
+
+	caps := adapter.GetSurfaceCapabilities(nil)
+	if caps != nil {
+		t.Error("GetSurfaceCapabilities(nil) should return nil")
+	}
+}
+
+func TestGetSurfaceCapabilitiesReleasedAdapter(t *testing.T) {
+	_, adapter := newAdapter(t)
+	adapter.Release()
+
+	caps := adapter.GetSurfaceCapabilities(nil)
+	if caps != nil {
+		t.Error("GetSurfaceCapabilities on released adapter should return nil")
+	}
+}
+
+func TestGetSurfaceCapabilitiesCoreOnlyPath(t *testing.T) {
+	_, adapter := newAdapter(t)
+	defer adapter.Release()
+
+	// With a non-nil surface (from HAL wrap) on a mock adapter, this tests
+	// the core-only path which returns default capabilities.
+	surface := wgpu.NewSurfaceFromHAL(nil, "test-surface")
+	caps := adapter.GetSurfaceCapabilities(surface)
+	// On mock adapter without HAL, expect the core-only defaults.
+	if caps != nil {
+		// If caps are returned, Fifo should be present (spec guaranteed).
+		hasFifo := false
+		for _, pm := range caps.PresentModes {
+			if pm == wgpu.PresentModeFifo {
+				hasFifo = true
+				break
+			}
+		}
+		if !hasFifo {
+			t.Error("SurfaceCapabilities should include PresentModeFifo")
+		}
+	}
+}
+
+// =============================================================================
+// Device.FreeCommandBuffer — with a real encoder
+// Covers device_native.go lines 825-838 (halBuffer() path)
+// =============================================================================
+
+func TestFreeCommandBufferAfterFinish(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{
+		Label: "free-cb-encoder",
+	})
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	cb, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// FreeCommandBuffer should not panic. After this the command buffer handle
+	// is invalid.
+	device.FreeCommandBuffer(cb)
+}
+
+// =============================================================================
+// Device.WaitIdle — released device
+// Covers device_native.go WaitIdle guard clause
+// =============================================================================
+
+func TestWaitIdleReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	err := device.WaitIdle()
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("WaitIdle after Release: got %v, want ErrReleased", err)
+	}
+}
+
+// =============================================================================
+// Device.PushErrorScope / PopErrorScope — nested scopes
+// Covers device_native.go lines 840-848
+// =============================================================================
+
+func TestErrorScopeNestedFilters(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	// Push three nested scopes with different filters.
+	device.PushErrorScope(wgpu.ErrorFilterValidation)
+	device.PushErrorScope(wgpu.ErrorFilterOutOfMemory)
+	device.PushErrorScope(wgpu.ErrorFilterInternal)
+
+	// Pop in reverse order. All should be nil since no errors were generated.
+	for i, name := range []string{"Internal", "OutOfMemory", "Validation"} {
+		gpuErr := device.PopErrorScope()
+		if gpuErr != nil {
+			t.Errorf("PopErrorScope[%d] (%s): got non-nil error: %v", i, name, gpuErr)
+		}
+	}
+}

--- a/coverage_encoder_test.go
+++ b/coverage_encoder_test.go
@@ -1,0 +1,529 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+)
+
+// =============================================================================
+// CopyTextureToBuffer — valid path with real resources
+// Covers encoder_native.go CopyTextureToBuffer lines 178-205
+// (texture/buffer tracking + HAL call)
+// =============================================================================
+
+func TestCopyTextureToBufferValid(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "t2b-src-tex",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	defer tex.Release()
+
+	// RGBA8Unorm = 4 bytes per pixel, 4x4 = 64 bytes
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "t2b-dst-buf",
+		Size:  256,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	regions := []wgpu.BufferTextureCopy{
+		{
+			TextureBase: wgpu.ImageCopyTexture{Texture: tex},
+			BufferLayout: wgpu.ImageDataLayout{
+				Offset:       0,
+				BytesPerRow:  16,
+				RowsPerImage: 4,
+			},
+			Size: wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		},
+	}
+	enc.CopyTextureToBuffer(tex, buf, regions)
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if cmdBuf == nil {
+		t.Fatal("Finish returned nil CommandBuffer")
+	}
+	cmdBuf.Release()
+}
+
+// =============================================================================
+// CopyTextureToTexture — valid path with real textures
+// Covers encoder_native.go CopyTextureToTexture lines 209-235
+// (texture tracking for both src and dst)
+// =============================================================================
+
+func TestCopyTextureToTextureValidPath(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	srcTex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "t2t-src",
+		Size:          wgpu.Extent3D{Width: 8, Height: 8, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture src: %v", err)
+	}
+	defer srcTex.Release()
+
+	dstTex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "t2t-dst",
+		Size:          wgpu.Extent3D{Width: 8, Height: 8, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture dst: %v", err)
+	}
+	defer dstTex.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	regions := []wgpu.TextureCopy{
+		{
+			Source:      wgpu.ImageCopyTexture{Texture: srcTex},
+			Destination: wgpu.ImageCopyTexture{Texture: dstTex},
+			Size:        wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		},
+	}
+	enc.CopyTextureToTexture(srcTex, dstTex, regions)
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	cmdBuf.Release()
+}
+
+// =============================================================================
+// TransitionTextures — with actual barriers
+// Covers encoder_native.go TransitionTextures lines 241-254
+// =============================================================================
+
+func TestTransitionTexturesWithBarrier(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "barrier-tex",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageCopySrc | wgpu.TextureUsageRenderAttachment,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	defer tex.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	barriers := []wgpu.TextureBarrier{
+		{
+			Texture: tex,
+			Range: wgpu.TextureRange{
+				BaseMipLevel:    0,
+				MipLevelCount:   1,
+				BaseArrayLayer:  0,
+				ArrayLayerCount: 1,
+			},
+			Usage: wgpu.TextureUsageTransition{
+				OldUsage: wgpu.TextureUsageRenderAttachment,
+				NewUsage: wgpu.TextureUsageCopySrc,
+			},
+		},
+	}
+	enc.TransitionTextures(barriers)
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	cmdBuf.Release()
+}
+
+// =============================================================================
+// Encoder resource tracking transfer — trackBuffer, trackTexture, trackBindGroup
+// Covers encoder_native.go lines 70-104
+// =============================================================================
+
+func TestEncoderTrackBufferLazyInit(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	srcBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "track-src",
+		Size:  32,
+		Usage: wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer src: %v", err)
+	}
+	defer srcBuf.Release()
+
+	dstBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "track-dst",
+		Size:  32,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer dst: %v", err)
+	}
+	defer dstBuf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// CopyBufferToBuffer triggers trackBuffer for both src and dst.
+	enc.CopyBufferToBuffer(srcBuf, 0, dstBuf, 0, 32)
+
+	// Finish to verify no errors from tracking.
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Verify refs were transferred (encoder is empty after Finish).
+	if enc.TestTrackedRefs() != nil {
+		t.Error("encoder should have nil trackedRefs after Finish")
+	}
+	cmdBuf.Release()
+}
+
+func TestEncoderTrackBindGroupTransfer(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "track-bg-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:   "track-bg",
+		Layout:  bgl,
+		Entries: []wgpu.BindGroupEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	defer bg.Release()
+
+	// Verify bind group is not released.
+	if bg.TestBindGroupReleased() {
+		t.Error("bind group should not be released after creation")
+	}
+}
+
+// =============================================================================
+// DiscardEncoding — drops tracked refs and returns pooled encoder
+// Covers encoder_native.go lines 259-291
+// =============================================================================
+
+func TestDiscardEncodingAfterCopy(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	srcBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "discard-src",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer src: %v", err)
+	}
+	defer srcBuf.Release()
+
+	dstBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "discard-dst",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer dst: %v", err)
+	}
+	defer dstBuf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	enc.CopyBufferToBuffer(srcBuf, 0, dstBuf, 0, 32)
+
+	// Discard instead of Finish — should drop tracked refs.
+	enc.DiscardEncoding()
+
+	// After discard, encoder is released — Finish should fail.
+	_, err = enc.Finish()
+	if err == nil {
+		t.Fatal("Finish after DiscardEncoding should fail")
+	}
+}
+
+// =============================================================================
+// CopyBufferToBuffer — nil src and dst
+// Covers encoder_native.go lines 150-167
+// =============================================================================
+
+func TestCopyBufferToBufferNilSrc(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	dstBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "nil-src-dst",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer dstBuf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// nil src should record deferred error.
+	enc.CopyBufferToBuffer(nil, 0, dstBuf, 0, 64)
+
+	_, err = enc.Finish()
+	if err == nil {
+		t.Fatal("Finish should fail: CopyBufferToBuffer with nil src")
+	}
+}
+
+func TestCopyBufferToBufferNilDst(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	srcBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "nil-dst-src",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer srcBuf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// nil dst should record deferred error.
+	enc.CopyBufferToBuffer(srcBuf, 0, nil, 0, 64)
+
+	_, err = enc.Finish()
+	if err == nil {
+		t.Fatal("Finish should fail: CopyBufferToBuffer with nil dst")
+	}
+}
+
+// =============================================================================
+// CommandBuffer.Release — on nil, on already-released
+// Covers encoder_native.go CommandBuffer.Release lines 447-462
+// =============================================================================
+
+func TestCommandBufferDoubleRelease(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	cmdBuf.Release()
+	// Second Release should be a no-op (halEncoder is nil).
+	cmdBuf.Release()
+}
+
+// =============================================================================
+// Encoder.Finish — error path drops refs
+// Covers encoder_native.go Finish lines 299-340 (error path)
+// =============================================================================
+
+func TestFinishWithEncodingError(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// Record a deferred error via nil src buffer.
+	enc.CopyBufferToBuffer(nil, 0, nil, 0, 64)
+
+	_, err = enc.Finish()
+	if err == nil {
+		t.Fatal("Finish should fail with deferred encoding error")
+	}
+
+	// After Finish error, encoder is released. Further Finish should also fail.
+	_, err = enc.Finish()
+	if err == nil {
+		t.Fatal("second Finish should also fail")
+	}
+}
+
+// =============================================================================
+// Encoder pool interaction — CreateCommandEncoder returns encoder to pool on error
+// Covers device_native.go lines 712-742 (pool acquire/release path)
+// =============================================================================
+
+func TestEncoderPoolRecycling(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	poolSize := device.TestCmdEncoderPoolSize()
+	if poolSize < 0 {
+		t.Skip("no encoder pool configured (mock device)")
+	}
+
+	// Create and finish an encoder.
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Release the command buffer — returns encoder to pool.
+	cmdBuf.Release()
+
+	// Pool should now have at least one encoder.
+	newPoolSize := device.TestCmdEncoderPoolSize()
+	if newPoolSize < 1 {
+		t.Log("pool size after release:", newPoolSize, "(may vary by backend)")
+	}
+}
+
+// =============================================================================
+// Bind group with texture view resources
+// Covers bind_native.go collectBindGroupResources + boundTextures path
+// =============================================================================
+
+func TestCreateBindGroupWithTextureView(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "bg-tv-tex",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageTextureBinding,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	defer tex.Release()
+
+	view, err := device.CreateTextureView(tex, nil)
+	if err != nil {
+		t.Fatalf("CreateTextureView: %v", err)
+	}
+	defer view.Release()
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "bg-tv-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: wgpu.ShaderStageFragment,
+				Texture: &gputypes.TextureBindingLayout{
+					SampleType:    gputypes.TextureSampleTypeFloat,
+					ViewDimension: gputypes.TextureViewDimension2D,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "bg-with-texture",
+		Layout: bgl,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, TextureView: view},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	bg.Release()
+}

--- a/coverage_mapping_test.go
+++ b/coverage_mapping_test.go
@@ -1,0 +1,566 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gogpu/wgpu"
+)
+
+// =============================================================================
+// MapPending — Wait fast path (already resolved)
+// Covers map_pending.go Wait lines 90-118 (fast path + goroutine path)
+// =============================================================================
+
+func TestMapPendingWaitFastPath(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "wait-fast-buf",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapRead | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+
+	pending, err := buf.MapAsync(wgpu.MapModeRead, 0, 64)
+	if err != nil {
+		t.Fatalf("MapAsync: %v", err)
+	}
+	defer pending.Release()
+
+	// Poll to resolve.
+	device.Poll(wgpu.PollWait)
+
+	// Wait should hit the fast path (already resolved).
+	err = pending.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait (fast path): %v", err)
+	}
+}
+
+// =============================================================================
+// MapPending — Wait with goroutine path (unresolved, then resolved)
+// Covers map_pending.go Wait lines 107-117 (doneCh + goroutine path)
+// =============================================================================
+
+func TestMapPendingWaitGoroutinePath(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "wait-goroutine-buf",
+		Size:  64,
+		Usage: wgpu.BufferUsageMapRead | wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	pending, err := buf.MapAsync(wgpu.MapModeRead, 0, 64)
+	if err != nil {
+		t.Fatalf("MapAsync: %v", err)
+	}
+	defer pending.Release()
+
+	// Use a context with a deadline to avoid hanging.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Start a goroutine that polls the device to drive the map forward.
+	go func() {
+		device.Poll(wgpu.PollWait)
+	}()
+
+	// Wait should resolve via the goroutine path.
+	err = pending.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait (goroutine path): %v", err)
+	}
+}
+
+// =============================================================================
+// MapPending — Status idempotent on resolved
+// Covers map_pending.go Status lines 69-83 (resolved cache)
+// =============================================================================
+
+func TestMapPendingStatusIdempotent(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "status-idempotent",
+		Size:             32,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+
+	pending, err := buf.MapAsync(wgpu.MapModeWrite, 0, 32)
+	if err != nil {
+		t.Fatalf("MapAsync: %v", err)
+	}
+	defer pending.Release()
+
+	device.Poll(wgpu.PollWait)
+
+	// Call Status three times — all should return the same result.
+	for i := 0; i < 3; i++ {
+		ready, mapErr := pending.Status()
+		if !ready {
+			t.Errorf("iteration %d: Status should be ready", i)
+		}
+		if mapErr != nil {
+			t.Errorf("iteration %d: Status error: %v", i, mapErr)
+		}
+	}
+}
+
+// =============================================================================
+// MapPending — Release before resolution
+// Covers map_pending.go release() lines 47-56
+// =============================================================================
+
+func TestMapPendingReleaseBeforeResolution(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "release-before-resolve",
+		Size:  64,
+		Usage: wgpu.BufferUsageMapRead | wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	pending, err := buf.MapAsync(wgpu.MapModeRead, 0, 64)
+	if err != nil {
+		t.Fatalf("MapAsync: %v", err)
+	}
+
+	// Release without waiting — should not panic.
+	pending.Release()
+}
+
+// =============================================================================
+// MappedRange — Len() and Offset() on valid range
+// Covers mapped_range.go lines 81-94 (Len, Offset)
+// =============================================================================
+
+func TestMappedRangeLenAndOffset(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "mr-len-offset",
+		Size:             128,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// Map at offset 64, size 32 (both multiples of 8 and 4).
+	rng, err := buf.MappedRange(64, 32)
+	if err != nil {
+		t.Fatalf("MappedRange(64,32): %v", err)
+	}
+
+	if rng.Len() != 32 {
+		t.Errorf("Len() = %d, want 32", rng.Len())
+	}
+	if rng.Offset() != 64 {
+		t.Errorf("Offset() = %d, want 64", rng.Offset())
+	}
+
+	data := rng.Bytes()
+	if data == nil {
+		t.Fatal("Bytes() returned nil on valid range")
+	}
+	if len(data) != 32 {
+		t.Errorf("len(Bytes()) = %d, want 32", len(data))
+	}
+
+	rng.Release()
+}
+
+// =============================================================================
+// MappedRange — generation mismatch after Unmap
+// Covers mapped_range.go Bytes() lines 64-78 (generation check)
+// =============================================================================
+
+func TestMappedRangeGenerationMismatch(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "mr-gen-mismatch",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	rng, err := buf.MappedRange(0, 64)
+	if err != nil {
+		t.Fatalf("MappedRange: %v", err)
+	}
+
+	// Before unmap, Bytes should work.
+	if rng.Bytes() == nil {
+		t.Fatal("Bytes() should be non-nil before Unmap")
+	}
+
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+
+	// After unmap, generation mismatch makes Bytes return nil.
+	if rng.Bytes() != nil {
+		t.Error("Bytes() should return nil after Unmap (generation mismatch)")
+	}
+
+	rng.Release()
+}
+
+// =============================================================================
+// MappedRange — Release resets all fields
+// Covers mapped_range.go Release() lines 102-112
+// =============================================================================
+
+func TestMappedRangeReleaseResets(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "mr-reset",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	rng, err := buf.MappedRange(0, 64)
+	if err != nil {
+		t.Fatalf("MappedRange: %v", err)
+	}
+
+	rng.Release()
+
+	// After Release, all fields should be zero.
+	if rng.Bytes() != nil {
+		t.Error("Bytes() should be nil after Release")
+	}
+	if rng.Len() != 0 {
+		t.Errorf("Len() = %d, want 0 after Release", rng.Len())
+	}
+	if rng.Offset() != 0 {
+		t.Errorf("Offset() = %d, want 0 after Release", rng.Offset())
+	}
+}
+
+// =============================================================================
+// Buffer.Map — synchronous map with PollWait
+// Covers buffer.go Map lines 112-152 (full synchronous path)
+// =============================================================================
+
+func TestBufferMapSynchronous(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "sync-map",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapRead | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// Unmap to allow re-mapping.
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+
+	// Synchronous map should succeed.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err = buf.Map(ctx, wgpu.MapModeRead, 0, 64)
+	if err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+
+	state := buf.MapState()
+	if state != wgpu.MapStateMapped {
+		t.Errorf("MapState after Map = %v, want MapStateMapped", state)
+	}
+
+	rng, err := buf.MappedRange(0, 64)
+	if err != nil {
+		t.Fatalf("MappedRange: %v", err)
+	}
+	data := rng.Bytes()
+	if data == nil {
+		t.Fatal("Bytes() should be non-nil after Map")
+	}
+	if len(data) != 64 {
+		t.Errorf("len(Bytes()) = %d, want 64", len(data))
+	}
+	rng.Release()
+
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap after Map: %v", err)
+	}
+}
+
+// =============================================================================
+// Buffer.Map — range overflow
+// Covers buffer.go Map -> MapAsync -> core.BeginMap overflow check
+// =============================================================================
+
+func TestBufferMapRangeOverflow(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "overflow-map",
+		Size:  64,
+		Usage: wgpu.BufferUsageMapRead | wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// offset + size > buffer size should fail.
+	_, err = buf.MapAsync(wgpu.MapModeRead, 32, 64)
+	if !errors.Is(err, wgpu.ErrMapRangeOverflow) {
+		t.Errorf("MapAsync overflow: got %v, want ErrMapRangeOverflow", err)
+	}
+}
+
+// =============================================================================
+// Buffer.Map — alignment validation
+// Covers buffer.go Map -> MapAsync -> core.BeginMap alignment check
+// =============================================================================
+
+func TestBufferMapAlignmentErrors(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "align-map",
+		Size:  128,
+		Usage: wgpu.BufferUsageMapRead | wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	tests := []struct {
+		name   string
+		offset uint64
+		size   uint64
+	}{
+		{"offset not multiple of 8", 3, 64},
+		{"size not multiple of 4", 0, 5},
+		{"both misaligned", 1, 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := buf.MapAsync(wgpu.MapModeRead, tt.offset, tt.size)
+			if !errors.Is(err, wgpu.ErrMapAlignment) {
+				t.Errorf("got %v, want ErrMapAlignment", err)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Buffer.Unmap — double unmap returns error
+// Covers buffer.go Unmap lines 232-252
+// =============================================================================
+
+func TestBufferDoubleUnmap(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "double-unmap",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("first Unmap: %v", err)
+	}
+
+	// Second unmap should fail (buffer is no longer mapped).
+	err = buf.Unmap()
+	if err == nil {
+		t.Fatal("second Unmap should return error")
+	}
+}
+
+// =============================================================================
+// coreErrToTyped — all error kind mappings
+// Covers map_types.go coreErrToTyped lines 142-173
+// =============================================================================
+
+func TestCoreErrToTypedMapping(t *testing.T) {
+	// This is tested indirectly by verifying that each sentinel error
+	// is distinct, non-nil, and has a meaningful message.
+	allErrors := []struct {
+		name string
+		err  error
+	}{
+		{"AlreadyPending", wgpu.ErrMapAlreadyPending},
+		{"AlreadyMapped", wgpu.ErrMapAlreadyMapped},
+		{"NotMapped", wgpu.ErrMapNotMapped},
+		{"RangeOverlap", wgpu.ErrMapRangeOverlap},
+		{"RangeDetached", wgpu.ErrMapRangeDetached},
+		{"Alignment", wgpu.ErrMapAlignment},
+		{"Canceled", wgpu.ErrMapCanceled},
+		{"Destroyed", wgpu.ErrBufferDestroyed},
+		{"DeviceLost", wgpu.ErrMapDeviceLost},
+		{"InvalidMode", wgpu.ErrMapInvalidMode},
+		{"RangeOverflow", wgpu.ErrMapRangeOverflow},
+	}
+
+	for i, a := range allErrors {
+		if a.err == nil {
+			t.Errorf("[%d] %s is nil", i, a.name)
+		}
+		msg := a.err.Error()
+		if msg == "" {
+			t.Errorf("[%d] %s has empty message", i, a.name)
+		}
+		// Verify uniqueness.
+		for j := i + 1; j < len(allErrors); j++ {
+			if errors.Is(a.err, allErrors[j].err) {
+				t.Errorf("%s == %s (should be distinct)", a.name, allErrors[j].name)
+			}
+		}
+	}
+}
+
+// =============================================================================
+// MapMode and MapState conversions
+// Covers map_types.go MapMode.toInternal and mapStateFromCore
+// =============================================================================
+
+func TestMapModeRead(t *testing.T) {
+	if wgpu.MapModeRead != 1 {
+		t.Errorf("MapModeRead = %d, want 1", wgpu.MapModeRead)
+	}
+}
+
+func TestMapModeWrite(t *testing.T) {
+	if wgpu.MapModeWrite != 2 {
+		t.Errorf("MapModeWrite = %d, want 2", wgpu.MapModeWrite)
+	}
+}
+
+// =============================================================================
+// Buffer.Map with write mode
+// Covers buffer.go Map + map_types.go MapModeWrite path
+// =============================================================================
+
+func TestBufferMapWriteMode(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "map-write",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// Unmap first.
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+
+	// Map with write mode.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err = buf.Map(ctx, wgpu.MapModeWrite, 0, 64)
+	if err != nil {
+		t.Fatalf("Map(Write): %v", err)
+	}
+
+	rng, err := buf.MappedRange(0, 64)
+	if err != nil {
+		t.Fatalf("MappedRange: %v", err)
+	}
+	data := rng.Bytes()
+	if data == nil {
+		t.Fatal("Bytes() nil after Map(Write)")
+	}
+	// Write something to the range.
+	for i := range data {
+		data[i] = byte(i)
+	}
+	rng.Release()
+
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+}

--- a/coverage_pipeline_test.go
+++ b/coverage_pipeline_test.go
@@ -1,0 +1,357 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+)
+
+// =============================================================================
+// RenderPipeline — stripIndexFormat, blendConstantRequired, vertexBuffers count
+// Covers pipeline_native.go lines 58-117 (RenderPipeline fields + Release)
+// =============================================================================
+
+func TestRenderPipelineWithLayout(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	mod, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "rp-layout-shader",
+		WGSL:  "@vertex fn vs_main() -> @builtin(position) vec4f { return vec4f(0.0); }",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer mod.Release()
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "rp-layout-bgl",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	pl, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{
+		Label:            "rp-pipeline-layout",
+		BindGroupLayouts: []*wgpu.BindGroupLayout{bgl},
+	})
+	if err != nil {
+		t.Fatalf("CreatePipelineLayout: %v", err)
+	}
+	defer pl.Release()
+
+	pipeline, err := device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
+		Label:  "rp-with-layout",
+		Layout: pl,
+		Vertex: wgpu.VertexState{Module: mod, EntryPoint: "vs_main"},
+	})
+	if err != nil {
+		t.Fatalf("CreateRenderPipeline: %v", err)
+	}
+	defer pipeline.Release()
+
+	if pipeline == nil {
+		t.Fatal("CreateRenderPipeline with layout returned nil")
+	}
+}
+
+func TestRenderPipelineWithVertexBuffers(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	mod, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "rp-vb-shader",
+		WGSL:  "@vertex fn vs_main() -> @builtin(position) vec4f { return vec4f(0.0); }",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer mod.Release()
+
+	pipeline, err := device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
+		Label: "rp-with-vb",
+		Vertex: wgpu.VertexState{
+			Module:     mod,
+			EntryPoint: "vs_main",
+			Buffers: []wgpu.VertexBufferLayout{
+				{
+					ArrayStride: 16,
+					StepMode:    gputypes.VertexStepModeVertex,
+					Attributes: []gputypes.VertexAttribute{
+						{Format: gputypes.VertexFormatFloat32x4, Offset: 0, ShaderLocation: 0},
+					},
+				},
+				{
+					ArrayStride: 8,
+					StepMode:    gputypes.VertexStepModeVertex,
+					Attributes: []gputypes.VertexAttribute{
+						{Format: gputypes.VertexFormatFloat32x2, Offset: 0, ShaderLocation: 1},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateRenderPipeline: %v", err)
+	}
+	defer pipeline.Release()
+
+	// The pipeline should remember 2 vertex buffer layouts.
+	// We can verify by using SetTestRequiredVertexBuffers if needed,
+	// but the main assertion is that creation succeeds with >1 VB layout.
+	if pipeline == nil {
+		t.Fatal("CreateRenderPipeline with vertex buffers returned nil")
+	}
+}
+
+// =============================================================================
+// ComputePipeline — with layout, with labels
+// Covers pipeline_native.go lines 119-164 (ComputePipeline fields + Release)
+// =============================================================================
+
+func TestComputePipelineWithLayout(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	mod, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "cp-layout-shader",
+		WGSL:  "@compute @workgroup_size(1) fn main() {}",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer mod.Release()
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "cp-layout-bgl",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	pl, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{
+		Label:            "cp-pipeline-layout",
+		BindGroupLayouts: []*wgpu.BindGroupLayout{bgl},
+	})
+	if err != nil {
+		t.Fatalf("CreatePipelineLayout: %v", err)
+	}
+	defer pl.Release()
+
+	pipeline, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Label:      "cp-with-layout",
+		Layout:     pl,
+		Module:     mod,
+		EntryPoint: "main",
+	})
+	if err != nil {
+		// Software backend may not support compute.
+		t.Skipf("CreateComputePipeline not supported: %v", err)
+	}
+	defer pipeline.Release()
+
+	if pipeline == nil {
+		t.Fatal("CreateComputePipeline with layout returned nil")
+	}
+}
+
+// =============================================================================
+// Pipeline ref counting — TestRef() on render/compute pipelines
+// Covers pipeline_native.go ref field initialization
+// =============================================================================
+
+func TestRenderPipelineHasRef(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	mod, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "ref-shader",
+		WGSL:  "@vertex fn vs_main() -> @builtin(position) vec4f { return vec4f(0.0); }",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer mod.Release()
+
+	pipeline, err := device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
+		Label:  "ref-rp",
+		Vertex: wgpu.VertexState{Module: mod, EntryPoint: "vs_main"},
+	})
+	if err != nil {
+		t.Fatalf("CreateRenderPipeline: %v", err)
+	}
+	defer pipeline.Release()
+
+	if pipeline.TestRef() == nil {
+		t.Error("RenderPipeline should have a non-nil ResourceRef after creation")
+	}
+}
+
+func TestComputePipelineHasRef(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	mod, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "ref-cs",
+		WGSL:  "@compute @workgroup_size(1) fn main() {}",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer mod.Release()
+
+	pipeline, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Label:      "ref-cp",
+		Module:     mod,
+		EntryPoint: "main",
+	})
+	if err != nil {
+		t.Skipf("CreateComputePipeline not supported: %v", err)
+	}
+	defer pipeline.Release()
+
+	if pipeline.TestRef() == nil {
+		t.Error("ComputePipeline should have a non-nil ResourceRef after creation")
+	}
+}
+
+// =============================================================================
+// BindGroupLayout compatibility — isCompatibleWith
+// Covers bind_native.go lines 42-55, 60-82
+// =============================================================================
+
+func TestBindGroupLayoutCompatibility(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	entries := []wgpu.BindGroupLayoutEntry{
+		{
+			Binding:    0,
+			Visibility: wgpu.ShaderStageVertex,
+			Buffer: &gputypes.BufferBindingLayout{
+				Type:           gputypes.BufferBindingTypeUniform,
+				MinBindingSize: 16,
+			},
+		},
+	}
+
+	// Two identical layouts should be compatible even if separate objects.
+	bgl1, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "compat-a",
+		Entries: entries,
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout a: %v", err)
+	}
+	defer bgl1.Release()
+
+	bgl2, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "compat-b",
+		Entries: entries,
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout b: %v", err)
+	}
+	defer bgl2.Release()
+
+	// Both should be usable in separate pipelines targeting the same bind group slot.
+	// This tests that the entries copy logic works correctly.
+	if bgl1 == nil || bgl2 == nil {
+		t.Fatal("both layouts should be non-nil")
+	}
+}
+
+// =============================================================================
+// ShaderModule — SPIR-V path (no IR parsing)
+// Covers shader_native.go lines 234-244 (WGSL-specific parsing skipped for SPIRV)
+// =============================================================================
+
+func TestShaderModuleCreationPath(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	// Create with valid WGSL — this exercises the naga parse + lower path.
+	mod, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "wgsl-shader",
+		WGSL:  "@vertex fn vs_main() -> @builtin(position) vec4f { return vec4f(0.0); }",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	mod.Release()
+}
+
+// =============================================================================
+// BindGroup — Release + released flag
+// Covers bind_native.go lines 211-239 (BindGroup.Release path)
+// =============================================================================
+
+func TestBindGroupReleaseIdempotent(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "bg-release-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:   "bg-release-test",
+		Layout:  bgl,
+		Entries: []wgpu.BindGroupEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+
+	bg.Release()
+	bg.Release() // idempotent
+}
+
+func TestBindGroupHasRef(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "bg-ref-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:   "bg-ref-test",
+		Layout:  bgl,
+		Entries: []wgpu.BindGroupEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	defer bg.Release()
+
+	if bg.TestRef() == nil {
+		t.Error("BindGroup should have a non-nil ResourceRef")
+	}
+}

--- a/coverage_wrap_test.go
+++ b/coverage_wrap_test.go
@@ -1,0 +1,335 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gogpu/wgpu"
+)
+
+// =============================================================================
+// NewDeviceFromHAL — nil device + nil queue
+// Covers wrap.go lines 19-25 (nil guard clauses)
+// =============================================================================
+
+func TestNewDeviceFromHALBothNil(t *testing.T) {
+	_, err := wgpu.NewDeviceFromHAL(nil, nil, 0, wgpu.DefaultLimits(), "both-nil")
+	if err == nil {
+		t.Fatal("NewDeviceFromHAL(nil, nil) should fail")
+	}
+}
+
+// =============================================================================
+// NewTextureFromHAL — format preservation for multiple formats
+// Covers wrap.go lines 78-80
+// =============================================================================
+
+func TestNewTextureFromHALFormats(t *testing.T) {
+	formats := []struct {
+		name   string
+		format wgpu.TextureFormat
+	}{
+		{"RGBA8Unorm", wgpu.TextureFormatRGBA8Unorm},
+		{"BGRA8Unorm", wgpu.TextureFormatBGRA8Unorm},
+		{"Depth32Float", wgpu.TextureFormatDepth32Float},
+	}
+
+	for _, tt := range formats {
+		t.Run(tt.name, func(t *testing.T) {
+			tex := wgpu.NewTextureFromHAL(nil, nil, tt.format)
+			if tex == nil {
+				t.Fatal("NewTextureFromHAL returned nil")
+			}
+			if got := tex.Format(); got != tt.format {
+				t.Errorf("Format() = %v, want %v", got, tt.format)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// NewTextureViewFromHAL + NewSamplerFromHAL — nil args
+// Covers wrap.go lines 83-89
+// =============================================================================
+
+func TestNewTextureViewFromHALNilArgs(t *testing.T) {
+	view := wgpu.NewTextureViewFromHAL(nil, nil)
+	if view == nil {
+		t.Fatal("NewTextureViewFromHAL returned nil")
+	}
+}
+
+func TestNewSamplerFromHALNilArgs(t *testing.T) {
+	sampler := wgpu.NewSamplerFromHAL(nil, nil)
+	if sampler == nil {
+		t.Fatal("NewSamplerFromHAL returned nil")
+	}
+}
+
+// =============================================================================
+// NewSurfaceFromHAL — with label
+// Covers wrap.go lines 69-74
+// =============================================================================
+
+func TestNewSurfaceFromHALWithLabel(t *testing.T) {
+	surface := wgpu.NewSurfaceFromHAL(nil, "labeled-surface")
+	if surface == nil {
+		t.Fatal("NewSurfaceFromHAL returned nil")
+	}
+}
+
+// =============================================================================
+// HalDevice / HalQueue — edge cases on live and released device
+// Covers wrap.go lines 92-109
+// =============================================================================
+
+func TestHalDeviceOnLiveDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	// On a live device with HAL, HalDevice should return non-nil.
+	hal := device.HalDevice()
+	if hal == nil {
+		t.Error("HalDevice() should return non-nil on live device")
+	}
+}
+
+func TestHalQueueOnLiveDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	q := device.HalQueue()
+	if q == nil {
+		t.Error("HalQueue() should return non-nil on live device")
+	}
+}
+
+func TestHalDeviceOnReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	hal := device.HalDevice()
+	if hal != nil {
+		t.Error("HalDevice() on released device should return nil")
+	}
+}
+
+func TestHalQueueOnReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	// Queue on released device — should not panic.
+	_ = device.HalQueue()
+}
+
+// =============================================================================
+// Device.CreateCommandEncoder — pool acquire/release integration
+// Covers device_native.go lines 698-742
+// =============================================================================
+
+func TestCreateAndDiscardMultipleEncoders(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	// Create, discard, repeat — exercises pool acquire/release cycle.
+	for i := 0; i < 5; i++ {
+		enc, err := device.CreateCommandEncoder(nil)
+		if err != nil {
+			t.Fatalf("iteration %d: CreateCommandEncoder: %v", i, err)
+		}
+		enc.DiscardEncoding()
+	}
+}
+
+func TestCreateAndFinishMultipleEncoders(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	var cmdBufs []*wgpu.CommandBuffer
+
+	// Create and finish several encoders — exercises pool pressure.
+	for i := 0; i < 3; i++ {
+		enc, err := device.CreateCommandEncoder(nil)
+		if err != nil {
+			t.Fatalf("iteration %d: CreateCommandEncoder: %v", i, err)
+		}
+		cb, err := enc.Finish()
+		if err != nil {
+			t.Fatalf("iteration %d: Finish: %v", i, err)
+		}
+		cmdBufs = append(cmdBufs, cb)
+	}
+
+	// Release all command buffers — encoders return to pool.
+	for _, cb := range cmdBufs {
+		cb.Release()
+	}
+}
+
+// =============================================================================
+// Device.Features and Device.Limits — stability
+// Covers device_native.go lines 51-58
+// =============================================================================
+
+func TestDeviceFeaturesStable(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	f1 := device.Features()
+	f2 := device.Features()
+	if f1 != f2 {
+		t.Errorf("Features() should be stable: %v vs %v", f1, f2)
+	}
+}
+
+func TestDeviceLimitsStable(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	l1 := device.Limits()
+	l2 := device.Limits()
+	if l1.MaxBufferSize != l2.MaxBufferSize {
+		t.Error("Limits() MaxBufferSize should be stable")
+	}
+	if l1.MaxBindGroups != l2.MaxBindGroups {
+		t.Error("Limits() MaxBindGroups should be stable")
+	}
+}
+
+// =============================================================================
+// Released device — all Create* methods return ErrReleased (table-driven)
+// Covers device_native.go guard clauses comprehensively
+// =============================================================================
+
+func TestAllCreateMethodsOnReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{"CreateBuffer", func() error {
+			_, err := device.CreateBuffer(&wgpu.BufferDescriptor{Size: 64, Usage: wgpu.BufferUsageVertex})
+			return err
+		}},
+		{"CreateTexture", func() error {
+			_, err := device.CreateTexture(&wgpu.TextureDescriptor{
+				Size: wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1}, MipLevelCount: 1, SampleCount: 1,
+				Format: wgpu.TextureFormatRGBA8Unorm, Usage: wgpu.TextureUsageTextureBinding,
+			})
+			return err
+		}},
+		{"CreateSampler", func() error {
+			_, err := device.CreateSampler(nil)
+			return err
+		}},
+		{"CreateShaderModule", func() error {
+			_, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{WGSL: "test"})
+			return err
+		}},
+		{"CreateBindGroupLayout", func() error {
+			_, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{})
+			return err
+		}},
+		{"CreatePipelineLayout", func() error {
+			_, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{})
+			return err
+		}},
+		{"CreateBindGroup", func() error {
+			_, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{})
+			return err
+		}},
+		{"CreateRenderPipeline", func() error {
+			_, err := device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{})
+			return err
+		}},
+		{"CreateComputePipeline", func() error {
+			_, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{EntryPoint: "main"})
+			return err
+		}},
+		{"CreateCommandEncoder", func() error {
+			_, err := device.CreateCommandEncoder(nil)
+			return err
+		}},
+		{"CreateFence", func() error {
+			_, err := device.CreateFence()
+			return err
+		}},
+		{"WaitIdle", func() error {
+			return device.WaitIdle()
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn()
+			if !errors.Is(err, wgpu.ErrReleased) {
+				t.Errorf("got %v, want ErrReleased", err)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Nil descriptor tests — table-driven
+// Covers device_native.go nil-desc guard clauses
+// =============================================================================
+
+func TestAllCreateMethodsWithNilDesc(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{"CreateBuffer(nil)", func() error {
+			_, err := device.CreateBuffer(nil)
+			return err
+		}},
+		{"CreateTexture(nil)", func() error {
+			_, err := device.CreateTexture(nil)
+			return err
+		}},
+		{"CreateShaderModule(nil)", func() error {
+			_, err := device.CreateShaderModule(nil)
+			return err
+		}},
+		{"CreateBindGroupLayout(nil)", func() error {
+			_, err := device.CreateBindGroupLayout(nil)
+			return err
+		}},
+		{"CreatePipelineLayout(nil)", func() error {
+			_, err := device.CreatePipelineLayout(nil)
+			return err
+		}},
+		{"CreateBindGroup(nil)", func() error {
+			_, err := device.CreateBindGroup(nil)
+			return err
+		}},
+		{"CreateRenderPipeline(nil)", func() error {
+			_, err := device.CreateRenderPipeline(nil)
+			return err
+		}},
+		{"CreateComputePipeline(nil)", func() error {
+			_, err := device.CreateComputePipeline(nil)
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn()
+			if err == nil {
+				t.Error("expected error for nil descriptor")
+			}
+		})
+	}
+}

--- a/device_test.go
+++ b/device_test.go
@@ -1,0 +1,558 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/gogpu/wgpu"
+)
+
+// =============================================================================
+// Fence lifecycle tests — Device.CreateFence, DestroyFence, ResetFence,
+// GetFenceStatus, WaitForFence
+// Covers device_native.go lines 747-820, fence.go lines 1-30
+// =============================================================================
+
+func TestDeviceCreateFence(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+	if fence == nil {
+		t.Fatal("CreateFence returned nil")
+	}
+	fence.Release()
+}
+
+func TestDeviceCreateFenceReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	fence, err := device.CreateFence()
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("CreateFence after Release: got %v, want ErrReleased", err)
+	}
+	if fence != nil {
+		t.Error("CreateFence after Release should return nil")
+	}
+}
+
+func TestFenceReleaseIdempotent(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+
+	// First release succeeds.
+	fence.Release()
+	// Second release is a no-op (idempotent).
+	fence.Release()
+}
+
+func TestDeviceDestroyFence(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+
+	// DestroyFence is the deprecated path that calls fence.Release().
+	device.DestroyFence(fence)
+	// Second call should not panic.
+	device.DestroyFence(fence)
+}
+
+func TestDeviceDestroyFenceNil(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	// DestroyFence(nil) should not panic.
+	device.DestroyFence(nil)
+}
+
+func TestDeviceResetFence(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+	defer fence.Release()
+
+	// ResetFence on a valid fence should succeed.
+	if err := device.ResetFence(fence); err != nil {
+		t.Fatalf("ResetFence: %v", err)
+	}
+}
+
+func TestDeviceResetFenceReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+	defer fence.Release()
+
+	device.Release()
+
+	err = device.ResetFence(fence)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("ResetFence after Release: got %v, want ErrReleased", err)
+	}
+}
+
+func TestDeviceResetFenceNilFence(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	err := device.ResetFence(nil)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("ResetFence(nil): got %v, want ErrReleased", err)
+	}
+}
+
+func TestDeviceResetFenceReleasedFence(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+
+	fence.Release()
+	err = device.ResetFence(fence)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("ResetFence on released fence: got %v, want ErrReleased", err)
+	}
+}
+
+func TestDeviceGetFenceStatus(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+	defer fence.Release()
+
+	// GetFenceStatus on a freshly created fence should not error.
+	_, err = device.GetFenceStatus(fence)
+	if err != nil {
+		t.Fatalf("GetFenceStatus: %v", err)
+	}
+}
+
+func TestDeviceGetFenceStatusReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+	defer fence.Release()
+
+	device.Release()
+
+	_, err = device.GetFenceStatus(fence)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("GetFenceStatus after Release: got %v, want ErrReleased", err)
+	}
+}
+
+func TestDeviceGetFenceStatusNilFence(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	_, err := device.GetFenceStatus(nil)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("GetFenceStatus(nil): got %v, want ErrReleased", err)
+	}
+}
+
+func TestDeviceGetFenceStatusReleasedFence(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+
+	fence.Release()
+
+	_, err = device.GetFenceStatus(fence)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("GetFenceStatus on released fence: got %v, want ErrReleased", err)
+	}
+}
+
+func TestDeviceWaitForFence(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+	defer fence.Release()
+
+	// WaitForFence with a short timeout should return without error.
+	_, err = device.WaitForFence(fence, 0, 10*time.Millisecond)
+	if err != nil {
+		t.Fatalf("WaitForFence: %v", err)
+	}
+}
+
+func TestDeviceWaitForFenceReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+	defer fence.Release()
+
+	device.Release()
+
+	_, err = device.WaitForFence(fence, 0, time.Millisecond)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("WaitForFence after Release: got %v, want ErrReleased", err)
+	}
+}
+
+func TestDeviceWaitForFenceNilFence(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	_, err := device.WaitForFence(nil, 0, time.Millisecond)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("WaitForFence(nil): got %v, want ErrReleased", err)
+	}
+}
+
+func TestDeviceWaitForFenceReleasedFence(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	fence, err := device.CreateFence()
+	if err != nil {
+		t.Fatalf("CreateFence: %v", err)
+	}
+
+	fence.Release()
+
+	_, err = device.WaitForFence(fence, 0, time.Millisecond)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("WaitForFence on released fence: got %v, want ErrReleased", err)
+	}
+}
+
+// =============================================================================
+// FreeCommandBuffer — Device.FreeCommandBuffer
+// Covers device_native.go lines 822-838
+// =============================================================================
+
+func TestDeviceFreeCommandBufferNil(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	// FreeCommandBuffer(nil) should not panic.
+	device.FreeCommandBuffer(nil)
+}
+
+func TestDeviceFreeCommandBufferReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	// FreeCommandBuffer on released device should not panic.
+	device.FreeCommandBuffer(nil)
+}
+
+func TestDeviceFreeCommandBuffer(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// FreeCommandBuffer should not panic on a valid command buffer.
+	device.FreeCommandBuffer(cmdBuf)
+}
+
+// =============================================================================
+// Released device extended tests — fence operations on released device
+// Covers device_native.go fence guard clauses
+// =============================================================================
+
+func TestReleasedDeviceFenceOperations(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{"CreateFence", func() error {
+			_, err := device.CreateFence()
+			return err
+		}},
+		{"ResetFence_nil", func() error {
+			return device.ResetFence(nil)
+		}},
+		{"GetFenceStatus_nil", func() error {
+			_, err := device.GetFenceStatus(nil)
+			return err
+		}},
+		{"WaitForFence_nil", func() error {
+			_, err := device.WaitForFence(nil, 0, time.Millisecond)
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn()
+			if !errors.Is(err, wgpu.ErrReleased) {
+				t.Errorf("got %v, want ErrReleased", err)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Device.Poll tests — Covers device_native.go lines 942-961
+// =============================================================================
+
+func TestDevicePollOnNilDevice(t *testing.T) {
+	// Ensure Poll on a nil-ish device does not panic.
+	var device *wgpu.Device
+	result := device.Poll(wgpu.PollPoll)
+	if result {
+		t.Error("Poll on nil device should return false")
+	}
+}
+
+func TestDevicePollWait(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	// Poll(PollWait) with no pending operations should return quickly.
+	result := device.Poll(wgpu.PollWait)
+	// No maps in flight, expect false.
+	if result {
+		t.Error("PollWait with no pending maps should return false")
+	}
+}
+
+func TestDevicePollPoll(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	// Poll(PollPoll) with no pending operations should return immediately.
+	result := device.Poll(wgpu.PollPoll)
+	if result {
+		t.Error("PollPoll with no pending maps should return false")
+	}
+}
+
+// =============================================================================
+// Device.CreatePipelineLayout validation
+// Covers device_native.go lines 286-331
+// =============================================================================
+
+func TestDeviceCreatePipelineLayoutReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	_, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{
+		Label: "released-layout",
+	})
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("CreatePipelineLayout after Release: got %v, want ErrReleased", err)
+	}
+}
+
+func TestDeviceCreatePipelineLayoutNilDesc(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	_, err := device.CreatePipelineLayout(nil)
+	if err == nil {
+		t.Fatal("CreatePipelineLayout(nil) should return error")
+	}
+}
+
+// =============================================================================
+// Device.CreateBindGroup validation
+// Covers device_native.go lines 334-436
+// =============================================================================
+
+func TestDeviceCreateBindGroupReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	_, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label: "released-bg",
+	})
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("CreateBindGroup after Release: got %v, want ErrReleased", err)
+	}
+}
+
+func TestDeviceCreateBindGroupNilDesc(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	_, err := device.CreateBindGroup(nil)
+	if err == nil {
+		t.Fatal("CreateBindGroup(nil) should return error")
+	}
+}
+
+// =============================================================================
+// Device.CreateTextureView validation
+// Covers device_native.go lines 126-157
+// =============================================================================
+
+func TestDeviceCreateTextureViewReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	_, err := device.CreateTextureView(nil, nil)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("CreateTextureView after Release: got %v, want ErrReleased", err)
+	}
+}
+
+func TestDeviceCreateTextureViewNilTexture(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	_, err := device.CreateTextureView(nil, nil)
+	if err == nil {
+		t.Fatal("CreateTextureView(nil texture) should return error")
+	}
+}
+
+func TestDeviceCreateTextureView(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "view-texture",
+		Size:          wgpu.Extent3D{Width: 16, Height: 16, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageTextureBinding,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	defer tex.Release()
+
+	view, err := device.CreateTextureView(tex, nil)
+	if err != nil {
+		t.Fatalf("CreateTextureView: %v", err)
+	}
+	if view == nil {
+		t.Fatal("CreateTextureView returned nil")
+	}
+	view.Release()
+}
+
+func TestDeviceCreateTextureViewWithDescriptor(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "view-desc-texture",
+		Size:          wgpu.Extent3D{Width: 32, Height: 32, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageTextureBinding,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	defer tex.Release()
+
+	view, err := device.CreateTextureView(tex, &wgpu.TextureViewDescriptor{
+		Label:           "test-view",
+		Format:          wgpu.TextureFormatRGBA8Unorm,
+		BaseMipLevel:    0,
+		MipLevelCount:   1,
+		BaseArrayLayer:  0,
+		ArrayLayerCount: 1,
+	})
+	if err != nil {
+		t.Fatalf("CreateTextureView with desc: %v", err)
+	}
+	if view == nil {
+		t.Fatal("CreateTextureView with desc returned nil")
+	}
+	view.Release()
+}
+
+// =============================================================================
+// Wrap tests — NewDeviceFromHAL, NewSurfaceFromHAL, etc.
+// Covers wrap.go lines 19-109
+// =============================================================================
+
+func TestNewDeviceFromHALNilDevice(t *testing.T) {
+	_, err := wgpu.NewDeviceFromHAL(nil, nil, 0, wgpu.DefaultLimits(), "test")
+	if err == nil {
+		t.Fatal("NewDeviceFromHAL(nil device) should fail")
+	}
+}
+
+func TestHalDeviceOnNilQueue(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	// HalQueue returns nil when queue is not HAL-backed. On mock device
+	// the queue may be nil.
+	_ = device.HalQueue()
+}

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -1,0 +1,513 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/wgpu"
+)
+
+// =============================================================================
+// CommandEncoder copy and barrier operations
+// Covers encoder_native.go missed lines (CopyTextureToTexture,
+// CopyTextureToBuffer, TransitionTextures, trackBuffer/trackTexture/
+// trackBindGroup transfer to CommandBuffer)
+// =============================================================================
+
+func TestCopyTextureToTextureNilSrc(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "copy-dst-tex",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	defer tex.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// nil src should record a deferred error.
+	enc.CopyTextureToTexture(nil, tex, nil)
+
+	_, err = enc.Finish()
+	if err == nil {
+		t.Fatal("Finish should fail: CopyTextureToTexture with nil src")
+	}
+}
+
+func TestCopyTextureToTextureNilDst(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "copy-src-tex",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	defer tex.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// nil dst should record a deferred error.
+	enc.CopyTextureToTexture(tex, nil, nil)
+
+	_, err = enc.Finish()
+	if err == nil {
+		t.Fatal("Finish should fail: CopyTextureToTexture with nil dst")
+	}
+}
+
+func TestCopyTextureToTextureValid(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	srcTex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "copy-t2t-src",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture src: %v", err)
+	}
+	defer srcTex.Release()
+
+	dstTex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "copy-t2t-dst",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture dst: %v", err)
+	}
+	defer dstTex.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	regions := []wgpu.TextureCopy{
+		{
+			Source:      wgpu.ImageCopyTexture{Texture: srcTex},
+			Destination: wgpu.ImageCopyTexture{Texture: dstTex},
+			Size:        wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		},
+	}
+	enc.CopyTextureToTexture(srcTex, dstTex, regions)
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Command buffer should not be nil.
+	if cmdBuf == nil {
+		t.Fatal("Finish returned nil CommandBuffer")
+	}
+	cmdBuf.Release()
+}
+
+func TestCopyTextureToBufferNilSrc(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "copy-t2b-dst",
+		Size:  256,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// nil src texture should record a deferred error.
+	enc.CopyTextureToBuffer(nil, buf, nil)
+
+	_, err = enc.Finish()
+	if err == nil {
+		t.Fatal("Finish should fail: CopyTextureToBuffer with nil src")
+	}
+}
+
+func TestCopyTextureToBufferNilDst(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "copy-t2b-src",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	defer tex.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// nil dst buffer should record a deferred error.
+	enc.CopyTextureToBuffer(tex, nil, nil)
+
+	_, err = enc.Finish()
+	if err == nil {
+		t.Fatal("Finish should fail: CopyTextureToBuffer with nil dst")
+	}
+}
+
+func TestTransitionTexturesEmpty(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// Empty barriers should be a no-op.
+	enc.TransitionTextures(nil)
+	enc.TransitionTextures([]wgpu.TextureBarrier{})
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if cmdBuf == nil {
+		t.Fatal("Finish returned nil")
+	}
+	cmdBuf.Release()
+}
+
+func TestTransitionTexturesReleasedEncoder(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// Consume the encoder.
+	_, err = enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// TransitionTextures on a consumed encoder should be a no-op (released=true).
+	enc.TransitionTextures(nil)
+}
+
+// =============================================================================
+// CommandEncoder resource tracking — trackBuffer, trackTexture, trackBindGroup
+// Covers encoder_native.go lines 70-104 (tracking map initialization + transfer)
+// =============================================================================
+
+func TestEncoderTrackedRefsTransferOnFinish(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	srcBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "tracked-src",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer src: %v", err)
+	}
+	defer srcBuf.Release()
+
+	dstBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "tracked-dst",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer dst: %v", err)
+	}
+	defer dstBuf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	enc.CopyBufferToBuffer(srcBuf, 0, dstBuf, 0, 64)
+
+	// After encoding, encoder should have tracked refs.
+	refs := enc.TestTrackedRefs()
+	if len(refs) == 0 {
+		t.Log("encoder tracked refs may be nil on mock device (no core.Buffer.Ref)")
+	}
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// After Finish, encoder refs should be transferred to CommandBuffer.
+	if enc.TestTrackedRefs() != nil {
+		t.Error("encoder tracked refs should be nil after Finish")
+	}
+
+	// CommandBuffer should carry the refs.
+	cbRefs := cmdBuf.TestTrackedRefs()
+	if len(refs) > 0 && len(cbRefs) == 0 {
+		t.Error("command buffer should carry tracked refs from encoder")
+	}
+
+	cmdBuf.Release()
+}
+
+func TestCommandBufferReleaseFull(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Release should free the HAL encoder and tracked refs.
+	cmdBuf.Release()
+
+	// After Release, halEncoder should be nil.
+	if cmdBuf.TestHALEncoder() != nil {
+		t.Error("halEncoder should be nil after Release")
+	}
+	if cmdBuf.TestTrackedRefs() != nil {
+		t.Error("trackedRefs should be nil after Release")
+	}
+}
+
+func TestCommandBufferReleaseNil(t *testing.T) {
+	// Release on nil CommandBuffer should not panic.
+	var cb *wgpu.CommandBuffer
+	cb.Release()
+}
+
+// =============================================================================
+// DiscardEncoding tests
+// Covers encoder_native.go lines 259-291
+// =============================================================================
+
+func TestDiscardEncodingReleasedEncoder(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// Finish consumes the encoder.
+	_, err = enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// DiscardEncoding on a consumed encoder should be a no-op.
+	enc.DiscardEncoding()
+}
+
+func TestDiscardEncodingDropsTrackedRefs(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	srcBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "discard-src",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer src: %v", err)
+	}
+	defer srcBuf.Release()
+
+	dstBuf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "discard-dst",
+		Size:  64,
+		Usage: wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer dst: %v", err)
+	}
+	defer dstBuf.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	enc.CopyBufferToBuffer(srcBuf, 0, dstBuf, 0, 64)
+
+	enc.DiscardEncoding()
+
+	// After discard, Finish should fail (encoder is released).
+	_, err = enc.Finish()
+	if err == nil {
+		t.Fatal("Finish after DiscardEncoding should fail")
+	}
+}
+
+// =============================================================================
+// BeginRenderPass / BeginComputePass on released encoder
+// Covers encoder_native.go released guard clauses
+// =============================================================================
+
+func TestBeginRenderPassReleasedEncoder(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	_, _ = enc.Finish()
+
+	_, err = enc.BeginRenderPass(nil)
+	if err == nil {
+		t.Fatal("BeginRenderPass on consumed encoder should fail")
+	}
+}
+
+func TestBeginComputePassReleasedEncoder(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	_, _ = enc.Finish()
+
+	_, err = enc.BeginComputePass(nil)
+	if err == nil {
+		t.Fatal("BeginComputePass on consumed encoder should fail")
+	}
+}
+
+// =============================================================================
+// CopyBufferToBuffer on released encoder — no-op
+// Covers encoder_native.go line 147
+// =============================================================================
+
+func TestCopyBufferToBufferReleasedEncoder(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// Consume the encoder.
+	_, _ = enc.Finish()
+
+	// CopyBufferToBuffer on released encoder is a no-op.
+	enc.CopyBufferToBuffer(nil, 0, nil, 0, 0)
+}
+
+// =============================================================================
+// CopyTextureToTexture on released encoder — no-op
+// Covers encoder_native.go line 211
+// =============================================================================
+
+func TestCopyTextureToTextureReleasedEncoder(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	_, _ = enc.Finish()
+
+	// CopyTextureToTexture on released encoder is a no-op.
+	enc.CopyTextureToTexture(nil, nil, nil)
+}
+
+// =============================================================================
+// CopyTextureToBuffer on released encoder — no-op
+// Covers encoder_native.go line 181
+// =============================================================================
+
+func TestCopyTextureToBufferReleasedEncoder(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	_, _ = enc.Finish()
+
+	// CopyTextureToBuffer on released encoder is a no-op.
+	enc.CopyTextureToBuffer(nil, nil, nil)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.5.0
 	github.com/gogpu/gputypes v0.5.0
-	github.com/gogpu/naga v0.17.8
+	github.com/gogpu/naga v0.17.10
 	golang.org/x/sys v0.43.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.17.8 h1:twxjkEMd4wL+ayIOb/U4jglQ37pHAcDv4sKAWbaXaQI=
-github.com/gogpu/naga v0.17.8/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.17.10 h1:dJjMXb7b5ybSK8XbsiCA5aUVIAvLHjJg129FB1Ocz/I=
+github.com/gogpu/naga v0.17.10/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/mapping_test.go
+++ b/mapping_test.go
@@ -1,0 +1,611 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gogpu/wgpu"
+)
+
+// =============================================================================
+// MapPending lifecycle tests
+// Covers map_pending.go missed lines (Status, Wait, Release, nil guards)
+// =============================================================================
+
+func TestMapPendingStatusOnNil(t *testing.T) {
+	// A nil MapPending should return ready=true with ErrMapCanceled.
+	var pending *wgpu.MapPending
+	ready, err := pending.Status()
+	if !ready {
+		t.Error("Status on nil MapPending should return ready=true")
+	}
+	if !errors.Is(err, wgpu.ErrMapCanceled) {
+		t.Errorf("Status on nil: got %v, want ErrMapCanceled", err)
+	}
+}
+
+func TestMapPendingWaitOnNil(t *testing.T) {
+	// A nil MapPending.Wait should return ErrMapCanceled.
+	var pending *wgpu.MapPending
+	err := pending.Wait(context.Background())
+	if !errors.Is(err, wgpu.ErrMapCanceled) {
+		t.Errorf("Wait on nil: got %v, want ErrMapCanceled", err)
+	}
+}
+
+func TestMapPendingReleaseOnNil(t *testing.T) {
+	// Release on nil should not panic.
+	var pending *wgpu.MapPending
+	pending.Release()
+}
+
+func TestMapPendingStatusResolvesImmediately(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "pending-status-buf",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapRead | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// Unmap so we can MapAsync.
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+
+	pending, err := buf.MapAsync(wgpu.MapModeRead, 0, 64)
+	if err != nil {
+		t.Fatalf("MapAsync: %v", err)
+	}
+	defer pending.Release()
+
+	// Poll to drive the map to completion.
+	device.Poll(wgpu.PollWait)
+
+	ready, mapErr := pending.Status()
+	if !ready {
+		t.Error("Status should be ready after PollWait")
+	}
+	if mapErr != nil {
+		t.Errorf("Status error: %v", mapErr)
+	}
+}
+
+func TestMapPendingStatusCachedAfterResolve(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "pending-cached-buf",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapRead | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+
+	pending, err := buf.MapAsync(wgpu.MapModeRead, 0, 64)
+	if err != nil {
+		t.Fatalf("MapAsync: %v", err)
+	}
+	defer pending.Release()
+
+	device.Poll(wgpu.PollWait)
+
+	// First call resolves.
+	ready1, _ := pending.Status()
+	// Second call returns cached result.
+	ready2, _ := pending.Status()
+
+	if !ready1 || !ready2 {
+		t.Error("both Status calls should return ready=true")
+	}
+}
+
+func TestMapPendingWaitResolvesImmediately(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "pending-wait-buf",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapRead | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+
+	pending, err := buf.MapAsync(wgpu.MapModeRead, 0, 64)
+	if err != nil {
+		t.Fatalf("MapAsync: %v", err)
+	}
+	defer pending.Release()
+
+	// Poll first so it resolves.
+	device.Poll(wgpu.PollWait)
+
+	// Wait after resolve returns cached result.
+	err = pending.Wait(context.Background())
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+}
+
+func TestMapPendingWaitContextCancel(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "pending-cancel-buf",
+		Size:  64,
+		Usage: wgpu.BufferUsageMapRead | wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	pending, err := buf.MapAsync(wgpu.MapModeRead, 0, 64)
+	if err != nil {
+		t.Fatalf("MapAsync: %v", err)
+	}
+	defer pending.Release()
+
+	// Use an already-canceled context.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Poll once to check.
+	device.Poll(wgpu.PollPoll)
+
+	err = pending.Wait(ctx)
+	// Should return context cancellation or map success (if resolved during poll).
+	if err != nil && !errors.Is(err, context.Canceled) {
+		t.Errorf("Wait with canceled ctx: got %v, want context.Canceled or nil", err)
+	}
+}
+
+// =============================================================================
+// MapMode conversion tests
+// Covers map_types.go MapMode.toInternal and mapStateFromCore
+// =============================================================================
+
+func TestMapModeConstants(t *testing.T) {
+	if wgpu.MapModeRead != 1 {
+		t.Errorf("MapModeRead = %d, want 1", wgpu.MapModeRead)
+	}
+	if wgpu.MapModeWrite != 2 {
+		t.Errorf("MapModeWrite = %d, want 2", wgpu.MapModeWrite)
+	}
+}
+
+func TestMapStateConstants(t *testing.T) {
+	// Verify the enum values are stable.
+	if wgpu.MapStateUnmapped != 0 {
+		t.Errorf("MapStateUnmapped = %d, want 0", wgpu.MapStateUnmapped)
+	}
+	if wgpu.MapStatePending != 1 {
+		t.Errorf("MapStatePending = %d, want 1", wgpu.MapStatePending)
+	}
+	if wgpu.MapStateMapped != 2 {
+		t.Errorf("MapStateMapped = %d, want 2", wgpu.MapStateMapped)
+	}
+	if wgpu.MapStateDestroyed != 3 {
+		t.Errorf("MapStateDestroyed = %d, want 3", wgpu.MapStateDestroyed)
+	}
+}
+
+func TestPollTypeConstants(t *testing.T) {
+	if wgpu.PollPoll != 0 {
+		t.Errorf("PollPoll = %d, want 0", wgpu.PollPoll)
+	}
+	if wgpu.PollWait != 1 {
+		t.Errorf("PollWait = %d, want 1", wgpu.PollWait)
+	}
+}
+
+// =============================================================================
+// Typed error mapping tests (coreErrToTyped coverage)
+// Covers map_types.go lines 142-173
+// =============================================================================
+
+func TestMappingErrorSentinels(t *testing.T) {
+	// Verify all mapping error sentinels are distinct and non-nil.
+	errs := []error{
+		wgpu.ErrMapAlreadyPending,
+		wgpu.ErrMapAlreadyMapped,
+		wgpu.ErrMapNotMapped,
+		wgpu.ErrMapRangeOverlap,
+		wgpu.ErrMapRangeDetached,
+		wgpu.ErrMapAlignment,
+		wgpu.ErrMapCanceled,
+		wgpu.ErrBufferDestroyed,
+		wgpu.ErrMapDeviceLost,
+		wgpu.ErrMapInvalidMode,
+		wgpu.ErrMapRangeOverflow,
+	}
+
+	for i, err := range errs {
+		if err == nil {
+			t.Errorf("mapping error sentinel [%d] is nil", i)
+		}
+		for j := i + 1; j < len(errs); j++ {
+			if errors.Is(errs[i], errs[j]) {
+				t.Errorf("mapping error sentinel [%d] (%v) equals [%d] (%v)", i, errs[i], j, errs[j])
+			}
+		}
+	}
+}
+
+func TestMappingErrorMessages(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantSub string
+	}{
+		{"AlreadyPending", wgpu.ErrMapAlreadyPending, "already pending"},
+		{"AlreadyMapped", wgpu.ErrMapAlreadyMapped, "already mapped"},
+		{"NotMapped", wgpu.ErrMapNotMapped, "not mapped"},
+		{"RangeOverlap", wgpu.ErrMapRangeOverlap, "overlaps"},
+		{"RangeDetached", wgpu.ErrMapRangeDetached, "detached"},
+		{"Alignment", wgpu.ErrMapAlignment, "aligned"},
+		{"Canceled", wgpu.ErrMapCanceled, "canceled"},
+		{"Destroyed", wgpu.ErrBufferDestroyed, "destroyed"},
+		{"DeviceLost", wgpu.ErrMapDeviceLost, "device lost"},
+		{"InvalidMode", wgpu.ErrMapInvalidMode, "MAP_READ/MAP_WRITE"},
+		{"RangeOverflow", wgpu.ErrMapRangeOverflow, "exceeds"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tt.err.Error()
+			if msg == "" {
+				t.Error("error message is empty")
+			}
+		})
+	}
+}
+
+// =============================================================================
+// MappedRange tests — Bytes(), Len(), Offset(), Release()
+// Covers mapped_range.go missed lines
+// =============================================================================
+
+func TestMappedRangeOnNil(t *testing.T) {
+	var mr *wgpu.MappedRange
+
+	if got := mr.Bytes(); got != nil {
+		t.Errorf("nil MappedRange.Bytes() = %v, want nil", got)
+	}
+	if got := mr.Len(); got != 0 {
+		t.Errorf("nil MappedRange.Len() = %d, want 0", got)
+	}
+	if got := mr.Offset(); got != 0 {
+		t.Errorf("nil MappedRange.Offset() = %d, want 0", got)
+	}
+
+	// Release on nil should not panic.
+	mr.Release()
+}
+
+func TestMappedRangeValid(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "mr-valid",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	rng, err := buf.MappedRange(0, 64)
+	if err != nil {
+		t.Fatalf("MappedRange: %v", err)
+	}
+
+	if rng.Len() != 64 {
+		t.Errorf("Len() = %d, want 64", rng.Len())
+	}
+	if rng.Offset() != 0 {
+		t.Errorf("Offset() = %d, want 0", rng.Offset())
+	}
+
+	data := rng.Bytes()
+	if data == nil {
+		t.Fatal("Bytes() returned nil on valid mapped range")
+	}
+	if len(data) != 64 {
+		t.Errorf("len(Bytes()) = %d, want 64", len(data))
+	}
+
+	rng.Release()
+}
+
+func TestMappedRangeDetachedAfterUnmap(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "mr-detach",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	rng, err := buf.MappedRange(0, 64)
+	if err != nil {
+		t.Fatalf("MappedRange: %v", err)
+	}
+
+	// Bytes should be valid before unmap.
+	if rng.Bytes() == nil {
+		t.Fatal("Bytes() should be non-nil before Unmap")
+	}
+
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+
+	// After unmap, generation mismatch should cause Bytes() to return nil.
+	if rng.Bytes() != nil {
+		t.Error("Bytes() should return nil after Unmap (generation mismatch)")
+	}
+
+	rng.Release()
+}
+
+func TestMappedRangeAfterRelease(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "mr-after-release",
+		Size:             32,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	rng, err := buf.MappedRange(0, 32)
+	if err != nil {
+		t.Fatalf("MappedRange: %v", err)
+	}
+
+	rng.Release()
+
+	// After Release, the MappedRange is pooled and zeroed.
+	// Bytes/Len/Offset should return zero values.
+	if rng.Bytes() != nil {
+		t.Error("Bytes() should return nil after Release")
+	}
+}
+
+func TestMappedRangeAlignmentError(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "mr-align",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// Offset not multiple of 8 should fail.
+	_, err = buf.MappedRange(3, 4)
+	if !errors.Is(err, wgpu.ErrMapAlignment) {
+		t.Errorf("MappedRange(offset=3): got %v, want ErrMapAlignment", err)
+	}
+
+	// Size not multiple of 4 should fail.
+	_, err = buf.MappedRange(0, 5)
+	if !errors.Is(err, wgpu.ErrMapAlignment) {
+		t.Errorf("MappedRange(size=5): got %v, want ErrMapAlignment", err)
+	}
+}
+
+func TestMappedRangeOnUnmappedBuffer(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "mr-unmapped",
+		Size:  64,
+		Usage: wgpu.BufferUsageVertex,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// Buffer is not mapped — MappedRange should fail.
+	_, err = buf.MappedRange(0, 64)
+	if err == nil {
+		t.Fatal("MappedRange on unmapped buffer should fail")
+	}
+}
+
+func TestMappedRangeOnNilBuffer(t *testing.T) {
+	var buf *wgpu.Buffer
+	_, err := buf.MappedRange(0, 64)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("MappedRange on nil buffer: got %v, want ErrReleased", err)
+	}
+}
+
+// =============================================================================
+// Buffer.Map error paths
+// Covers buffer.go Map/MapAsync missed lines
+// =============================================================================
+
+func TestBufferMapOnNilBuffer(t *testing.T) {
+	var buf *wgpu.Buffer
+	err := buf.Map(context.Background(), wgpu.MapModeRead, 0, 64)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("Map on nil buffer: got %v, want ErrReleased", err)
+	}
+}
+
+func TestBufferMapAsyncOnNilBuffer(t *testing.T) {
+	var buf *wgpu.Buffer
+	_, err := buf.MapAsync(wgpu.MapModeRead, 0, 64)
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("MapAsync on nil buffer: got %v, want ErrReleased", err)
+	}
+}
+
+func TestBufferUnmapOnNilBuffer(t *testing.T) {
+	var buf *wgpu.Buffer
+	err := buf.Unmap()
+	if !errors.Is(err, wgpu.ErrReleased) {
+		t.Errorf("Unmap on nil buffer: got %v, want ErrReleased", err)
+	}
+}
+
+func TestBufferMapWrongUsage(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	// Buffer without MapRead usage.
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "map-wrong-usage",
+		Size:  64,
+		Usage: wgpu.BufferUsageVertex,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	_, err = buf.MapAsync(wgpu.MapModeRead, 0, 64)
+	if !errors.Is(err, wgpu.ErrMapInvalidMode) {
+		t.Errorf("MapAsync wrong usage: got %v, want ErrMapInvalidMode", err)
+	}
+}
+
+func TestBufferMapAlreadyMapped(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "map-already-mapped",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// Buffer is already mapped from MappedAtCreation.
+	_, err = buf.MapAsync(wgpu.MapModeWrite, 0, 64)
+	if !errors.Is(err, wgpu.ErrMapAlreadyMapped) {
+		t.Errorf("MapAsync on already mapped: got %v, want ErrMapAlreadyMapped", err)
+	}
+}
+
+func TestBufferMapContextAlreadyCanceled(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "map-ctx-cancel",
+		Size:  64,
+		Usage: wgpu.BufferUsageMapRead | wgpu.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// Already-canceled context should return error immediately.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = buf.Map(ctx, wgpu.MapModeRead, 0, 64)
+	if err == nil {
+		t.Fatal("Map with already-canceled context should fail")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Map with canceled ctx: got %v, want context.Canceled", err)
+	}
+}
+
+func TestBufferMapNilContext(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "map-nil-ctx",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapRead | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	// Unmap first so we can map.
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+
+	// nil context should be replaced with Background.
+	//nolint:staticcheck // intentionally testing nil context
+	err = buf.Map(nil, wgpu.MapModeRead, 0, 64)
+	if err != nil {
+		t.Fatalf("Map with nil context should succeed: %v", err)
+	}
+}

--- a/resource_test.go
+++ b/resource_test.go
@@ -1,0 +1,595 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+)
+
+// =============================================================================
+// Buffer accessor tests — Size(), Usage(), MapState(), Label()
+// Covers buffer.go missed lines
+// =============================================================================
+
+func TestBufferAccessorsTableDriven(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tests := []struct {
+		name  string
+		label string
+		size  uint64
+		usage wgpu.BufferUsage
+	}{
+		{"small_vertex", "small-vertex-buf", 64, wgpu.BufferUsageVertex | wgpu.BufferUsageCopyDst},
+		{"large_storage", "large-storage-buf", 4096, wgpu.BufferUsageStorage | wgpu.BufferUsageCopyDst},
+		{"uniform_buffer", "uniform-buf", 256, wgpu.BufferUsageUniform | wgpu.BufferUsageCopyDst},
+		{"minimal_size", "min-buf", 4, wgpu.BufferUsageCopyDst},
+		{"copysrc_copydst", "copy-buf", 128, wgpu.BufferUsageCopySrc | wgpu.BufferUsageCopyDst},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+				Label: tt.label,
+				Size:  tt.size,
+				Usage: tt.usage,
+			})
+			if err != nil {
+				t.Fatalf("CreateBuffer: %v", err)
+			}
+			defer buf.Release()
+
+			if got := buf.Size(); got != tt.size {
+				t.Errorf("Size() = %d, want %d", got, tt.size)
+			}
+			if got := buf.Usage(); got != tt.usage {
+				t.Errorf("Usage() = %v, want %v", got, tt.usage)
+			}
+			if got := buf.Label(); got != tt.label {
+				t.Errorf("Label() = %q, want %q", got, tt.label)
+			}
+		})
+	}
+}
+
+func TestBufferMapStateUnmapped(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "mapstate-unmapped",
+		Size:  64,
+		Usage: wgpu.BufferUsageVertex,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	state := buf.MapState()
+	if state != wgpu.MapStateUnmapped {
+		t.Errorf("MapState() = %v, want MapStateUnmapped", state)
+	}
+}
+
+func TestBufferMapStateMappedAtCreation(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "mapstate-mapped",
+		Size:             64,
+		Usage:            wgpu.BufferUsageMapWrite | wgpu.BufferUsageCopySrc,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	state := buf.MapState()
+	if state != wgpu.MapStateMapped {
+		t.Errorf("MapState() for MappedAtCreation = %v, want MapStateMapped", state)
+	}
+}
+
+func TestBufferMapStateOnNilBuffer(t *testing.T) {
+	// MapState on nil buffer should return Unmapped without panic.
+	var buf *wgpu.Buffer
+	state := buf.MapState()
+	if state != wgpu.MapStateUnmapped {
+		t.Errorf("MapState() on nil buffer = %v, want MapStateUnmapped", state)
+	}
+}
+
+func TestBufferReleaseTrackesReleasedFlag(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "release-tracked",
+		Size:  64,
+		Usage: wgpu.BufferUsageVertex,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+
+	if buf.TestReleased() {
+		t.Error("buffer should not be released before Release()")
+	}
+
+	buf.Release()
+	if !buf.TestReleased() {
+		t.Error("buffer should be released after Release()")
+	}
+
+	// Double release should not change state or panic.
+	buf.Release()
+	if !buf.TestReleased() {
+		t.Error("buffer should remain released after double Release()")
+	}
+}
+
+// =============================================================================
+// Texture accessor tests
+// Covers texture_native.go missed lines
+// =============================================================================
+
+func TestTextureFormat(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tests := []struct {
+		name   string
+		format wgpu.TextureFormat
+	}{
+		{"RGBA8Unorm", wgpu.TextureFormatRGBA8Unorm},
+		{"BGRA8Unorm", wgpu.TextureFormatBGRA8Unorm},
+		{"R8Unorm", gputypes.TextureFormatR8Unorm},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+				Label:         "fmt-" + tt.name,
+				Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+				MipLevelCount: 1,
+				SampleCount:   1,
+				Dimension:     wgpu.TextureDimension2D,
+				Format:        tt.format,
+				Usage:         wgpu.TextureUsageTextureBinding,
+			})
+			if err != nil {
+				t.Fatalf("CreateTexture: %v", err)
+			}
+			defer tex.Release()
+
+			if got := tex.Format(); got != tt.format {
+				t.Errorf("Format() = %v, want %v", got, tt.format)
+			}
+		})
+	}
+}
+
+func TestTextureHalTexture(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "hal-texture",
+		Size:          wgpu.Extent3D{Width: 8, Height: 8, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageTextureBinding,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+
+	// Before release, HalTexture should be non-nil.
+	if tex.HalTexture() == nil {
+		t.Error("HalTexture() is nil on live texture")
+	}
+
+	tex.Release()
+
+	// After release, HalTexture should be nil.
+	if tex.HalTexture() != nil {
+		t.Error("HalTexture() should be nil after Release")
+	}
+}
+
+func TestTextureReleaseIdempotent(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "release-tex",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageTextureBinding,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+
+	tex.Release()
+	tex.Release() // idempotent — should not panic
+}
+
+// =============================================================================
+// TextureView accessor tests
+// Covers texture_native.go TextureView missed lines
+// =============================================================================
+
+func TestTextureViewHalTextureView(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "tv-hal-texture",
+		Size:          wgpu.Extent3D{Width: 8, Height: 8, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageTextureBinding,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	defer tex.Release()
+
+	view, err := device.CreateTextureView(tex, nil)
+	if err != nil {
+		t.Fatalf("CreateTextureView: %v", err)
+	}
+
+	if view.HalTextureView() == nil {
+		t.Error("HalTextureView() is nil on live view")
+	}
+
+	view.Release()
+
+	if view.HalTextureView() != nil {
+		t.Error("HalTextureView() should be nil after Release")
+	}
+}
+
+func TestTextureViewReleaseIdempotent(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "tv-release-tex",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageTextureBinding,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	defer tex.Release()
+
+	view, err := device.CreateTextureView(tex, nil)
+	if err != nil {
+		t.Fatalf("CreateTextureView: %v", err)
+	}
+
+	view.Release()
+	view.Release() // idempotent
+}
+
+// =============================================================================
+// Sampler tests
+// Covers sampler_native.go missed lines
+// =============================================================================
+
+func TestSamplerReleaseIdempotent(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	sampler, err := device.CreateSampler(&wgpu.SamplerDescriptor{
+		Label: "release-sampler",
+	})
+	if err != nil {
+		t.Fatalf("CreateSampler: %v", err)
+	}
+
+	sampler.Release()
+	sampler.Release() // idempotent
+}
+
+func TestSamplerWithFullDescriptor(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	sampler, err := device.CreateSampler(&wgpu.SamplerDescriptor{
+		Label:        "full-sampler",
+		AddressModeU: gputypes.AddressModeRepeat,
+		AddressModeV: gputypes.AddressModeRepeat,
+		AddressModeW: gputypes.AddressModeRepeat,
+		MagFilter:    gputypes.FilterModeLinear,
+		MinFilter:    gputypes.FilterModeLinear,
+		MipmapFilter: gputypes.FilterModeLinear,
+		LodMinClamp:  0.0,
+		LodMaxClamp:  32.0,
+	})
+	if err != nil {
+		t.Fatalf("CreateSampler: %v", err)
+	}
+	defer sampler.Release()
+
+	if sampler == nil {
+		t.Fatal("CreateSampler returned nil for full descriptor")
+	}
+}
+
+// =============================================================================
+// ShaderModule tests
+// Covers shader_native.go missed lines
+// =============================================================================
+
+func TestShaderModuleReleaseIdempotent(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	mod, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "release-shader",
+		WGSL:  "@vertex fn vs_main() -> @builtin(position) vec4f { return vec4f(0.0); }",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+
+	mod.Release()
+	mod.Release() // idempotent
+}
+
+func TestShaderModuleEmptyWGSL(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+
+	// Empty WGSL with no SPIRV should fail validation.
+	_, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "empty-shader",
+		WGSL:  "",
+	})
+	if err == nil {
+		t.Fatal("CreateShaderModule with empty WGSL should fail")
+	}
+}
+
+// =============================================================================
+// RenderPipeline tests
+// Covers pipeline_native.go missed lines
+// =============================================================================
+
+func TestRenderPipelineReleaseIdempotent(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	mod, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "rp-shader",
+		WGSL:  "@vertex fn vs_main() -> @builtin(position) vec4f { return vec4f(0.0); }",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer mod.Release()
+
+	pipeline, err := device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
+		Label:  "release-rp",
+		Vertex: wgpu.VertexState{Module: mod, EntryPoint: "vs_main"},
+	})
+	if err != nil {
+		t.Fatalf("CreateRenderPipeline: %v", err)
+	}
+
+	pipeline.Release()
+	pipeline.Release() // idempotent
+}
+
+// =============================================================================
+// ComputePipeline tests
+// Covers pipeline_native.go missed lines
+// =============================================================================
+
+func TestComputePipelineReleaseIdempotent(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	mod, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "cp-shader",
+		WGSL:  "@compute @workgroup_size(1) fn main() {}",
+	})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer mod.Release()
+
+	pipeline, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Label:      "release-cp",
+		Module:     mod,
+		EntryPoint: "main",
+	})
+	if err != nil {
+		// Software backend does not support compute pipelines.
+		t.Skipf("CreateComputePipeline not supported by this backend: %v", err)
+	}
+
+	pipeline.Release()
+	pipeline.Release() // idempotent
+}
+
+// =============================================================================
+// BindGroupLayout tests
+// Covers bind_native.go missed lines
+// =============================================================================
+
+func TestBindGroupLayoutReleaseIdempotent(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	layout, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "release-bgl",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+
+	layout.Release()
+	layout.Release() // idempotent
+}
+
+// =============================================================================
+// PipelineLayout tests
+// Covers bind_native.go missed lines
+// =============================================================================
+
+func TestPipelineLayoutReleaseIdempotent(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "pl-bgl",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	layout, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{
+		Label:            "release-pl",
+		BindGroupLayouts: []*wgpu.BindGroupLayout{bgl},
+	})
+	if err != nil {
+		t.Fatalf("CreatePipelineLayout: %v", err)
+	}
+
+	layout.Release()
+	layout.Release() // idempotent
+}
+
+// =============================================================================
+// BindGroup with buffer and texture resource collection
+// Covers bind_native.go collectBindGroupResources + boundBuffers/boundTextures
+// =============================================================================
+
+func TestBindGroupWithBufferResource(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "bg-buffer",
+		Size:  64,
+		Usage: wgpu.BufferUsageUniform | wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	bufLayoutEntry := wgpu.BindGroupLayoutEntry{
+		Binding:    0,
+		Visibility: wgpu.ShaderStageVertex | wgpu.ShaderStageFragment,
+		Buffer: &gputypes.BufferBindingLayout{
+			Type:           gputypes.BufferBindingTypeUniform,
+			MinBindingSize: 64,
+		},
+	}
+
+	layout, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "bg-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{bufLayoutEntry},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer layout.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "bg-with-buffer",
+		Layout: layout,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: buf, Offset: 0, Size: 64},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	defer bg.Release()
+
+	if bg.TestBindGroupReleased() {
+		t.Error("bind group should not be released immediately after creation")
+	}
+}
+
+func TestBindGroupReleaseTrackesReleasedFlag(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	layout, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "bg-release-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer layout.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:   "bg-release-test",
+		Layout:  layout,
+		Entries: []wgpu.BindGroupEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+
+	if bg.TestBindGroupReleased() {
+		t.Error("bind group should not be released before Release()")
+	}
+
+	bg.Release()
+
+	if !bg.TestBindGroupReleased() {
+		t.Error("bind group should be released after Release()")
+	}
+
+	// Double release should not panic.
+	bg.Release()
+}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -1,0 +1,80 @@
+//go:build !(js && wasm)
+
+package wgpu_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/wgpu"
+)
+
+// =============================================================================
+// wrap.go coverage — NewDeviceFromHAL, NewSurfaceFromHAL, etc.
+// Covers wrap.go 0% coverage (37 missed lines)
+// =============================================================================
+
+func TestNewDeviceFromHALNilDeviceError(t *testing.T) {
+	_, err := wgpu.NewDeviceFromHAL(nil, nil, 0, wgpu.DefaultLimits(), "nil-device")
+	if err == nil {
+		t.Fatal("NewDeviceFromHAL(nil device, nil queue) should fail")
+	}
+}
+
+func TestNewSurfaceFromHAL(t *testing.T) {
+	surface := wgpu.NewSurfaceFromHAL(nil, "test-surface")
+	if surface == nil {
+		t.Fatal("NewSurfaceFromHAL returned nil")
+	}
+}
+
+func TestNewTextureFromHAL(t *testing.T) {
+	tex := wgpu.NewTextureFromHAL(nil, nil, wgpu.TextureFormatRGBA8Unorm)
+	if tex == nil {
+		t.Fatal("NewTextureFromHAL returned nil")
+	}
+}
+
+func TestNewTextureViewFromHAL(t *testing.T) {
+	view := wgpu.NewTextureViewFromHAL(nil, nil)
+	if view == nil {
+		t.Fatal("NewTextureViewFromHAL returned nil")
+	}
+}
+
+func TestNewSamplerFromHAL(t *testing.T) {
+	sampler := wgpu.NewSamplerFromHAL(nil, nil)
+	if sampler == nil {
+		t.Fatal("NewSamplerFromHAL returned nil")
+	}
+}
+
+func TestDeviceHalDeviceAndQueue(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	// HalDevice may return nil or non-nil depending on backend.
+	// The test ensures no panic.
+	_ = device.HalDevice()
+	_ = device.HalQueue()
+}
+
+func TestDeviceHalDeviceReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	// HalDevice on released device should return nil without panic.
+	hal := device.HalDevice()
+	if hal != nil {
+		t.Error("HalDevice on released device should return nil")
+	}
+}
+
+func TestDeviceHalQueueReleasedDevice(t *testing.T) {
+	_, _, device := newDevice(t)
+	device.Release()
+
+	// HalQueue on released device — queue may be freed or nil.
+	// Should not panic.
+	_ = device.HalQueue()
+}


### PR DESCRIPTION
## Summary

- **Test coverage boost** (COV-004) — core 73.9%→85.5%, root 69.1%→78.4%. 8 new test files, ~160 real tests
- **Metal entry point fix** (#168 by @k-chimi) — naga MSL renames reserved words, HAL now uses translated names
- **Codecov ignore fix** — `hal/` excluded properly, badge reflects testable code
- **naga** v0.17.8 → v0.17.10

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] `gofmt -l .` — clean
- [ ] CI