### PR TITLE
feat: SPIR-V interpreter + lint zero + resource guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Software backend: SPIR-V interpreter** (FEAT-SW-004) — minimal CPU interpreter for
+  SPIR-V shaders. Executes vertex and fragment shaders on the software backend, enabling
+  `gogpu/examples/triangle` to render a visible triangle with `GOGPU_GRAPHICS_API=software`.
+  Handles: OpLoad/OpStore, OpAccessChain, OpCompositeConstruct/Extract, OpConvertUToF,
+  arithmetic ops, `@builtin(vertex_index)` input, `@builtin(position)` output, `@location(0)`
+  fragment output. WGSL automatically compiled to SPIR-V via naga when no SPIR-V provided.
+  ~650 LOC, 14 tests, 2 benchmarks. Phase 1 of 5 (triangle only — uniforms, textures,
+  control flow, compute planned).
+
+### Fixed
+
+- **Software backend: RGBA→BGRA pixel order** in SPIR-V draw path — raster pipeline outputs
+  RGBA but framebuffer is BGRA for GDI/X11. Without swap, red triangle appeared blue.
+
 ## [0.26.12] - 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ import _ "github.com/gogpu/wgpu/hal/software"
 - Blending (13 factors, 5 operations)
 - 6-plane frustum clipping (Sutherland-Hodgman)
 - 8x8 tile-based parallel rendering
+- **SPIR-V interpreter** — executes vertex/fragment shaders on CPU (Phase 1: basic shaders)
 
 **Windowed Presentation:**
 - **Windows:** DWM-safe `CreateDIBSection` + `BitBlt` (SDL3/Qt6 pattern), zero-copy into GDI bitmap

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -53,6 +53,7 @@
 ✅ **Zero-init workgroup memory** — WebGPU spec default, plumbed through all layers
 ✅ **CopyTextureToTexture public API** — DMA hardware copy with sub-region support
 ✅ **Vulkan relay semaphores** — GPU-side submission ordering (Mesa ANV workaround)
+✅ **Software SPIR-V interpreter** — CPU shader execution for vertex/fragment (Phase 1: triangle)
 ✅ **WASM platform split** — root package _native.go/_browser.go, core/hal excluded from WASM build
 ✅ **Vulkan command buffer free list** — batch alloc 16 CBs, pool reset (Khronos/NVIDIA/ARM/Mesa/Rust parity)
 ✅ **Damage-aware surface presentation** — `PresentWithDamage()` with compositor dirty rects. First WebGPU implementation. Software + Vulkan + DX12 + GLES backends.

--- a/core/command.go
+++ b/core/command.go
@@ -67,17 +67,24 @@ const (
 	CommandEncoderStatusConsumed
 )
 
+// Common state names shared between CommandEncoderStatus and CommandEncoderPassState.
+const (
+	stateRecording = "Recording"
+	stateFinished  = "Finished"
+	stateError     = "Error"
+)
+
 // String returns a human-readable representation of the status.
 func (s CommandEncoderStatus) String() string {
 	switch s {
 	case CommandEncoderStatusRecording:
-		return "Recording"
+		return stateRecording
 	case CommandEncoderStatusLocked:
 		return "Locked"
 	case CommandEncoderStatusFinished:
-		return "Finished"
+		return stateFinished
 	case CommandEncoderStatusError:
-		return "Error"
+		return stateError
 	case CommandEncoderStatusConsumed:
 		return "Consumed"
 	default:

--- a/core/hub.go
+++ b/core/hub.go
@@ -433,6 +433,26 @@ func (h *Hub) UnregisterQuerySet(id QuerySetID) (QuerySet, error) {
 	return h.querySets.Unregister(id)
 }
 
+// Resource type keys used in ResourceCounts and diagnostics.
+const (
+	keyAdapters         = "adapters"
+	keyDevices          = "devices"
+	keyQueues           = "queues"
+	keyBuffers          = "buffers"
+	keyTextures         = "textures"
+	keyTextureViews     = "textureViews"
+	keySamplers         = "samplers"
+	keyBindGroupLayouts = "bindGroupLayouts"
+	keyPipelineLayouts  = "pipelineLayouts"
+	keyBindGroups       = "bindGroups"
+	keyShaderModules    = "shaderModules"
+	keyRenderPipelines  = "renderPipelines"
+	keyComputePipelines = "computePipelines"
+	keyCommandEncoders  = "commandEncoders"
+	keyCommandBuffers   = "commandBuffers"
+	keyQuerySets        = "querySets"
+)
+
 // ResourceCounts returns the count of each resource type in the hub.
 // Useful for debugging and diagnostics.
 func (h *Hub) ResourceCounts() map[string]uint64 {
@@ -440,22 +460,22 @@ func (h *Hub) ResourceCounts() map[string]uint64 {
 	defer h.mu.RUnlock()
 
 	return map[string]uint64{
-		"adapters":         h.adapters.Count(),
-		"devices":          h.devices.Count(),
-		"queues":           h.queues.Count(),
-		"buffers":          h.buffers.Count(),
-		"textures":         h.textures.Count(),
-		"textureViews":     h.textureViews.Count(),
-		"samplers":         h.samplers.Count(),
-		"bindGroupLayouts": h.bindGroupLayouts.Count(),
-		"pipelineLayouts":  h.pipelineLayouts.Count(),
-		"bindGroups":       h.bindGroups.Count(),
-		"shaderModules":    h.shaderModules.Count(),
-		"renderPipelines":  h.renderPipelines.Count(),
-		"computePipelines": h.computePipelines.Count(),
-		"commandEncoders":  h.commandEncoders.Count(),
-		"commandBuffers":   h.commandBuffers.Count(),
-		"querySets":        h.querySets.Count(),
+		keyAdapters:         h.adapters.Count(),
+		keyDevices:          h.devices.Count(),
+		keyQueues:           h.queues.Count(),
+		keyBuffers:          h.buffers.Count(),
+		keyTextures:         h.textures.Count(),
+		keyTextureViews:     h.textureViews.Count(),
+		keySamplers:         h.samplers.Count(),
+		keyBindGroupLayouts: h.bindGroupLayouts.Count(),
+		keyPipelineLayouts:  h.pipelineLayouts.Count(),
+		keyBindGroups:       h.bindGroups.Count(),
+		keyShaderModules:    h.shaderModules.Count(),
+		keyRenderPipelines:  h.renderPipelines.Count(),
+		keyComputePipelines: h.computePipelines.Count(),
+		keyCommandEncoders:  h.commandEncoders.Count(),
+		keyCommandBuffers:   h.commandBuffers.Count(),
+		keyQuerySets:        h.querySets.Count(),
 	}
 }
 

--- a/core/resource.go
+++ b/core/resource.go
@@ -1278,15 +1278,15 @@ const (
 func (s CommandEncoderPassState) String() string {
 	switch s {
 	case CommandEncoderPassStateRecording:
-		return "Recording"
+		return stateRecording
 	case CommandEncoderPassStateInRenderPass:
 		return "InRenderPass"
 	case CommandEncoderPassStateInComputePass:
 		return "InComputePass"
 	case CommandEncoderPassStateFinished:
-		return "Finished"
+		return stateFinished
 	case CommandEncoderPassStateError:
-		return "Error"
+		return stateError
 	default:
 		return fmt.Sprintf("Unknown(%d)", s)
 	}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,7 +145,7 @@ Pure Go OpenGL ES 3.0+ / OpenGL 4.3+ implementation.
 CPU-based rasterizer. Always compiled (no build tags required). Pure Go, zero system dependencies.
 
 - `raster/` — Triangle rasterization, blending, depth/stencil, tiling
-- `shader/` — Software shader execution (callback-based)
+- `shader/` — SPIR-V interpreter (CPU shader execution) + legacy callback shaders
 
 Use cases: headless rendering (servers, CI/CD), testing without GPU, embedded systems, fallback when no GPU available.
 

--- a/hal/gles/api.go
+++ b/hal/gles/api.go
@@ -14,6 +14,10 @@ import (
 	"github.com/gogpu/wgpu/hal/gles/wgl"
 )
 
+// vendorUnknown is the placeholder vendor name used when the actual GPU vendor
+// cannot be determined (e.g., no surface available during adapter enumeration).
+const vendorUnknown = "Unknown"
+
 // Backend implements hal.Backend for OpenGL ES / OpenGL 3.3+.
 type Backend struct{}
 
@@ -92,7 +96,7 @@ func (i *Instance) EnumerateAdapters(surfaceHint hal.Surface) []hal.ExposedAdapt
 			Adapter: &Adapter{},
 			Info: gputypes.AdapterInfo{
 				Name:       "OpenGL Adapter",
-				Vendor:     "Unknown",
+				Vendor:     vendorUnknown,
 				VendorID:   0,
 				DeviceID:   0,
 				DeviceType: gputypes.DeviceTypeOther,

--- a/hal/gles/api_linux.go
+++ b/hal/gles/api_linux.go
@@ -14,6 +14,10 @@ import (
 	"github.com/gogpu/wgpu/hal/gles/gl"
 )
 
+// vendorUnknown is the placeholder vendor name used when the actual GPU vendor
+// cannot be determined (e.g., no surface available during adapter enumeration).
+const vendorUnknown = "Unknown"
+
 // Backend implements hal.Backend for OpenGL ES / OpenGL 3.3+ on Linux.
 type Backend struct{}
 
@@ -97,7 +101,7 @@ func (i *Instance) EnumerateAdapters(surfaceHint hal.Surface) []hal.ExposedAdapt
 			Adapter: &Adapter{},
 			Info: gputypes.AdapterInfo{
 				Name:       "OpenGL Adapter",
-				Vendor:     "Unknown",
+				Vendor:     vendorUnknown,
 				VendorID:   0,
 				DeviceID:   0,
 				DeviceType: gputypes.DeviceTypeOther,

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -630,7 +630,7 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 	}
 
 	// Get and set fragment function if present
-	if fragmentModule != nil && desc.Fragment != nil {
+	if fragmentModule != nil && desc.Fragment != nil { //nolint:nestif // sequential Metal pipeline setup
 		// Resolve translated entrypoint name
 		entrypointName := desc.Fragment.EntryPoint
 		if translated, ok := fragmentModule.entrypointNames[entrypointName]; ok {

--- a/hal/software/device.go
+++ b/hal/software/device.go
@@ -3,6 +3,7 @@
 package software
 
 import (
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"sync"
@@ -10,6 +11,7 @@ import (
 	"unsafe"
 
 	"github.com/gogpu/gputypes"
+	naga "github.com/gogpu/naga"
 	"github.com/gogpu/wgpu/hal"
 )
 
@@ -173,8 +175,28 @@ func (d *Device) CreatePipelineLayout(_ *hal.PipelineLayoutDescriptor) (hal.Pipe
 func (d *Device) DestroyPipelineLayout(_ hal.PipelineLayout) {}
 
 // CreateShaderModule creates a software shader module.
+// If the source is WGSL, it compiles to SPIR-V via naga for interpretation.
+// If SPIR-V is provided directly, it is stored as-is.
+// Compilation failure is non-fatal: the module falls back to the existing
+// callback-based shader path (fullscreen blit, vertex buffer draw).
 func (d *Device) CreateShaderModule(desc *hal.ShaderModuleDescriptor) (hal.ShaderModule, error) {
-	return &ShaderModule{desc: desc}, nil
+	sm := &ShaderModule{desc: desc}
+
+	switch {
+	case len(desc.Source.SPIRV) > 0:
+		sm.spirv = desc.Source.SPIRV
+	case desc.Source.WGSL != "":
+		spirvBytes, err := naga.Compile(desc.Source.WGSL)
+		if err == nil && len(spirvBytes)%4 == 0 {
+			sm.spirv = make([]uint32, len(spirvBytes)/4)
+			for i := range sm.spirv {
+				sm.spirv[i] = binary.LittleEndian.Uint32(spirvBytes[i*4:])
+			}
+		}
+		// Compilation failure is non-fatal — existing draw paths don't need SPIR-V.
+	}
+
+	return sm, nil
 }
 
 // DestroyShaderModule is a no-op.

--- a/hal/software/draw.go
+++ b/hal/software/draw.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/hal/software/raster"
+	"github.com/gogpu/wgpu/hal/software/shader"
 )
 
 // executeDraw is the core draw implementation.
@@ -22,10 +23,18 @@ func (r *RenderPassEncoder) executeDraw(vertexCount, firstVertex uint32) {
 		return
 	}
 
-	// Fullscreen blit path: no vertex buffer → blit bound texture to target.
-	// The blit overwrites every destination pixel, so applyClear is redundant.
-	// Skipping clear saves ~18% CPU (8 MB memset at 1920x1080).
+	// No vertex buffer bound — try SPIR-V shader path or fullscreen blit.
 	if r.vertexBufs[0].buffer == nil {
+		// SPIR-V path: when the pipeline has no vertex buffer layouts but has
+		// a shader module with SPIR-V (e.g. @builtin(vertex_index) triangle),
+		// execute the shader via the interpreter.
+		if r.executeSPIRVDraw(target, vertexCount, firstVertex) {
+			return
+		}
+
+		// Fullscreen blit path: blit bound texture to target.
+		// The blit overwrites every destination pixel, so applyClear is redundant.
+		// Skipping clear saves ~18% CPU (8 MB memset at 1920x1080).
 		if r.executeFullscreenBlit(target) {
 			r.cleared = true
 			return
@@ -196,6 +205,8 @@ func (r *RenderPassEncoder) executeVertexDraw(target *Texture, vertexCount, firs
 
 	layouts := r.pipeline.desc.Vertex.Buffers
 	if len(layouts) == 0 {
+		// No vertex buffer layouts — this draw was already handled by
+		// executeSPIRVDraw in executeDraw. Nothing more to do.
 		return
 	}
 
@@ -454,4 +465,213 @@ func (r *RenderPassEncoder) resolveFragmentColor() [4]float32 {
 	}
 
 	return [4]float32{1, 1, 1, 1} // Default: white.
+}
+
+// executeSPIRVDraw handles draws where vertex positions come from SPIR-V
+// shader execution (e.g. @builtin(vertex_index) with no vertex buffers).
+// Returns true if the draw was handled, false if no SPIR-V module is available.
+func (r *RenderPassEncoder) executeSPIRVDraw(target *Texture, vertexCount, firstVertex uint32) bool {
+	if r.pipeline == nil || r.pipeline.desc == nil {
+		return false
+	}
+
+	// Get the vertex shader module.
+	vsModule, ok := r.pipeline.desc.Vertex.Module.(*ShaderModule)
+	if !ok || vsModule == nil {
+		return false
+	}
+
+	parsed := vsModule.ParsedModule()
+	if parsed == nil {
+		return false
+	}
+
+	// Find the vertex shader entry point.
+	vsEntry := r.pipeline.desc.Vertex.EntryPoint
+	ep, ok := parsed.EntryPoints[vsEntry]
+	if !ok || ep.ExecutionModel != shader.ExecutionModelVertex {
+		return false
+	}
+
+	// Identify input/output variable IDs by their BuiltIn/Location decorations.
+	var vertexIndexVarID uint32
+	var positionVarID uint32
+	hasVertexIndex := false
+	hasPosition := false
+
+	for _, varID := range ep.InterfaceIDs {
+		vi, ok := parsed.Variables[varID]
+		if !ok {
+			continue
+		}
+		builtIn := parsed.GetBuiltIn(varID)
+		switch {
+		case vi.StorageClass == shader.StorageClassInput && builtIn == shader.BuiltInVertexIndex:
+			vertexIndexVarID = varID
+			hasVertexIndex = true
+		case vi.StorageClass == shader.StorageClassOutput && builtIn == shader.BuiltInPosition:
+			positionVarID = varID
+			hasPosition = true
+		}
+	}
+
+	if !hasVertexIndex || !hasPosition {
+		return false
+	}
+
+	// Clear before drawing (triangles may not cover all pixels).
+	if !r.cleared {
+		r.applyClear()
+	}
+
+	w := int(target.width)
+	h := int(target.height)
+
+	pipe := raster.NewPipeline(w, h)
+
+	// Copy current framebuffer so draws composite correctly.
+	target.mu.RLock()
+	existingData := make([]byte, len(target.data))
+	copy(existingData, target.data)
+	target.mu.RUnlock()
+	pipe.Clear(0, 0, 0, 0)
+	for py := 0; py < h; py++ {
+		for px := 0; px < w; px++ {
+			idx := (py*w + px) * 4
+			pipe.SetPixel(px, py, existingData[idx], existingData[idx+1], existingData[idx+2], existingData[idx+3])
+		}
+	}
+
+	// Execute vertex shader for each vertex.
+	vertices := make([]raster.ScreenVertex, 0, vertexCount)
+	for i := uint32(0); i < vertexCount; i++ {
+		vi := firstVertex + i
+
+		inputs := map[uint32]shader.Value{
+			vertexIndexVarID: vi,
+		}
+
+		outputs, err := parsed.Execute(vsEntry, inputs)
+		if err != nil {
+			return false
+		}
+
+		// Extract position from outputs.
+		posVal, ok := outputs[positionVarID]
+		if !ok {
+			return false
+		}
+		pos := shader.Vec4ToFloat32(posVal)
+
+		// NDC to screen transform.
+		// Position is in clip space: x,y in [-1,1], z in [0,1], w=1.
+		// Screen: x = (ndcX+1)/2 * width, y = (1-ndcY)/2 * height (Y flipped).
+		wClip := pos[3]
+		if wClip == 0 {
+			wClip = 1
+		}
+		ndcX := pos[0] / wClip
+		ndcY := pos[1] / wClip
+		ndcZ := pos[2] / wClip
+
+		sx := (ndcX + 1.0) * 0.5 * float32(w)
+		sy := (1.0 - ndcY) * 0.5 * float32(h)
+
+		vertices = append(vertices, raster.ScreenVertex{
+			X: sx,
+			Y: sy,
+			Z: ndcZ,
+			W: 1.0,
+		})
+	}
+
+	// Group into triangles (TriangleList topology).
+	triCount := len(vertices) / 3
+	triangles := make([]raster.Triangle, 0, triCount)
+	for i := 0; i < triCount; i++ {
+		triangles = append(triangles, raster.Triangle{
+			V0: vertices[i*3+0],
+			V1: vertices[i*3+1],
+			V2: vertices[i*3+2],
+		})
+	}
+
+	// Execute fragment shader to determine color.
+	fragColor := r.executeSPIRVFragment()
+
+	pipe.DrawTriangles(triangles, fragColor)
+
+	// Write raster result back to texture in BGRA byte order.
+	// Raster pipeline operates in RGBA; the surface framebuffer is BGRA
+	// (required by GDI BitBlt on Windows and X11 ZPixmap on Linux).
+	target.mu.Lock()
+	for py := 0; py < h; py++ {
+		for px := 0; px < w; px++ {
+			cr, cg, cb, ca := pipe.GetPixel(px, py)
+			idx := (py*w + px) * 4
+			target.data[idx+0] = cb // B
+			target.data[idx+1] = cg // G
+			target.data[idx+2] = cr // R
+			target.data[idx+3] = ca // A
+		}
+	}
+	target.mu.Unlock()
+
+	return true
+}
+
+// executeSPIRVFragment runs the fragment shader entry point to get a color.
+// Falls back to white if no fragment shader is available.
+func (r *RenderPassEncoder) executeSPIRVFragment() [4]float32 {
+	if r.pipeline.desc.Fragment == nil {
+		return [4]float32{1, 1, 1, 1}
+	}
+
+	fsModuleSW, ok := r.pipeline.desc.Fragment.Module.(*ShaderModule)
+	if !ok || fsModuleSW == nil {
+		return [4]float32{1, 1, 1, 1}
+	}
+
+	parsed := fsModuleSW.ParsedModule()
+	if parsed == nil {
+		return [4]float32{1, 1, 1, 1}
+	}
+
+	fsEntry := r.pipeline.desc.Fragment.EntryPoint
+	ep, ok := parsed.EntryPoints[fsEntry]
+	if !ok || ep.ExecutionModel != shader.ExecutionModelFragment {
+		return [4]float32{1, 1, 1, 1}
+	}
+
+	// Find the output variable (location 0).
+	var colorVarID uint32
+	hasColorOut := false
+	for _, varID := range ep.InterfaceIDs {
+		vi, ok := parsed.Variables[varID]
+		if !ok || vi.StorageClass != shader.StorageClassOutput {
+			continue
+		}
+		loc := parsed.GetLocation(varID)
+		if loc == 0 {
+			colorVarID = varID
+			hasColorOut = true
+			break
+		}
+	}
+
+	if !hasColorOut {
+		return [4]float32{1, 1, 1, 1}
+	}
+
+	outputs, err := parsed.Execute(fsEntry, nil)
+	if err != nil {
+		return [4]float32{1, 1, 1, 1}
+	}
+
+	colorVal, ok := outputs[colorVarID]
+	if !ok {
+		return [4]float32{1, 1, 1, 1}
+	}
+
+	return shader.Vec4ToFloat32(colorVal)
 }

--- a/hal/software/draw.go
+++ b/hal/software/draw.go
@@ -4,6 +4,7 @@ package software
 
 import (
 	"encoding/binary"
+	"log/slog"
 	"math"
 
 	"github.com/gogpu/gputypes"
@@ -517,6 +518,23 @@ func (r *RenderPassEncoder) executeSPIRVDraw(target *Texture, vertexCount, first
 
 	if !hasVertexIndex || !hasPosition {
 		return false
+	}
+
+	// Check ALL module-level variables (not just EntryPoint InterfaceIDs,
+	// which in SPIR-V < 1.4 omit Uniform/UniformConstant variables).
+	// The interpreter only supports Input/Output/Function storage classes.
+	// Shaders using Uniform, UniformConstant (textures/samplers), or
+	// StorageBuffer require bind group resources that the interpreter
+	// cannot provide — fall back to executeFullscreenBlit.
+	for _, vi := range parsed.Variables {
+		switch vi.StorageClass {
+		case shader.StorageClassUniform,
+			shader.StorageClassUniformConstant,
+			shader.StorageClassStorageBuffer:
+			slog.Debug("software: SPIR-V interpreter cannot handle shader with resource bindings",
+				"entryPoint", vsEntry, "storageClass", vi.StorageClass)
+			return false
+		}
 	}
 
 	// Clear before drawing (triangles may not cover all pixels).

--- a/hal/software/resource.go
+++ b/hal/software/resource.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/hal"
+	"github.com/gogpu/wgpu/hal/software/shader"
 )
 
 // nextResourceID is a monotonic counter for assigning unique IDs to software resources.
@@ -301,7 +302,28 @@ type BindGroup struct {
 }
 
 // ShaderModule stores shader source for the software backend.
+// When SPIR-V bytecode is available (directly or compiled from WGSL via naga),
+// the parsed Module is cached for use by the SPIR-V interpreter in draw calls.
 type ShaderModule struct {
 	Resource
-	desc *hal.ShaderModuleDescriptor
+	desc   *hal.ShaderModuleDescriptor
+	spirv  []uint32       // SPIR-V bytecode (nil if unavailable)
+	parsed *shader.Module // parsed SPIR-V module (nil until first use)
+}
+
+// ParsedModule returns the parsed SPIR-V module, parsing on first access.
+// Returns nil if no SPIR-V bytecode is available.
+func (sm *ShaderModule) ParsedModule() *shader.Module {
+	if sm.parsed != nil {
+		return sm.parsed
+	}
+	if len(sm.spirv) == 0 {
+		return nil
+	}
+	m, err := shader.ParseModule(sm.spirv)
+	if err != nil {
+		return nil
+	}
+	sm.parsed = m
+	return sm.parsed
 }

--- a/hal/software/shader/doc.go
+++ b/hal/software/shader/doc.go
@@ -1,10 +1,17 @@
 //go:build !(js && wasm)
 
-// Package shader provides callback-based shader execution for the software backend.
+// Package shader provides shader execution for the software backend.
 //
-// Since there is no SPIR-V interpreter in Go, we use callback functions to define
-// vertex and fragment shaders. This allows testing the rendering pipeline without
-// full shader compilation.
+// Two execution paths are supported:
+//
+//   - SPIR-V interpreter: parses and executes SPIR-V bytecode (compiled from WGSL
+//     via naga). This enables rendering shaders that use @builtin(vertex_index) with
+//     no vertex buffers (e.g. the gogpu triangle example). See Module, ParseModule,
+//     and Module.Execute.
+//
+//   - Callback shaders: Go functions implementing VertexShaderFunc / FragmentShaderFunc
+//     for programmatic shader definition without SPIR-V. Useful for testing and
+//     built-in effects (solid color, vertex color, textured).
 //
 // # Shader Types
 //

--- a/hal/software/shader/interpreter.go
+++ b/hal/software/shader/interpreter.go
@@ -1,0 +1,700 @@
+//go:build !(js && wasm)
+
+// SPIR-V interpreter for the software backend.
+//
+// Executes a single SPIR-V entry point with provided inputs and returns outputs.
+// This is a minimal interpreter sufficient for the gogpu triangle shader:
+//   - OpLoad / OpStore for variable access
+//   - OpAccessChain for array/composite indexing
+//   - OpCompositeConstruct / OpCompositeExtract for building/decomposing vectors
+//   - OpVariable for local storage
+//   - OpBranch for unconditional jumps between basic blocks
+//   - OpConvertUToF for uint-to-float conversion
+//   - Basic arithmetic: OpFAdd, OpFSub, OpFMul, OpFDiv, OpFNegate
+//   - Basic integer arithmetic: OpIAdd, OpISub, OpIMul
+//
+// Control flow beyond OpBranch (loops, conditionals) is NOT implemented.
+
+package shader
+
+import (
+	"fmt"
+	"math"
+)
+
+// Execute runs the named entry point with the given input variable values.
+//
+// inputs maps variable ID (decorated with BuiltIn or Location) to its value.
+// Returns a map of output variable ID to its value after execution.
+//
+// For a vertex shader, inputs typically contain:
+//   - vertex_index variable ID -> Uint32 value
+//
+// Outputs typically contain:
+//   - position variable ID -> Vec4 value
+func (m *Module) Execute(entryPoint string, inputs map[uint32]Value) (map[uint32]Value, error) {
+	ep, ok := m.EntryPoints[entryPoint]
+	if !ok {
+		return nil, fmt.Errorf("spirv: entry point %q not found", entryPoint)
+	}
+
+	fn, ok := m.Functions[entryPoint]
+	if !ok {
+		return nil, fmt.Errorf("spirv: function body for %q not found", entryPoint)
+	}
+
+	interp := &interpreter{
+		module: m,
+		ep:     ep,
+		fn:     fn,
+		values: make(map[uint32]Value, m.Bound),
+		labels: make(map[uint32]int),
+	}
+
+	// Seed constants into the value map.
+	for id, val := range m.Constants {
+		interp.values[id] = val
+	}
+
+	// Build label index for OpBranch targets.
+	for i, inst := range fn.Instructions {
+		if inst.Opcode == OpLabel {
+			interp.labels[inst.ResultID] = i
+		}
+	}
+
+	// Initialize interface variables (inputs/outputs).
+	interp.initVariables(inputs)
+
+	// Execute the function body.
+	if err := interp.run(); err != nil {
+		return nil, err
+	}
+
+	// Collect output values.
+	outputs := make(map[uint32]Value)
+	for _, varID := range ep.InterfaceIDs {
+		vi, ok := m.Variables[varID]
+		if !ok {
+			continue
+		}
+		if vi.StorageClass != StorageClassOutput {
+			continue
+		}
+		if ptr, ok := interp.values[varID].(*Pointer); ok {
+			outputs[varID] = ptr.Value
+		}
+	}
+
+	return outputs, nil
+}
+
+// interpreter holds execution state for a single entry point invocation.
+type interpreter struct {
+	module *Module
+	ep     *EntryPoint
+	fn     *Function
+	values map[uint32]Value
+	labels map[uint32]int // label ID -> instruction index
+}
+
+// initVariables sets up input, output, and function-local variables.
+func (interp *interpreter) initVariables(inputs map[uint32]Value) {
+	m := interp.module
+
+	for _, varID := range interp.ep.InterfaceIDs {
+		vi, ok := m.Variables[varID]
+		if !ok {
+			continue
+		}
+
+		switch vi.StorageClass {
+		case StorageClassInput:
+			// Seed from caller-provided inputs.
+			val := inputs[varID]
+			if val == nil {
+				// Default zero value based on pointee type.
+				val = zeroValueForVar(m, vi.TypeID)
+			}
+			interp.values[varID] = &Pointer{Value: val}
+
+		case StorageClassOutput:
+			interp.values[varID] = &Pointer{Value: zeroValueForVar(m, vi.TypeID)}
+		}
+	}
+}
+
+// zeroValueForVar creates a zero value matching the pointee type of a pointer type.
+func zeroValueForVar(m *Module, ptrTypeID uint32) Value {
+	ti := m.PointeeType(ptrTypeID)
+	if ti == nil {
+		return Uint32(0)
+	}
+	switch ti.Kind {
+	case TypeFloat:
+		return Float32(0)
+	case TypeInt:
+		if ti.Signed {
+			return Int32(0)
+		}
+		return Uint32(0)
+	case TypeVector:
+		switch ti.Components {
+		case 2:
+			return Vec2{}
+		case 3:
+			return Vec3{}
+		case 4:
+			return Vec4{}
+		}
+	case TypeArray:
+		if ti.Length > 0 {
+			arr := make(Array, ti.Length)
+			for i := range arr {
+				arr[i] = zeroValue(m.Types, ti.ElemType)
+			}
+			return arr
+		}
+	}
+	return Uint32(0)
+}
+
+// run executes instructions sequentially, handling OpBranch for jumps.
+//
+//nolint:maintidx,unparam // Opcode dispatch switch is inherently large. Error return is API contract for future opcodes.
+func (interp *interpreter) run() error {
+	instructions := interp.fn.Instructions
+	pc := 0
+
+	for pc < len(instructions) {
+		inst := instructions[pc]
+		pc++
+
+		switch inst.Opcode {
+		case OpLabel:
+			// No-op at execution time; labels are already indexed.
+
+		case OpVariable:
+			// Function-local variable: allocate a Pointer with zero value.
+			if len(inst.Operands) < 1 {
+				break
+			}
+			storageClass := inst.Operands[0]
+			if storageClass == StorageClassFunction {
+				val := zeroValueForVar(interp.module, inst.TypeID)
+				interp.values[inst.ResultID] = &Pointer{Value: val}
+			}
+
+		case OpLoad:
+			// OpLoad: type resultID pointer [memory access]
+			if len(inst.Operands) < 1 {
+				break
+			}
+			ptrID := inst.Operands[0]
+			if ptr, ok := interp.values[ptrID].(*Pointer); ok {
+				interp.values[inst.ResultID] = ptr.Value
+			} else {
+				// Direct value fallback (shouldn't happen in valid SPIR-V).
+				interp.values[inst.ResultID] = interp.values[ptrID]
+			}
+
+		case OpStore:
+			// OpStore: pointer value [memory access]
+			if len(inst.Operands) < 2 {
+				break
+			}
+			ptrID := inst.Operands[0]
+			valID := inst.Operands[1]
+			if ptr, ok := interp.values[ptrID].(*Pointer); ok {
+				ptr.Value = interp.values[valID]
+			}
+
+		case OpAccessChain:
+			// OpAccessChain: type resultID base indexes...
+			if len(inst.Operands) < 2 {
+				break
+			}
+			baseID := inst.Operands[0]
+			indexes := inst.Operands[1:]
+			interp.values[inst.ResultID] = interp.accessChain(baseID, indexes)
+
+		case OpCompositeConstruct:
+			// OpCompositeConstruct: type resultID constituents...
+			interp.values[inst.ResultID] = interp.compositeConstruct(inst.TypeID, inst.Operands)
+
+		case OpCompositeExtract:
+			// OpCompositeExtract: type resultID composite indexes...
+			if len(inst.Operands) < 2 {
+				break
+			}
+			compositeID := inst.Operands[0]
+			indexes := inst.Operands[1:]
+			interp.values[inst.ResultID] = interp.compositeExtract(interp.values[compositeID], indexes)
+
+		case OpConvertUToF:
+			// OpConvertUToF: type resultID value
+			if len(inst.Operands) < 1 {
+				break
+			}
+			interp.values[inst.ResultID] = convertToFloat(interp.values[inst.Operands[0]])
+
+		case OpConvertSToF:
+			if len(inst.Operands) < 1 {
+				break
+			}
+			interp.values[inst.ResultID] = convertSignedToFloat(interp.values[inst.Operands[0]])
+
+		case OpConvertFToU:
+			if len(inst.Operands) < 1 {
+				break
+			}
+			interp.values[inst.ResultID] = convertFloatToUint(interp.values[inst.Operands[0]])
+
+		case OpBitcast:
+			if len(inst.Operands) < 1 {
+				break
+			}
+			// For now, bitcast just copies the value (works for same-width types).
+			interp.values[inst.ResultID] = interp.values[inst.Operands[0]]
+
+		case OpFAdd:
+			if len(inst.Operands) >= 2 {
+				interp.values[inst.ResultID] = floatBinOp(interp.values[inst.Operands[0]], interp.values[inst.Operands[1]], func(a, b float32) float32 { return a + b })
+			}
+
+		case OpFSub:
+			if len(inst.Operands) >= 2 {
+				interp.values[inst.ResultID] = floatBinOp(interp.values[inst.Operands[0]], interp.values[inst.Operands[1]], func(a, b float32) float32 { return a - b })
+			}
+
+		case OpFMul:
+			if len(inst.Operands) >= 2 {
+				interp.values[inst.ResultID] = floatBinOp(interp.values[inst.Operands[0]], interp.values[inst.Operands[1]], func(a, b float32) float32 { return a * b })
+			}
+
+		case OpFDiv:
+			if len(inst.Operands) >= 2 {
+				interp.values[inst.ResultID] = floatBinOp(interp.values[inst.Operands[0]], interp.values[inst.Operands[1]], func(a, b float32) float32 { return a / b })
+			}
+
+		case OpFNegate:
+			if len(inst.Operands) >= 1 {
+				interp.values[inst.ResultID] = floatUnaryOp(interp.values[inst.Operands[0]], func(a float32) float32 { return -a })
+			}
+
+		case OpIAdd:
+			if len(inst.Operands) >= 2 {
+				interp.values[inst.ResultID] = intBinOp(interp.values[inst.Operands[0]], interp.values[inst.Operands[1]], func(a, b uint32) uint32 { return a + b })
+			}
+
+		case OpISub:
+			if len(inst.Operands) >= 2 {
+				interp.values[inst.ResultID] = intBinOp(interp.values[inst.Operands[0]], interp.values[inst.Operands[1]], func(a, b uint32) uint32 { return a - b })
+			}
+
+		case OpIMul:
+			if len(inst.Operands) >= 2 {
+				interp.values[inst.ResultID] = intBinOp(interp.values[inst.Operands[0]], interp.values[inst.Operands[1]], func(a, b uint32) uint32 { return a * b })
+			}
+
+		case OpReturn:
+			return nil
+
+		case OpReturnValue:
+			// For void-returning entry points this shouldn't happen,
+			// but handle it gracefully.
+			return nil
+
+		case OpBranch:
+			// OpBranch: target label
+			if len(inst.Operands) < 1 {
+				break
+			}
+			targetLabel := inst.Operands[0]
+			if idx, ok := interp.labels[targetLabel]; ok {
+				pc = idx + 1 // +1 to skip the label instruction itself
+			}
+
+		case OpFunctionParameter, OpFunctionEnd:
+			// No-op during execution.
+
+		case OpSelectionMerge, OpLoopMerge:
+			// Structured control flow hints — no-op for the interpreter.
+
+		case OpBranchConditional:
+			if len(inst.Operands) >= 3 {
+				cond := interp.values[inst.Operands[0]]
+				trueLabel := inst.Operands[1]
+				falseLabel := inst.Operands[2]
+				target := falseLabel
+				if toBool(cond) {
+					target = trueLabel
+				}
+				if idx, ok := interp.labels[target]; ok {
+					pc = idx + 1
+				}
+			}
+
+		case OpSelect:
+			if len(inst.Operands) >= 3 {
+				cond := interp.values[inst.Operands[0]]
+				trueVal := interp.values[inst.Operands[1]]
+				falseVal := interp.values[inst.Operands[2]]
+				if toBool(cond) {
+					interp.values[inst.ResultID] = trueVal
+				} else {
+					interp.values[inst.ResultID] = falseVal
+				}
+			}
+
+		case OpIEqual:
+			if len(inst.Operands) >= 2 {
+				a := toUint32(interp.values[inst.Operands[0]])
+				b := toUint32(interp.values[inst.Operands[1]])
+				interp.values[inst.ResultID] = a == b
+			}
+
+		case OpINotEqual:
+			if len(inst.Operands) >= 2 {
+				a := toUint32(interp.values[inst.Operands[0]])
+				b := toUint32(interp.values[inst.Operands[1]])
+				interp.values[inst.ResultID] = a != b
+			}
+
+		case OpFOrdEqual:
+			if len(inst.Operands) >= 2 {
+				a := toFloat32(interp.values[inst.Operands[0]])
+				b := toFloat32(interp.values[inst.Operands[1]])
+				interp.values[inst.ResultID] = a == b
+			}
+
+		case OpFOrdLessThan:
+			if len(inst.Operands) >= 2 {
+				a := toFloat32(interp.values[inst.Operands[0]])
+				b := toFloat32(interp.values[inst.Operands[1]])
+				interp.values[inst.ResultID] = a < b
+			}
+
+		case OpFOrdGreaterThan:
+			if len(inst.Operands) >= 2 {
+				a := toFloat32(interp.values[inst.Operands[0]])
+				b := toFloat32(interp.values[inst.Operands[1]])
+				interp.values[inst.ResultID] = a > b
+			}
+
+		case OpFOrdLessThanEqual:
+			if len(inst.Operands) >= 2 {
+				a := toFloat32(interp.values[inst.Operands[0]])
+				b := toFloat32(interp.values[inst.Operands[1]])
+				interp.values[inst.ResultID] = a <= b
+			}
+
+		case OpFOrdGreaterThanEqual:
+			if len(inst.Operands) >= 2 {
+				a := toFloat32(interp.values[inst.Operands[0]])
+				b := toFloat32(interp.values[inst.Operands[1]])
+				interp.values[inst.ResultID] = a >= b
+			}
+
+		case OpPhi:
+			// Phi nodes are not needed for the triangle shader (single basic block per branch).
+			// For safety, treat as no-op and let the value remain from whichever predecessor ran.
+
+		default:
+			// Unknown opcodes are skipped. The triangle shader uses a small subset.
+		}
+	}
+
+	return nil
+}
+
+// accessChain navigates into a composite value through a chain of indexes,
+// returning a Pointer to the innermost element.
+func (interp *interpreter) accessChain(baseID uint32, indexes []uint32) *Pointer {
+	baseVal := interp.values[baseID]
+
+	// If base is a Pointer, unwrap.
+	if ptr, ok := baseVal.(*Pointer); ok {
+		baseVal = ptr.Value
+	}
+
+	// Navigate through each index.
+	current := baseVal
+	for _, idxID := range indexes {
+		idx := toUint32(interp.values[idxID])
+		current = indexComposite(current, idx)
+	}
+
+	return &Pointer{Value: current}
+}
+
+// indexComposite extracts element at the given index from a composite value.
+func indexComposite(composite Value, index uint32) Value {
+	switch v := composite.(type) {
+	case Array:
+		if int(index) < len(v) {
+			return v[index]
+		}
+	case Vec2:
+		if index < 2 {
+			return Float32(v[index])
+		}
+	case Vec3:
+		if index < 3 {
+			return Float32(v[index])
+		}
+	case Vec4:
+		if index < 4 {
+			return Float32(v[index])
+		}
+	}
+	return Float32(0)
+}
+
+// compositeConstruct builds a composite value from constituent IDs.
+func (interp *interpreter) compositeConstruct(typeID uint32, constituentIDs []uint32) Value {
+	ti, ok := interp.module.Types[typeID]
+	if !ok {
+		return Vec4{}
+	}
+
+	switch ti.Kind {
+	case TypeVector:
+		// Flatten constituents: each may be scalar or smaller vector.
+		var components []float32
+		for _, id := range constituentIDs {
+			components = appendComponents(components, interp.values[id])
+		}
+		switch ti.Components {
+		case 2:
+			var v Vec2
+			for i := 0; i < 2 && i < len(components); i++ {
+				v[i] = components[i]
+			}
+			return v
+		case 3:
+			var v Vec3
+			for i := 0; i < 3 && i < len(components); i++ {
+				v[i] = components[i]
+			}
+			return v
+		case 4:
+			var v Vec4
+			for i := 0; i < 4 && i < len(components); i++ {
+				v[i] = components[i]
+			}
+			return v
+		}
+
+	case TypeArray:
+		arr := make(Array, len(constituentIDs))
+		for i, id := range constituentIDs {
+			arr[i] = interp.values[id]
+		}
+		return arr
+
+	case TypeStruct:
+		arr := make(Array, len(constituentIDs))
+		for i, id := range constituentIDs {
+			arr[i] = interp.values[id]
+		}
+		return arr
+	}
+
+	return Uint32(0)
+}
+
+// compositeExtract navigates literal indexes to extract a scalar from a composite.
+func (interp *interpreter) compositeExtract(composite Value, indexes []uint32) Value {
+	current := composite
+	for _, idx := range indexes {
+		current = indexComposite(current, idx)
+	}
+	return current
+}
+
+// appendComponents flattens a value into float32 components.
+func appendComponents(dst []float32, val Value) []float32 {
+	switch v := val.(type) {
+	case Float32:
+		return append(dst, v)
+	case Vec2:
+		return append(dst, v[0], v[1])
+	case Vec3:
+		return append(dst, v[0], v[1], v[2])
+	case Vec4:
+		return append(dst, v[0], v[1], v[2], v[3])
+	case Uint32:
+		return append(dst, float32(v))
+	case Int32:
+		return append(dst, float32(v))
+	default:
+		return append(dst, 0)
+	}
+}
+
+// convertToFloat converts an unsigned integer value to float32.
+func convertToFloat(val Value) Value {
+	switch v := val.(type) {
+	case Uint32:
+		return Float32(float32(v))
+	case Int32:
+		return Float32(float32(v))
+	case Float32:
+		return v
+	default:
+		return Float32(0)
+	}
+}
+
+// convertSignedToFloat converts a signed integer value to float32.
+func convertSignedToFloat(val Value) Value {
+	switch v := val.(type) {
+	case Int32:
+		return Float32(float32(v))
+	case Uint32:
+		return Float32(float32(int32(v)))
+	case Float32:
+		return v
+	default:
+		return Float32(0)
+	}
+}
+
+// convertFloatToUint converts a float value to uint32.
+func convertFloatToUint(val Value) Value {
+	switch v := val.(type) {
+	case Float32:
+		return uint32(v)
+	case Uint32:
+		return v
+	case Int32:
+		return uint32(v)
+	default:
+		return Uint32(0)
+	}
+}
+
+// toFloat32 extracts a float32 from a Value.
+func toFloat32(val Value) float32 {
+	switch v := val.(type) {
+	case Float32:
+		return v
+	case Uint32:
+		return float32(v)
+	case Int32:
+		return float32(v)
+	default:
+		return 0
+	}
+}
+
+// toUint32 extracts a uint32 from a Value.
+func toUint32(val Value) uint32 {
+	switch v := val.(type) {
+	case Uint32:
+		return v
+	case Int32:
+		return uint32(v)
+	case Float32:
+		return uint32(v)
+	case bool:
+		if v {
+			return 1
+		}
+		return 0
+	default:
+		return 0
+	}
+}
+
+// toBool converts a Value to boolean.
+func toBool(val Value) bool {
+	switch v := val.(type) {
+	case bool:
+		return v
+	case Uint32:
+		return v != 0
+	case Int32:
+		return v != 0
+	case Float32:
+		return v != 0
+	default:
+		return false
+	}
+}
+
+// floatBinOp applies a binary operation to two float-typed values.
+// Works on scalars and vectors component-wise.
+func floatBinOp(a, b Value, op func(float32, float32) float32) Value {
+	switch av := a.(type) {
+	case Float32:
+		bv := toFloat32(b)
+		return Float32(op(av, bv))
+	case Vec2:
+		bv, ok := b.(Vec2)
+		if !ok {
+			return a
+		}
+		return Vec2{op(av[0], bv[0]), op(av[1], bv[1])}
+	case Vec3:
+		bv, ok := b.(Vec3)
+		if !ok {
+			return a
+		}
+		return Vec3{op(av[0], bv[0]), op(av[1], bv[1]), op(av[2], bv[2])}
+	case Vec4:
+		bv, ok := b.(Vec4)
+		if !ok {
+			return a
+		}
+		return Vec4{op(av[0], bv[0]), op(av[1], bv[1]), op(av[2], bv[2]), op(av[3], bv[3])}
+	default:
+		return Float32(0)
+	}
+}
+
+// floatUnaryOp applies a unary operation to a float-typed value.
+func floatUnaryOp(a Value, op func(float32) float32) Value {
+	switch av := a.(type) {
+	case Float32:
+		return Float32(op(av))
+	case Vec2:
+		return Vec2{op(av[0]), op(av[1])}
+	case Vec3:
+		return Vec3{op(av[0]), op(av[1]), op(av[2])}
+	case Vec4:
+		return Vec4{op(av[0]), op(av[1]), op(av[2]), op(av[3])}
+	default:
+		return Float32(0)
+	}
+}
+
+// intBinOp applies a binary operation to two integer values.
+func intBinOp(a, b Value, op func(uint32, uint32) uint32) Value {
+	av := toUint32(a)
+	bv := toUint32(b)
+	return op(av, bv)
+}
+
+// Vec4ToFloat32 extracts a Vec4 from a Value, returning zeros if type doesn't match.
+func Vec4ToFloat32(val Value) [4]float32 {
+	switch v := val.(type) {
+	case Vec4:
+		return v
+	case Vec3:
+		return [4]float32{v[0], v[1], v[2], 0}
+	case Vec2:
+		return [4]float32{v[0], v[1], 0, 0}
+	case Float32:
+		return [4]float32{v, 0, 0, 0}
+	default:
+		return [4]float32{}
+	}
+}
+
+// Float32BitsToUint32 converts a float32 to its bit representation as uint32.
+// Used for SPIR-V constant encoding in tests.
+func Float32BitsToUint32(f float32) uint32 {
+	return math.Float32bits(f)
+}

--- a/hal/software/shader/interpreter_test.go
+++ b/hal/software/shader/interpreter_test.go
@@ -1,0 +1,595 @@
+//go:build !(js && wasm)
+
+package shader
+
+import (
+	"math"
+	"testing"
+)
+
+// spirvInst encodes a SPIR-V instruction header word: (wordCount << 16) | opcode.
+func spirvInst(wordCount, opcode uint16) uint32 {
+	return uint32(wordCount)<<16 | uint32(opcode)
+}
+
+// spirvString encodes a string as null-terminated, word-aligned SPIR-V words.
+func spirvString(s string) []uint32 {
+	b := append([]byte(s), 0)
+	for len(b)%4 != 0 {
+		b = append(b, 0)
+	}
+	w := make([]uint32, len(b)/4)
+	for i := range w {
+		w[i] = uint32(b[i*4]) |
+			uint32(b[i*4+1])<<8 |
+			uint32(b[i*4+2])<<16 |
+			uint32(b[i*4+3])<<24
+	}
+	return w
+}
+
+// buildTriangleVertexSPIRV constructs a minimal SPIR-V module equivalent to:
+//
+//	@vertex fn vs_main(@builtin(vertex_index) idx: u32) -> @builtin(position) vec4<f32> {
+//	    var positions = array<vec2<f32>, 3>(
+//	        vec2(0.0, 0.5), vec2(-0.5, -0.5), vec2(0.5, -0.5)
+//	    );
+//	    return vec4<f32>(positions[idx], 0.0, 1.0);
+//	}
+//
+// The SPIR-V uses explicit IDs and follows the standard instruction encoding.
+func buildTriangleVertexSPIRV() []uint32 {
+	inst := spirvInst
+	str := spirvString
+	f := math.Float32bits
+
+	// ID assignments.
+	const (
+		idVoid       = 1
+		idFloat      = 2
+		idUint       = 3
+		idVec2       = 4
+		idVec4       = 5
+		idPtrVec4Out = 6  // pointer to vec4 (Output)
+		idPtrUintIn  = 7  // pointer to uint (Input)
+		idPosition   = 8  // @builtin(position) output variable
+		idVertexIdx  = 9  // @builtin(vertex_index) input variable
+		idFuncType   = 10 // void function type
+		idFunc       = 11 // vs_main function
+		idLabel1     = 12 // first label
+		idConst0     = 13 // 0.0f
+		idConst05    = 14 // 0.5f
+		idConstN05   = 15 // -0.5f
+		idConst1     = 16 // 1.0f
+		idUint3      = 17 // constant uint 3
+		idArrVec2    = 18 // array<vec2, 3>
+		idPtrArrFunc = 19 // pointer to array (Function)
+		idVec2_0     = 20 // vec2(0.0, 0.5)
+		idVec2_1     = 21 // vec2(-0.5, -0.5)
+		idVec2_2     = 22 // vec2(0.5, -0.5)
+		idArrConst   = 23 // constant array
+		idLocalArr   = 24 // local variable (function scope array)
+		idLoadIdx    = 25 // loaded vertex_index
+		idChainPtr   = 26 // access chain into array
+		idLoadElem   = 27 // loaded vec2 element
+		idExtractX   = 28 // extracted X component
+		idExtractY   = 29 // extracted Y component
+		idResult     = 30 // composed vec4 result
+		idBound      = 31
+	)
+
+	// Build entry point instruction (variable-length due to name encoding).
+	nameWords := str("vs_main")
+	epLen := uint16(3 + len(nameWords) + 2)
+	epInst := append([]uint32{inst(epLen, OpEntryPoint), ExecutionModelVertex, idFunc}, nameWords...)
+	epInst = append(epInst, idPosition, idVertexIdx)
+
+	// Header + preamble.
+	words := make([]uint32, 0, 200) //nolint:mnd // estimated capacity for triangle SPIR-V
+	words = append(words,
+		spirvMagic, 0x00010300, 0, idBound, 0, // header
+		inst(2, OpCapability), 1, // Shader capability
+		inst(3, OpMemoryModel), 0, 1, // Logical GLSL450
+	)
+	words = append(words, epInst...)
+	words = append(words,
+		// Decorations.
+		inst(4, OpDecorate), idPosition, DecorationBuiltIn, BuiltInPosition,
+		inst(4, OpDecorate), idVertexIdx, DecorationBuiltIn, BuiltInVertexIndex,
+		inst(4, OpDecorate), idArrVec2, DecorationArrayStride, 8,
+		// Types.
+		inst(2, OpTypeVoid), idVoid,
+		inst(3, OpTypeFloat), idFloat, 32,
+		inst(4, OpTypeInt), idUint, 32, 0,
+		inst(4, OpTypeVector), idVec2, idFloat, 2,
+		inst(4, OpTypeVector), idVec4, idFloat, 4,
+		inst(4, OpTypePointer), idPtrVec4Out, StorageClassOutput, idVec4,
+		inst(4, OpTypePointer), idPtrUintIn, StorageClassInput, idUint,
+		inst(3, OpTypeFunction), idFuncType, idVoid,
+		// Constants.
+		inst(4, OpConstant), idFloat, idConst0, f(0.0),
+		inst(4, OpConstant), idFloat, idConst05, f(0.5),
+		inst(4, OpConstant), idFloat, idConstN05, f(-0.5),
+		inst(4, OpConstant), idFloat, idConst1, f(1.0),
+		inst(4, OpConstant), idUint, idUint3, 3,
+		// Array and pointer types.
+		inst(4, OpTypeArray), idArrVec2, idVec2, idUint3,
+		inst(4, OpTypePointer), idPtrArrFunc, StorageClassFunction, idArrVec2,
+		// Constant composites.
+		inst(5, OpConstantComposite), idVec2, idVec2_0, idConst0, idConst05,
+		inst(5, OpConstantComposite), idVec2, idVec2_1, idConstN05, idConstN05,
+		inst(5, OpConstantComposite), idVec2, idVec2_2, idConst05, idConstN05,
+		inst(6, OpConstantComposite), idArrVec2, idArrConst, idVec2_0, idVec2_1, idVec2_2,
+		// Global variables.
+		inst(4, OpVariable), idPtrVec4Out, idPosition, StorageClassOutput,
+		inst(4, OpVariable), idPtrUintIn, idVertexIdx, StorageClassInput,
+		// Function body.
+		inst(5, OpFunction), idVoid, idFunc, 0, idFuncType,
+		inst(2, OpLabel), idLabel1,
+		inst(4, OpVariable), idPtrArrFunc, idLocalArr, StorageClassFunction,
+		inst(3, OpStore), idLocalArr, idArrConst,
+		inst(4, OpLoad), idUint, idLoadIdx, idVertexIdx,
+		inst(5, OpAccessChain), idVec2, idChainPtr, idLocalArr, idLoadIdx,
+		inst(4, OpLoad), idVec2, idLoadElem, idChainPtr,
+		inst(5, OpCompositeExtract), idFloat, idExtractX, idLoadElem, 0,
+		inst(5, OpCompositeExtract), idFloat, idExtractY, idLoadElem, 1,
+		inst(7, OpCompositeConstruct), idVec4, idResult, idExtractX, idExtractY, idConst0, idConst1,
+		inst(3, OpStore), idPosition, idResult,
+		inst(1, OpReturn),
+		inst(1, OpFunctionEnd),
+	)
+	return words
+}
+
+// buildTriangleFragmentSPIRV constructs SPIR-V for:
+//
+//	@fragment fn fs_main() -> @location(0) vec4<f32> {
+//	    return vec4<f32>(1.0, 0.0, 0.0, 1.0);
+//	}
+func buildTriangleFragmentSPIRV() []uint32 {
+	inst := spirvInst
+	str := spirvString
+	f := math.Float32bits
+
+	const (
+		idVoid       = 1
+		idFloat      = 2
+		idVec4       = 3
+		idPtrVec4Out = 4
+		idFuncType   = 5
+		idFunc       = 6
+		idLabel1     = 7
+		idConst0     = 8
+		idConst1     = 9
+		idColorOut   = 10
+		idResult     = 11
+		idBound      = 12
+	)
+
+	// Build entry point instruction.
+	nameWords := str("fs_main")
+	epLen := uint16(3 + len(nameWords) + 1)
+	epInst := append([]uint32{inst(epLen, OpEntryPoint), ExecutionModelFragment, idFunc}, nameWords...)
+	epInst = append(epInst, idColorOut)
+
+	words := make([]uint32, 0, 80) //nolint:mnd // estimated capacity for fragment SPIR-V
+	words = append(words,
+		spirvMagic, 0x00010300, 0, idBound, 0, // header
+		inst(2, OpCapability), 1, // Shader
+		inst(3, OpMemoryModel), 0, 1, // Logical GLSL450
+	)
+	words = append(words, epInst...)
+	words = append(words,
+		inst(3, OpExecutionMode), idFunc, 7, // OriginUpperLeft
+		inst(4, OpDecorate), idColorOut, DecorationLocation, 0,
+		// Types.
+		inst(2, OpTypeVoid), idVoid,
+		inst(3, OpTypeFloat), idFloat, 32,
+		inst(4, OpTypeVector), idVec4, idFloat, 4,
+		inst(4, OpTypePointer), idPtrVec4Out, StorageClassOutput, idVec4,
+		inst(3, OpTypeFunction), idFuncType, idVoid,
+		// Constants.
+		inst(4, OpConstant), idFloat, idConst0, f(0.0),
+		inst(4, OpConstant), idFloat, idConst1, f(1.0),
+		// Global variable.
+		inst(4, OpVariable), idPtrVec4Out, idColorOut, StorageClassOutput,
+		// Function body.
+		inst(5, OpFunction), idVoid, idFunc, 0, idFuncType,
+		inst(2, OpLabel), idLabel1,
+		inst(7, OpCompositeConstruct), idVec4, idResult, idConst1, idConst0, idConst0, idConst1,
+		inst(3, OpStore), idColorOut, idResult,
+		inst(1, OpReturn),
+		inst(1, OpFunctionEnd),
+	)
+	return words
+}
+
+func TestSPIRVParseModule(t *testing.T) {
+	words := buildTriangleVertexSPIRV()
+	m, err := ParseModule(words)
+	if err != nil {
+		t.Fatalf("ParseModule failed: %v", err)
+	}
+
+	// Check entry point exists.
+	ep, ok := m.EntryPoints["vs_main"]
+	if !ok {
+		t.Fatal("entry point vs_main not found")
+	}
+	if ep.ExecutionModel != ExecutionModelVertex {
+		t.Errorf("execution model = %d, want %d", ep.ExecutionModel, ExecutionModelVertex)
+	}
+
+	// Check function body exists.
+	_, ok = m.Functions["vs_main"]
+	if !ok {
+		t.Fatal("function body for vs_main not found")
+	}
+
+	// Verify decorations.
+	var posVarID, idxVarID uint32
+	for _, varID := range ep.InterfaceIDs {
+		bi := m.GetBuiltIn(varID)
+		switch bi {
+		case BuiltInPosition:
+			posVarID = varID
+		case BuiltInVertexIndex:
+			idxVarID = varID
+		}
+	}
+	if posVarID == 0 {
+		t.Fatal("position variable not found")
+	}
+	if idxVarID == 0 {
+		t.Fatal("vertex_index variable not found")
+	}
+}
+
+func TestSPIRVTriangleVertexShader(t *testing.T) {
+	words := buildTriangleVertexSPIRV()
+	m, err := ParseModule(words)
+	if err != nil {
+		t.Fatalf("ParseModule failed: %v", err)
+	}
+
+	ep := m.EntryPoints["vs_main"]
+
+	// Find variable IDs.
+	var posVarID, idxVarID uint32
+	for _, varID := range ep.InterfaceIDs {
+		bi := m.GetBuiltIn(varID)
+		if bi == BuiltInPosition {
+			posVarID = varID
+		}
+		if bi == BuiltInVertexIndex {
+			idxVarID = varID
+		}
+	}
+
+	// Expected positions from the triangle shader.
+	// positions = [vec2(0.0, 0.5), vec2(-0.5, -0.5), vec2(0.5, -0.5)]
+	// output = vec4(positions[idx].x, positions[idx].y, 0.0, 1.0)
+	expected := [][4]float32{
+		{0.0, 0.5, 0.0, 1.0},
+		{-0.5, -0.5, 0.0, 1.0},
+		{0.5, -0.5, 0.0, 1.0},
+	}
+
+	for idx, want := range expected {
+		inputs := map[uint32]Value{
+			idxVarID: uint32(idx),
+		}
+
+		outputs, err := m.Execute("vs_main", inputs)
+		if err != nil {
+			t.Fatalf("vertex %d: Execute failed: %v", idx, err)
+		}
+
+		posVal, ok := outputs[posVarID]
+		if !ok {
+			t.Fatalf("vertex %d: position output not found", idx)
+		}
+
+		pos := Vec4ToFloat32(posVal)
+		for c := 0; c < 4; c++ {
+			if math.Abs(float64(pos[c]-want[c])) > 1e-6 {
+				t.Errorf("vertex %d: component %d = %f, want %f", idx, c, pos[c], want[c])
+			}
+		}
+	}
+}
+
+func TestSPIRVTriangleFragmentShader(t *testing.T) {
+	words := buildTriangleFragmentSPIRV()
+	m, err := ParseModule(words)
+	if err != nil {
+		t.Fatalf("ParseModule failed: %v", err)
+	}
+
+	ep := m.EntryPoints["fs_main"]
+
+	// Find color output variable.
+	var colorVarID uint32
+	for _, varID := range ep.InterfaceIDs {
+		vi, ok := m.Variables[varID]
+		if !ok {
+			continue
+		}
+		if vi.StorageClass == StorageClassOutput {
+			loc := m.GetLocation(varID)
+			if loc == 0 {
+				colorVarID = varID
+				break
+			}
+		}
+	}
+	if colorVarID == 0 {
+		t.Fatal("color output variable (location 0) not found")
+	}
+
+	outputs, err := m.Execute("fs_main", nil)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	colorVal, ok := outputs[colorVarID]
+	if !ok {
+		t.Fatal("color output not found in outputs")
+	}
+
+	color := Vec4ToFloat32(colorVal)
+	want := [4]float32{1.0, 0.0, 0.0, 1.0} // Red
+	for c := 0; c < 4; c++ {
+		if math.Abs(float64(color[c]-want[c])) > 1e-6 {
+			t.Errorf("color[%d] = %f, want %f", c, color[c], want[c])
+		}
+	}
+}
+
+func TestSPIRVBadMagic(t *testing.T) {
+	words := []uint32{0xDEADBEEF, 0, 0, 10, 0}
+	_, err := ParseModule(words)
+	if err == nil {
+		t.Error("expected error for bad magic number")
+	}
+}
+
+func TestSPIRVTooShort(t *testing.T) {
+	words := []uint32{spirvMagic, 0}
+	_, err := ParseModule(words)
+	if err == nil {
+		t.Error("expected error for short module")
+	}
+}
+
+func TestSPIRVEmptyEntryPoint(t *testing.T) {
+	words := buildTriangleVertexSPIRV()
+	m, err := ParseModule(words)
+	if err != nil {
+		t.Fatalf("ParseModule failed: %v", err)
+	}
+
+	_, err = m.Execute("nonexistent", nil)
+	if err == nil {
+		t.Error("expected error for nonexistent entry point")
+	}
+}
+
+func TestSPIRVAccessChainOutOfBounds(t *testing.T) {
+	words := buildTriangleVertexSPIRV()
+	m, err := ParseModule(words)
+	if err != nil {
+		t.Fatalf("ParseModule failed: %v", err)
+	}
+
+	ep := m.EntryPoints["vs_main"]
+	var idxVarID uint32
+	for _, varID := range ep.InterfaceIDs {
+		if m.GetBuiltIn(varID) == BuiltInVertexIndex {
+			idxVarID = varID
+		}
+	}
+
+	// Index 10 is out of bounds for a 3-element array.
+	// The interpreter should not crash; it returns a zero element.
+	inputs := map[uint32]Value{
+		idxVarID: Uint32(10),
+	}
+	_, err = m.Execute("vs_main", inputs)
+	// Should not error — out-of-bounds returns zero.
+	if err != nil {
+		t.Fatalf("Execute with OOB index failed: %v", err)
+	}
+}
+
+func TestSPIRVConvertUToF(t *testing.T) {
+	// Test the convertToFloat helper directly.
+	tests := []struct {
+		name string
+		val  Value
+		want float32
+	}{
+		{"uint32_0", Uint32(0), 0},
+		{"uint32_42", Uint32(42), 42},
+		{"int32_neg", Int32(-5), -5},
+		{"float32", Float32(3.14), 3.14},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertToFloat(tt.val)
+			f, ok := result.(Float32)
+			if !ok {
+				t.Fatalf("convertToFloat returned %T, want Float32", result)
+			}
+			if math.Abs(float64(f-tt.want)) > 1e-5 {
+				t.Errorf("convertToFloat(%v) = %f, want %f", tt.val, f, tt.want)
+			}
+		})
+	}
+}
+
+func TestSPIRVCompositeConstruct(t *testing.T) {
+	// Test compositeConstruct via a simple module execution.
+	words := buildTriangleVertexSPIRV()
+	m, err := ParseModule(words)
+	if err != nil {
+		t.Fatalf("ParseModule failed: %v", err)
+	}
+
+	// Vertex 0 constructs vec4(0.0, 0.5, 0.0, 1.0).
+	ep := m.EntryPoints["vs_main"]
+	var idxVarID, posVarID uint32
+	for _, varID := range ep.InterfaceIDs {
+		switch m.GetBuiltIn(varID) {
+		case BuiltInVertexIndex:
+			idxVarID = varID
+		case BuiltInPosition:
+			posVarID = varID
+		}
+	}
+
+	inputs := map[uint32]Value{idxVarID: Uint32(0)}
+	outputs, err := m.Execute("vs_main", inputs)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+
+	pos := Vec4ToFloat32(outputs[posVarID])
+	if pos[3] != 1.0 {
+		t.Errorf("W component = %f, want 1.0 (CompositeConstruct should set it)", pos[3])
+	}
+}
+
+func TestDecodeString(t *testing.T) {
+	tests := []struct {
+		name      string
+		words     []uint32
+		wantStr   string
+		wantWords uint32
+	}{
+		{
+			name:      "main",
+			words:     []uint32{0x6E69616D, 0x00000000}, // "main\0\0\0\0"
+			wantStr:   "main",
+			wantWords: 2,
+		},
+		{
+			name:      "vs",
+			words:     []uint32{0x00007376}, // "vs\0\0"
+			wantStr:   "vs",
+			wantWords: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s, n := decodeString(tt.words)
+			if s != tt.wantStr {
+				t.Errorf("decodeString = %q, want %q", s, tt.wantStr)
+			}
+			if n != tt.wantWords {
+				t.Errorf("words consumed = %d, want %d", n, tt.wantWords)
+			}
+		})
+	}
+}
+
+func TestVec4ToFloat32(t *testing.T) {
+	tests := []struct {
+		name string
+		val  Value
+		want [4]float32
+	}{
+		{"vec4", Vec4{1, 2, 3, 4}, [4]float32{1, 2, 3, 4}},
+		{"vec3", Vec3{1, 2, 3}, [4]float32{1, 2, 3, 0}},
+		{"vec2", Vec2{1, 2}, [4]float32{1, 2, 0, 0}},
+		{"float", Float32(5), [4]float32{5, 0, 0, 0}},
+		{"nil", nil, [4]float32{0, 0, 0, 0}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Vec4ToFloat32(tt.val)
+			if got != tt.want {
+				t.Errorf("Vec4ToFloat32(%v) = %v, want %v", tt.val, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIndexComposite(t *testing.T) {
+	arr := Array{Float32(10), Float32(20), Float32(30)}
+	v := indexComposite(arr, 1)
+	f, ok := v.(Float32)
+	if !ok || f != 20 {
+		t.Errorf("indexComposite(arr, 1) = %v, want Float32(20)", v)
+	}
+
+	vec := Vec4{1, 2, 3, 4}
+	v = indexComposite(vec, 2)
+	f, ok = v.(Float32)
+	if !ok || f != 3 {
+		t.Errorf("indexComposite(vec4, 2) = %v, want Float32(3)", v)
+	}
+}
+
+func TestFloatBinOp(t *testing.T) {
+	add := func(a, b float32) float32 { return a + b }
+
+	result := floatBinOp(Float32(3), Float32(4), add)
+	if f, ok := result.(Float32); !ok || f != 7 {
+		t.Errorf("floatBinOp scalar = %v, want 7", result)
+	}
+
+	result = floatBinOp(Vec2{1, 2}, Vec2{3, 4}, add)
+	if v, ok := result.(Vec2); !ok || v != (Vec2{4, 6}) {
+		t.Errorf("floatBinOp vec2 = %v, want [4, 6]", result)
+	}
+}
+
+func TestIntBinOp(t *testing.T) {
+	add := func(a, b uint32) uint32 { return a + b }
+
+	result := intBinOp(Uint32(3), Uint32(4), add)
+	if u, ok := result.(Uint32); !ok || u != 7 {
+		t.Errorf("intBinOp = %v, want 7", result)
+	}
+}
+
+func BenchmarkSPIRVVertexShaderExecution(b *testing.B) {
+	words := buildTriangleVertexSPIRV()
+	m, err := ParseModule(words)
+	if err != nil {
+		b.Fatalf("ParseModule failed: %v", err)
+	}
+
+	ep := m.EntryPoints["vs_main"]
+	var idxVarID uint32
+	for _, varID := range ep.InterfaceIDs {
+		if m.GetBuiltIn(varID) == BuiltInVertexIndex {
+			idxVarID = varID
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		inputs := map[uint32]Value{
+			idxVarID: uint32(i % 3),
+		}
+		_, _ = m.Execute("vs_main", inputs)
+	}
+}
+
+func BenchmarkSPIRVFragmentShaderExecution(b *testing.B) {
+	words := buildTriangleFragmentSPIRV()
+	m, err := ParseModule(words)
+	if err != nil {
+		b.Fatalf("ParseModule failed: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = m.Execute("fs_main", nil)
+	}
+}

--- a/hal/software/shader/module.go
+++ b/hal/software/shader/module.go
@@ -1,0 +1,567 @@
+//go:build !(js && wasm)
+
+// SPIR-V module parser for the software backend.
+//
+// Parses a SPIR-V binary into types, constants, functions, entry points,
+// and decorations. Only handles the subset needed for the triangle shader:
+// scalar/vector/array types, constant composites, simple functions with
+// OpLoad/OpStore/OpAccessChain/OpCompositeConstruct.
+
+package shader
+
+import (
+	"fmt"
+	"math"
+)
+
+// Module is a parsed SPIR-V module ready for interpretation.
+type Module struct {
+	// Types maps result ID to type information.
+	Types map[uint32]*TypeInfo
+
+	// Constants maps result ID to constant value.
+	Constants map[uint32]Value
+
+	// Functions maps entry point name to function body.
+	Functions map[string]*Function
+
+	// EntryPoints maps entry point name to its metadata.
+	EntryPoints map[string]*EntryPoint
+
+	// Decorations maps (target ID, decoration kind) to decoration value.
+	Decorations map[decorationKey]uint32
+
+	// Variables maps result ID to variable metadata.
+	Variables map[uint32]*VariableInfo
+
+	// Bound is the upper bound of all IDs in the module.
+	Bound uint32
+}
+
+// TypeInfo describes a SPIR-V type.
+type TypeInfo struct {
+	Kind       TypeKind
+	Width      uint32   // bit width for int/float
+	Signed     bool     // for OpTypeInt
+	Components uint32   // for OpTypeVector
+	ElemType   uint32   // element type ID for vector/array/pointer
+	Length     uint32   // for OpTypeArray (number of elements)
+	Storage    uint32   // for OpTypePointer (storage class)
+	ParamIDs   []uint32 // for OpTypeFunction (parameter type IDs)
+	ReturnType uint32   // for OpTypeFunction
+	MemberIDs  []uint32 // for OpTypeStruct
+}
+
+// TypeKind classifies SPIR-V types.
+type TypeKind int
+
+const (
+	TypeVoid TypeKind = iota
+	TypeBool
+	TypeInt
+	TypeFloat
+	TypeVector
+	TypeArray
+	TypePointer
+	TypeFunction
+	TypeStruct
+)
+
+// EntryPoint describes a SPIR-V entry point.
+type EntryPoint struct {
+	ExecutionModel uint32
+	FunctionID     uint32
+	Name           string
+	InterfaceIDs   []uint32 // IDs of interface variables
+}
+
+// Function is a parsed SPIR-V function body.
+type Function struct {
+	ID           uint32
+	ReturnType   uint32
+	FunctionType uint32
+	Instructions []Instruction
+}
+
+// VariableInfo describes an OpVariable.
+type VariableInfo struct {
+	TypeID       uint32 // pointer type ID
+	StorageClass uint32
+}
+
+// decorationKey uniquely identifies a decoration on a target ID.
+type decorationKey struct {
+	TargetID   uint32
+	Decoration uint32
+}
+
+// ParseModule parses SPIR-V binary (as []uint32 words) into a Module.
+//
+// The SPIR-V format is: 5-word header (magic, version, generator, bound, reserved)
+// followed by a stream of instructions. Each instruction's first word encodes
+// (wordCount << 16 | opcode).
+//
+//nolint:maintidx // SPIR-V opcode dispatch switch is inherently large.
+func ParseModule(words []uint32) (*Module, error) {
+	if len(words) < 5 {
+		return nil, fmt.Errorf("spirv: module too short (%d words)", len(words))
+	}
+	if words[0] != spirvMagic {
+		return nil, fmt.Errorf("spirv: bad magic 0x%08x, expected 0x%08x", words[0], spirvMagic)
+	}
+
+	m := &Module{
+		Types:       make(map[uint32]*TypeInfo),
+		Constants:   make(map[uint32]Value),
+		Functions:   make(map[string]*Function),
+		EntryPoints: make(map[string]*EntryPoint),
+		Decorations: make(map[decorationKey]uint32),
+		Variables:   make(map[uint32]*VariableInfo),
+		Bound:       words[3],
+	}
+
+	// Maps function ID to function body (built during parse, keyed to entry points later).
+	funcsByID := make(map[uint32]*Function)
+
+	pos := 5 // skip header
+	var currentFunc *Function
+
+	for pos < len(words) {
+		word := words[pos]
+		wordCount := int(word >> 16)
+		opcode := uint16(word & 0xFFFF)
+
+		if wordCount == 0 {
+			return nil, fmt.Errorf("spirv: zero word count at position %d", pos)
+		}
+		if pos+wordCount > len(words) {
+			return nil, fmt.Errorf("spirv: instruction at %d extends past end (need %d, have %d)",
+				pos, wordCount, len(words)-pos)
+		}
+
+		operands := words[pos+1 : pos+wordCount]
+
+		switch opcode {
+		case OpTypeVoid:
+			if len(operands) < 1 {
+				break
+			}
+			m.Types[operands[0]] = &TypeInfo{Kind: TypeVoid}
+
+		case OpTypeBool:
+			if len(operands) < 1 {
+				break
+			}
+			m.Types[operands[0]] = &TypeInfo{Kind: TypeBool}
+
+		case OpTypeInt:
+			if len(operands) < 3 {
+				break
+			}
+			m.Types[operands[0]] = &TypeInfo{
+				Kind:   TypeInt,
+				Width:  operands[1],
+				Signed: operands[2] != 0,
+			}
+
+		case OpTypeFloat:
+			if len(operands) < 2 {
+				break
+			}
+			m.Types[operands[0]] = &TypeInfo{
+				Kind:  TypeFloat,
+				Width: operands[1],
+			}
+
+		case OpTypeVector:
+			if len(operands) < 3 {
+				break
+			}
+			m.Types[operands[0]] = &TypeInfo{
+				Kind:       TypeVector,
+				ElemType:   operands[1],
+				Components: operands[2],
+			}
+
+		case OpTypeArray:
+			if len(operands) < 3 {
+				break
+			}
+			// operands[2] is the ID of the constant holding the length.
+			length := uint32(0)
+			if cval, ok := m.Constants[operands[2]]; ok {
+				switch cv := cval.(type) {
+				case Uint32:
+					length = cv
+				case Int32:
+					length = uint32(cv)
+				}
+			}
+			m.Types[operands[0]] = &TypeInfo{
+				Kind:     TypeArray,
+				ElemType: operands[1],
+				Length:   length,
+			}
+
+		case OpTypePointer:
+			if len(operands) < 3 {
+				break
+			}
+			m.Types[operands[0]] = &TypeInfo{
+				Kind:     TypePointer,
+				Storage:  operands[1],
+				ElemType: operands[2],
+			}
+
+		case OpTypeFunction:
+			if len(operands) < 2 {
+				break
+			}
+			ti := &TypeInfo{
+				Kind:       TypeFunction,
+				ReturnType: operands[1],
+			}
+			if len(operands) > 2 {
+				ti.ParamIDs = make([]uint32, len(operands)-2)
+				copy(ti.ParamIDs, operands[2:])
+			}
+			m.Types[operands[0]] = ti
+
+		case OpTypeStruct:
+			if len(operands) < 1 {
+				break
+			}
+			ti := &TypeInfo{Kind: TypeStruct}
+			if len(operands) > 1 {
+				ti.MemberIDs = make([]uint32, len(operands)-1)
+				copy(ti.MemberIDs, operands[1:])
+			}
+			m.Types[operands[0]] = ti
+
+		case OpConstant:
+			// OpConstant: resultType resultID literal...
+			if len(operands) < 2 {
+				break
+			}
+			typeID := operands[0]
+			resultID := operands[1]
+			m.Constants[resultID] = resolveConstant(m.Types, typeID, operands[2:])
+
+		case OpConstantComposite:
+			// OpConstantComposite: resultType resultID constituents...
+			if len(operands) < 2 {
+				break
+			}
+			resultID := operands[1]
+			constituents := operands[2:]
+			elems := make(Array, len(constituents))
+			for i, cid := range constituents {
+				if v, ok := m.Constants[cid]; ok {
+					elems[i] = v
+				}
+			}
+			m.Constants[resultID] = elems
+
+		case OpConstantNull:
+			if len(operands) < 2 {
+				break
+			}
+			typeID := operands[0]
+			resultID := operands[1]
+			m.Constants[resultID] = zeroValue(m.Types, typeID)
+
+		case OpEntryPoint:
+			// OpEntryPoint: executionModel functionID "name" interfaceIDs...
+			if len(operands) < 2 {
+				break
+			}
+			execModel := operands[0]
+			funcID := operands[1]
+			name, nameWords := decodeString(operands[2:])
+			interfaceStart := 2 + nameWords
+			var interfaceIDs []uint32
+			if int(interfaceStart) < len(operands) {
+				interfaceIDs = make([]uint32, len(operands)-int(interfaceStart))
+				copy(interfaceIDs, operands[interfaceStart:])
+			}
+			m.EntryPoints[name] = &EntryPoint{
+				ExecutionModel: execModel,
+				FunctionID:     funcID,
+				Name:           name,
+				InterfaceIDs:   interfaceIDs,
+			}
+
+		case OpDecorate:
+			// OpDecorate: target decoration [extra words]
+			if len(operands) < 2 {
+				break
+			}
+			key := decorationKey{
+				TargetID:   operands[0],
+				Decoration: operands[1],
+			}
+			if len(operands) >= 3 {
+				m.Decorations[key] = operands[2]
+			} else {
+				m.Decorations[key] = 0
+			}
+
+		case OpVariable:
+			// OpVariable: resultType resultID storageClass [initializer]
+			if len(operands) < 3 {
+				break
+			}
+			typeID := operands[0]
+			resultID := operands[1]
+			storageClass := operands[2]
+			m.Variables[resultID] = &VariableInfo{
+				TypeID:       typeID,
+				StorageClass: storageClass,
+			}
+			// If inside a function, record as an instruction too.
+			if currentFunc != nil {
+				inst := Instruction{
+					Opcode:   opcode,
+					TypeID:   typeID,
+					ResultID: resultID,
+					Operands: []uint32{storageClass},
+				}
+				if len(operands) > 3 {
+					inst.Operands = append(inst.Operands, operands[3:]...)
+				}
+				currentFunc.Instructions = append(currentFunc.Instructions, inst)
+			}
+
+		case OpFunction:
+			// OpFunction: resultType resultID functionControl functionType
+			if len(operands) < 4 {
+				break
+			}
+			currentFunc = &Function{
+				ReturnType:   operands[0],
+				ID:           operands[1],
+				FunctionType: operands[3],
+			}
+			funcsByID[operands[1]] = currentFunc
+
+		case OpFunctionEnd:
+			currentFunc = nil
+
+		case OpLabel:
+			// OpLabel is a basic block start — record as instruction for the interpreter.
+			if currentFunc != nil && len(operands) >= 1 {
+				currentFunc.Instructions = append(currentFunc.Instructions, Instruction{
+					Opcode:   opcode,
+					ResultID: operands[0],
+				})
+			}
+
+		default:
+			// All other instructions inside a function body are recorded for interpretation.
+			if currentFunc != nil {
+				inst := decodeInstruction(opcode, operands)
+				currentFunc.Instructions = append(currentFunc.Instructions, inst)
+			}
+		}
+
+		pos += wordCount
+	}
+
+	// Map entry points to their function bodies.
+	for name, ep := range m.EntryPoints {
+		if fn, ok := funcsByID[ep.FunctionID]; ok {
+			m.Functions[name] = fn
+		}
+	}
+
+	return m, nil
+}
+
+// GetBuiltIn returns the BuiltIn decoration value for a variable ID, or -1 if none.
+func (m *Module) GetBuiltIn(varID uint32) int {
+	key := decorationKey{TargetID: varID, Decoration: DecorationBuiltIn}
+	if val, ok := m.Decorations[key]; ok {
+		return int(val)
+	}
+	return -1
+}
+
+// GetLocation returns the Location decoration value for a variable ID, or -1 if none.
+func (m *Module) GetLocation(varID uint32) int {
+	key := decorationKey{TargetID: varID, Decoration: DecorationLocation}
+	if val, ok := m.Decorations[key]; ok {
+		return int(val)
+	}
+	return -1
+}
+
+// PointeeType dereferences a pointer type, returning the type it points to.
+func (m *Module) PointeeType(ptrTypeID uint32) *TypeInfo {
+	ptrType, ok := m.Types[ptrTypeID]
+	if !ok || ptrType.Kind != TypePointer {
+		return nil
+	}
+	return m.Types[ptrType.ElemType]
+}
+
+// decodeInstruction builds an Instruction from an opcode and its operands.
+// Instructions with result type and result ID follow the pattern:
+// resultType resultID operands... for most typed instructions.
+func decodeInstruction(opcode uint16, operands []uint32) Instruction {
+	inst := Instruction{Opcode: opcode}
+
+	switch opcode {
+	// Instructions with result type AND result ID (type resultID operands...).
+	case OpLoad, OpAccessChain, OpCompositeConstruct, OpCompositeExtract,
+		OpConvertUToF, OpConvertFToU, OpConvertSToF, OpBitcast,
+		OpFAdd, OpFSub, OpFMul, OpFDiv, OpFNegate,
+		OpIAdd, OpISub, OpIMul, OpSDiv, OpUDiv,
+		OpSelect, OpPhi,
+		OpIEqual, OpINotEqual,
+		OpFOrdEqual, OpFOrdLessThan, OpFOrdGreaterThan,
+		OpFOrdLessThanEqual, OpFOrdGreaterThanEqual,
+		OpUndef, OpExtInst:
+		if len(operands) >= 2 {
+			inst.TypeID = operands[0]
+			inst.ResultID = operands[1]
+			if len(operands) > 2 {
+				inst.Operands = make([]uint32, len(operands)-2)
+				copy(inst.Operands, operands[2:])
+			}
+		}
+
+	// OpStore: pointer value [memory access]
+	case OpStore:
+		if len(operands) >= 2 {
+			inst.Operands = make([]uint32, len(operands))
+			copy(inst.Operands, operands)
+		}
+
+	// OpReturn / OpReturnValue
+	case OpReturn:
+		// no operands
+
+	case OpReturnValue:
+		if len(operands) >= 1 {
+			inst.Operands = []uint32{operands[0]}
+		}
+
+	// OpBranch: target label
+	case OpBranch:
+		if len(operands) >= 1 {
+			inst.Operands = []uint32{operands[0]}
+		}
+
+	case OpBranchConditional:
+		if len(operands) >= 3 {
+			inst.Operands = make([]uint32, len(operands))
+			copy(inst.Operands, operands)
+		}
+
+	case OpSelectionMerge, OpLoopMerge:
+		if len(operands) >= 1 {
+			inst.Operands = make([]uint32, len(operands))
+			copy(inst.Operands, operands)
+		}
+
+	// OpFunctionParameter: resultType resultID
+	case OpFunctionParameter:
+		if len(operands) >= 2 {
+			inst.TypeID = operands[0]
+			inst.ResultID = operands[1]
+		}
+
+	default:
+		// Unknown instruction — store all operands for forward compatibility.
+		if len(operands) > 0 {
+			inst.Operands = make([]uint32, len(operands))
+			copy(inst.Operands, operands)
+		}
+	}
+
+	return inst
+}
+
+// decodeString reads a null-terminated UTF-8 string from SPIR-V words.
+// Returns the string and the number of words consumed (including padding).
+func decodeString(words []uint32) (string, uint32) {
+	var bytes []byte
+	for i, w := range words {
+		b0 := byte(w)
+		b1 := byte(w >> 8)
+		b2 := byte(w >> 16)
+		b3 := byte(w >> 24)
+		if b0 == 0 {
+			return string(bytes), uint32(i + 1)
+		}
+		bytes = append(bytes, b0)
+		if b1 == 0 {
+			return string(bytes), uint32(i + 1)
+		}
+		bytes = append(bytes, b1)
+		if b2 == 0 {
+			return string(bytes), uint32(i + 1)
+		}
+		bytes = append(bytes, b2)
+		if b3 == 0 {
+			return string(bytes), uint32(i + 1)
+		}
+		bytes = append(bytes, b3)
+	}
+	return string(bytes), uint32(len(words))
+}
+
+// resolveConstant converts SPIR-V constant literal words to a Go value
+// based on the declared type.
+func resolveConstant(types map[uint32]*TypeInfo, typeID uint32, literals []uint32) Value {
+	ti, ok := types[typeID]
+	if !ok || len(literals) == 0 {
+		return Uint32(0)
+	}
+	switch ti.Kind {
+	case TypeFloat:
+		return math.Float32frombits(literals[0])
+	case TypeInt:
+		if ti.Signed {
+			return int32(literals[0])
+		}
+		return literals[0]
+	default:
+		return literals[0]
+	}
+}
+
+// zeroValue returns the zero/default value for a given type.
+func zeroValue(types map[uint32]*TypeInfo, typeID uint32) Value {
+	ti, ok := types[typeID]
+	if !ok {
+		return Uint32(0)
+	}
+	switch ti.Kind {
+	case TypeFloat:
+		return Float32(0)
+	case TypeInt:
+		if ti.Signed {
+			return Int32(0)
+		}
+		return Uint32(0)
+	case TypeVector:
+		switch ti.Components {
+		case 2:
+			return Vec2{}
+		case 3:
+			return Vec3{}
+		case 4:
+			return Vec4{}
+		}
+	case TypeArray:
+		if ti.Length > 0 {
+			arr := make(Array, ti.Length)
+			for i := range arr {
+				arr[i] = zeroValue(types, ti.ElemType)
+			}
+			return arr
+		}
+	}
+	return Uint32(0)
+}

--- a/hal/software/shader/opcodes.go
+++ b/hal/software/shader/opcodes.go
@@ -1,0 +1,130 @@
+//go:build !(js && wasm)
+
+// SPIR-V opcode constants and instruction representation.
+//
+// Only opcodes needed for the triangle shader are defined here.
+// See SPIR-V specification section 3.32 for the full opcode list.
+
+package shader
+
+// SPIR-V opcodes relevant to the triangle shader.
+// Reference: SPIR-V Specification v1.6, section 3.32 (Instructions).
+const (
+	OpNop                  = 0
+	OpExtInstImport        = 11
+	OpMemoryModel          = 14
+	OpEntryPoint           = 15
+	OpExecutionMode        = 16
+	OpCapability           = 17
+	OpTypeVoid             = 19
+	OpTypeBool             = 20
+	OpTypeInt              = 21
+	OpTypeFloat            = 22
+	OpTypeVector           = 23
+	OpTypeArray            = 28
+	OpTypeStruct           = 30
+	OpTypePointer          = 32
+	OpTypeFunction         = 33
+	OpConstant             = 43
+	OpConstantComposite    = 44
+	OpConstantNull         = 46
+	OpFunction             = 54
+	OpFunctionParameter    = 55
+	OpFunctionEnd          = 56
+	OpVariable             = 59
+	OpLoad                 = 61
+	OpStore                = 62
+	OpAccessChain          = 65
+	OpDecorate             = 71
+	OpMemberDecorate       = 72
+	OpCompositeExtract     = 81
+	OpCompositeConstruct   = 80
+	OpReturn               = 253
+	OpReturnValue          = 254
+	OpLabel                = 248
+	OpBranch               = 249
+	OpSource               = 3
+	OpSourceExtension      = 4
+	OpName                 = 5
+	OpMemberName           = 6
+	OpString               = 7
+	OpLine                 = 8
+	OpNoLine               = 317
+	OpModuleProcessed      = 330
+	OpUndef                = 1
+	OpExtInst              = 12
+	OpBitcast              = 124
+	OpConvertUToF          = 112
+	OpConvertFToU          = 109
+	OpConvertSToF          = 111
+	OpIAdd                 = 128
+	OpISub                 = 130
+	OpIMul                 = 132
+	OpFAdd                 = 129
+	OpFSub                 = 131
+	OpFMul                 = 133
+	OpFDiv                 = 136
+	OpSDiv                 = 135
+	OpUDiv                 = 134
+	OpFNegate              = 127
+	OpSelect               = 169
+	OpBranchConditional    = 250
+	OpSelectionMerge       = 247
+	OpLoopMerge            = 246
+	OpPhi                  = 245
+	OpIEqual               = 170
+	OpINotEqual            = 171
+	OpFOrdEqual            = 180
+	OpFOrdLessThan         = 184
+	OpFOrdGreaterThan      = 186
+	OpFOrdLessThanEqual    = 188
+	OpFOrdGreaterThanEqual = 190
+)
+
+// SPIR-V storage classes.
+const (
+	StorageClassUniformConstant = 0
+	StorageClassInput           = 1
+	StorageClassUniform         = 2
+	StorageClassOutput          = 3
+	StorageClassWorkgroup       = 4
+	StorageClassCrossWorkgroup  = 5
+	StorageClassPrivate         = 6
+	StorageClassFunction        = 7
+	StorageClassGeneric         = 8
+	StorageClassPushConstant    = 9
+	StorageClassAtomicCounter   = 10
+	StorageClassImage           = 11
+	StorageClassStorageBuffer   = 12
+)
+
+// SPIR-V decoration constants.
+const (
+	DecorationBuiltIn     = 11
+	DecorationLocation    = 30
+	DecorationBinding     = 33
+	DecorationArrayStride = 6
+)
+
+// SPIR-V BuiltIn values.
+const (
+	BuiltInPosition    = 0
+	BuiltInVertexIndex = 42
+)
+
+// SPIR-V execution model constants.
+const (
+	ExecutionModelVertex   = 0
+	ExecutionModelFragment = 4
+)
+
+// spirvMagic is the SPIR-V binary magic number.
+const spirvMagic = 0x07230203
+
+// Instruction represents a decoded SPIR-V instruction.
+type Instruction struct {
+	Opcode   uint16
+	ResultID uint32   // 0 if instruction produces no result
+	TypeID   uint32   // 0 if instruction has no result type
+	Operands []uint32 // remaining operands after result/type
+}

--- a/hal/software/shader/value.go
+++ b/hal/software/shader/value.go
@@ -1,0 +1,40 @@
+//go:build !(js && wasm)
+
+// SPIR-V runtime value types for the software backend interpreter.
+//
+// These types represent values during SPIR-V execution. The interpreter uses
+// Go interface{} (aliased as Value) for dynamic typing, matching SPIR-V's
+// untyped SSA register model.
+
+package shader
+
+// Value is a runtime value in the SPIR-V interpreter.
+// Concrete types: Float32, Uint32, Int32, Vec2, Vec3, Vec4, Array, Pointer.
+type Value = any
+
+// Float32 is a 32-bit floating point scalar.
+type Float32 = float32
+
+// Uint32 is a 32-bit unsigned integer scalar.
+type Uint32 = uint32
+
+// Int32 is a 32-bit signed integer scalar.
+type Int32 = int32
+
+// Vec2 is a 2-component float32 vector.
+type Vec2 = [2]float32
+
+// Vec3 is a 3-component float32 vector.
+type Vec3 = [3]float32
+
+// Vec4 is a 4-component float32 vector.
+type Vec4 = [4]float32
+
+// Array is a dynamically-sized collection of values.
+type Array = []Value
+
+// Pointer wraps a mutable reference to a Value stored in a variable.
+// SPIR-V OpVariable creates a Pointer; OpLoad dereferences it; OpStore writes to it.
+type Pointer struct {
+	Value Value
+}

--- a/hal/vulkan/api.go
+++ b/hal/vulkan/api.go
@@ -377,20 +377,30 @@ func cStringToGo(b []byte) string {
 	return string(b)
 }
 
+// GPU vendor names used in vendorIDToName and adapter info.
+const (
+	vendorAMD      = "AMD"
+	vendorNVIDIA   = "NVIDIA"
+	vendorIntel    = "Intel"
+	vendorARM      = "ARM"
+	vendorQualcomm = "Qualcomm"
+	vendorImgTec   = "ImgTec"
+)
+
 func vendorIDToName(id uint32) string {
 	switch id {
 	case 0x1002:
-		return "AMD"
+		return vendorAMD
 	case 0x10DE:
-		return "NVIDIA"
+		return vendorNVIDIA
 	case 0x8086:
-		return "Intel"
+		return vendorIntel
 	case 0x13B5:
-		return "ARM"
+		return vendorARM
 	case 0x5143:
-		return "Qualcomm"
+		return vendorQualcomm
 	case 0x1010:
-		return "ImgTec"
+		return vendorImgTec
 	default:
 		return fmt.Sprintf("0x%04X", id)
 	}


### PR DESCRIPTION
## Summary

- **SPIR-V interpreter** (FEAT-SW-004) — minimal CPU shader execution for software backend. Triangle renders red on `GOGPU_GRAPHICS_API=software`. ~650 LOC, 14 tests, 2 benchmarks.
- **Lint zero** — resolve all 29 goconst + 1 nestif warnings. 0 issues on Windows, Linux, macOS.
- **Resource guard** — SPIR-V interpreter skips shaders with uniform/texture bindings it can't handle, falls back to executeFullscreenBlit.

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] `GOGPU_GRAPHICS_API=software gogpu/examples/triangle` — red triangle renders
- [x] Benchmarks: 0 allocs/op on hot paths
- [ ] CI