### PR TITLE
naga v0.17.11 + tagged union Value + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.27.0] - 2026-05-06
 
 ### Added
 
 - **Software backend: full SPIR-V interpreter** (FEAT-SW-004) — CPU interpreter for SPIR-V
-  shaders enabling real shader execution on the software backend. ~10K LOC, 370+ tests, 84%
+  shaders. Designed for **shader debugging, CI/CD testing, and GPU-less fallback** — not for
+  production rendering (interpreted, ~100× slower than JIT). ~10K LOC, 370+ tests, 84%
   coverage. Seven phases:
   - **Phase 1**: Basic vertex/fragment (triangle renders red)
   - **Phase 2**: Uniform/storage buffers, vector/matrix ops
@@ -48,6 +49,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Flaky TestSnatchLock_ReadWriteExclusion** — replaced `time.Sleep(10ms)` with channel-based
   synchronization. Was failing intermittently on Windows CI (goroutine scheduler too slow for
   10ms deadline). Now deterministic — 100/100 passes.
+
+### Changed
+
+- **Tagged union Value** — SPIR-V interpreter values replaced from `any` (interface boxing,
+  heap alloc per scalar) to 48-byte tagged struct with inline F[4]float32 + U[4]uint32.
+  Fragment shader: 4→3 allocs (-25%), 490→438 ns (-11%).
+- **Fullscreen blit priority** (ADR-020) — `executeFullscreenBlit` (memcpy) checked before
+  `executeSPIRVDraw` (interpreted). 60 FPS vs 0.65 FPS for textured quad blit.
+
+### Dependencies
+
+- **naga** v0.17.10 → **v0.17.11** — fix #170 (SIGSEGV → error for `dot(v)` wrong arg count),
+  BUG-DXIL-041 (fine.wgsl 100% valid), lint hardening. gg production: 61/61 DXIL valid.
 
 ## [0.26.12] - 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ import _ "github.com/gogpu/wgpu/hal/software"
 - Blending (13 factors, 5 operations)
 - 6-plane frustum clipping (Sutherland-Hodgman)
 - 8x8 tile-based parallel rendering
-- **SPIR-V interpreter** — executes vertex/fragment shaders on CPU (Phase 1: basic shaders)
+- **SPIR-V interpreter** — executes vertex/fragment/compute shaders on CPU. Designed for shader debugging, CI/CD testing, and GPU-less environments — **not for production rendering** (interpreted, ~100× slower than JIT software renderers like SwiftShader). See [ADR](docs/dev/research/ADR-SPIRV-JIT-VS-INTERPRETER.md).
 
 **Windowed Presentation:**
 - **Windows:** DWM-safe `CreateDIBSection` + `BitBlt` (SDL3/Qt6 pattern), zero-copy into GDI bitmap

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.26.7
+## Current State: v0.27.0
 
 ✅ **All 5 HAL backends complete** (~127K LOC)
 ✅ **Three-layer WebGPU stack** — wgpu API → wgpu/core → wgpu/hal
@@ -144,6 +144,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.27.0** | 2026-05 | **Full SPIR-V interpreter** (7 phases, ~10K LOC), shader debugger, compute HAL, particles rendering, tagged union optimization, naga v0.17.11, flaky test fix |
 | **v0.26.12** | 2026-05 | **Test coverage** (core 85.5%, root 78.4%), Metal entry point fix (#168 by @k-chimi), naga v0.17.10 |
 | **v0.26.11** | 2026-04 | **DX12 indirect dispatch/draw** — ExecuteIndirect + CommandSignature (was last GPU backend with stubs) |
 | **v0.26.10** | 2026-04 | **Validation Phase B** — 5 P1 correctness checks (MinBindingSize, index format mismatch, indirect bounds, depth/stencil aspects, BindGroup Submit). Coverage 37% → 45%. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -145,10 +145,10 @@ Pure Go OpenGL ES 3.0+ / OpenGL 4.3+ implementation.
 CPU-based rasterizer with SPIR-V interpreter. Always compiled (no build tags required). Pure Go, zero system dependencies.
 
 - `raster/` — Triangle rasterization, blending, depth/stencil, tiling, per-pixel fragment shader callback
-- `shader/` — Full SPIR-V interpreter (~10K LOC): vertex, fragment, compute shaders. GLSL.std.450 math intrinsics (30+), texture sampling, control flow, atomics, workgroup shared memory. Shader debugger with breakpoints and JSON trace.
+- `shader/` — Full SPIR-V interpreter (~10K LOC): vertex, fragment, compute shaders. GLSL.std.450 math intrinsics (30+), texture sampling, control flow, atomics, workgroup shared memory. Shader debugger with breakpoints and JSON trace. **Not for production rendering** — interpreted execution is ~100× slower than JIT (SwiftShader/llvmpipe). Designed for shader debugging, CI/CD testing, and GPU-less fallback.
 - `compute_test.go` — Naga WGSL→SPIR-V integration tests for compute shaders
 
-Use cases: headless rendering (servers, CI/CD), testing without GPU, shader debugging, embedded systems, fallback when no GPU available. Verified: triangle + 4096-particle compute+render simulation.
+Use cases: **shader debugging** (step through every SPIR-V instruction), **CI/CD testing** (no GPU required), **headless rendering** (servers), **GPU-less fallback** (embedded systems). NOT for real-time production rendering — use GPU backends (Vulkan/DX12/Metal/GLES) for that. Verified: triangle + 4096-particle compute+render simulation.
 
 ### `hal/noop/` — No-op Backend
 

--- a/docs/COMPUTE-BACKENDS.md
+++ b/docs/COMPUTE-BACKENDS.md
@@ -6,13 +6,13 @@ This document describes compute shader support across wgpu's HAL backends.
 
 | Feature | Vulkan | DX12 | Metal | GLES | Software | Noop |
 |---------|:------:|:----:|:-----:|:----:|:--------:|:----:|
-| Compute shaders | Yes | Yes | Yes | Partial | No | No |
-| Storage buffers | Yes | Yes | Yes | Yes | No | No |
+| Compute shaders | Yes | Yes | Yes | Partial | Yes (interpreted) | No |
+| Storage buffers | Yes | Yes | Yes | Yes | Yes (interpreted) | No |
 | Timestamp queries | Yes | Stub | Stub | Stub | No | No |
 | Indirect dispatch | Yes | Yes | Yes | Yes | No | No |
 | Buffer mapping (GPU->CPU) | Yes | Yes | Yes | Yes | Yes | No |
-| Max workgroup size X | 1024+ | 1024 | 1024 | 1024 | N/A | N/A |
-| Max workgroup invocations | 1024+ | 1024 | 1024 | 1024 | N/A | N/A |
+| Max workgroup size X | 1024+ | 1024 | 1024 | 1024 | 1024 | N/A |
+| Max workgroup invocations | 1024+ | 1024 | 1024 | 1024 | 1024 | N/A |
 
 ## Vulkan
 
@@ -80,17 +80,24 @@ Vulkan provides the most complete compute shader implementation:
 
 ## Software Backend
 
-**Status:** Compute shaders are **not supported**.
+**Status:** Compute shaders supported via SPIR-V interpreter (v0.27.0+).
 
-The software backend is a CPU rasterizer designed for headless rendering and testing. It does not execute compute shaders.
+The software backend executes compute shaders on CPU through a built-in SPIR-V interpreter. **Designed for shader debugging, CI/CD testing, and GPU-less environments — not for production workloads** (interpreted, ~100× slower than JIT software renderers).
 
-- `CreateQuerySet` returns an error.
-- `BeginComputePass` returns a valid encoder, but `Dispatch` is a no-op.
-- Use the software backend only for render pipeline testing or as a fallback when no GPU is available.
+- **Shader compilation:** WGSL → SPIR-V (via `gogpu/naga`), then interpreted instruction-by-instruction.
+- **Storage buffers:** Full read/write support. Buffer writes from compute shader are immediately visible.
+- **Atomics:** OpAtomicIAdd, OpAtomicISub, OpAtomicExchange, OpAtomicCompareExchange, OpAtomicSMin/SMax/UMin/UMax.
+- **Workgroup shared memory:** Per-workgroup allocation, zeroed at dispatch start.
+- **Barriers:** OpControlBarrier accepted (sequential execution, no-op for synchronization).
+- **Shader debugger:** DebugContext with breakpoints, JSON trace, watch variables. Zero overhead when disabled.
+- **Workgroup size:** Read from OpExecutionMode LocalSize in SPIR-V.
+- `CreateQuerySet` returns an error (timestamps not supported).
+- `DispatchIndirect` logs a warning (not yet implemented).
 
-### Future Plans
+### Verified
 
-A CPU-based compute shader interpreter may be added in the future (tracked as CS-013).
+`wgpu/examples/software-test/` — 256-element scaled-copy compute shader, all values match.
+`gogpu/examples/particles/` — 4096-particle orbital simulation (compute + instanced render).
 
 ## Noop Backend
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.5.0
 	github.com/gogpu/gputypes v0.5.0
-	github.com/gogpu/naga v0.17.10
+	github.com/gogpu/naga v0.17.11
 	golang.org/x/sys v0.43.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,7 @@ github.com/go-webgpu/goffi v0.5.0 h1:EuvVRiRn9qAfCkYYXbHs9gz8NY+zv2/OA1N7gi56UVE
 github.com/go-webgpu/goffi v0.5.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.17.10 h1:dJjMXb7b5ybSK8XbsiCA5aUVIAvLHjJg129FB1Ocz/I=
-github.com/gogpu/naga v0.17.10/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.17.11 h1:BndN5LLj3BKSdfjJxrDibs3jdx4YstrkvYTgEoJhsWI=
+github.com/gogpu/naga v0.17.11/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/hal/software/draw.go
+++ b/hal/software/draw.go
@@ -28,20 +28,20 @@ func (r *RenderPassEncoder) executeDraw(vertexCount, instanceCount, firstVertex,
 		return
 	}
 
-	// No vertex buffer bound — try SPIR-V shader path or fullscreen blit.
+	// No vertex buffer bound — try fullscreen blit or SPIR-V shader path.
 	if r.vertexBufs[0].buffer == nil {
+		// Fullscreen blit path (FAST): direct memcpy/swizzle from bound texture.
+		// Must be checked BEFORE SPIR-V — memcpy is 100x faster than interpreting
+		// a fragment shader per-pixel (ADR-020: 60 FPS vs 0.65 FPS).
+		if r.executeFullscreenBlit(target) {
+			r.cleared = true
+			return
+		}
+
 		// SPIR-V path: when the pipeline has no vertex buffer layouts but has
 		// a shader module with SPIR-V (e.g. @builtin(vertex_index) triangle),
 		// execute the shader via the interpreter.
 		if r.executeSPIRVDraw(target, vertexCount, instanceCount, firstVertex, firstInstance) {
-			return
-		}
-
-		// Fullscreen blit path: blit bound texture to target.
-		// The blit overwrites every destination pixel, so applyClear is redundant.
-		// Skipping clear saves ~18% CPU (8 MB memset at 1920x1080).
-		if r.executeFullscreenBlit(target) {
-			r.cleared = true
 			return
 		}
 		// No source texture found — apply clear only (clear-only pass).

--- a/hal/software/draw.go
+++ b/hal/software/draw.go
@@ -519,10 +519,10 @@ func (r *RenderPassEncoder) fetchTrianglesSPIRV(
 			// Build input map for this invocation.
 			inputs := make(map[uint32]shader.Value)
 			if hasVertexIndex {
-				inputs[vertexIndexVarID] = vertexID
+				inputs[vertexIndexVarID] = shader.ValUint(vertexID)
 			}
 			if hasInstanceIndex {
-				inputs[instanceIndexVarID] = instanceID
+				inputs[instanceIndexVarID] = shader.ValUint(instanceID)
 			}
 
 			// Populate @location inputs from vertex buffer data.
@@ -721,31 +721,34 @@ func (r *RenderPassEncoder) buildExecutionContext() *shader.ExecutionContext {
 func floatsToShaderValue(vals []float32) shader.Value {
 	switch len(vals) {
 	case 1:
-		return shader.Float32(vals[0])
+		return shader.ValFloat(vals[0])
 	case 2:
-		return shader.Vec2{vals[0], vals[1]}
+		return shader.ValVec2(vals[0], vals[1])
 	case 3:
-		return shader.Vec3{vals[0], vals[1], vals[2]}
+		return shader.ValVec3(vals[0], vals[1], vals[2])
 	case 4:
-		return shader.Vec4{vals[0], vals[1], vals[2], vals[3]}
+		return shader.ValVec4(vals[0], vals[1], vals[2], vals[3])
 	default:
 		if len(vals) == 0 {
-			return shader.Float32(0)
+			return shader.ValFloat(0)
 		}
-		return shader.Vec4{vals[0], vals[1], vals[2], vals[3]}
+		return shader.ValVec4(vals[0], vals[1], vals[2], vals[3])
 	}
 }
 
 // shaderValueToFloats converts a shader Value into a float32 slice.
 func shaderValueToFloats(val shader.Value) []float32 {
-	switch v := val.(type) {
-	case shader.Float32:
-		return []float32{v}
-	case shader.Vec2:
+	switch val.Tag {
+	case shader.TagFloat32:
+		return []float32{val.F[0]}
+	case shader.TagVec2:
+		v := val.AsVec2()
 		return v[:]
-	case shader.Vec3:
+	case shader.TagVec3:
+		v := val.AsVec3()
 		return v[:]
-	case shader.Vec4:
+	case shader.TagVec4:
+		v := val.AsVec4()
 		return v[:]
 	default:
 		return []float32{0}
@@ -973,10 +976,10 @@ func (r *RenderPassEncoder) executeSPIRVDraw(target *Texture, vertexCount, insta
 			vertexID := firstVertex + vert
 
 			inputs := map[uint32]shader.Value{
-				vertexIndexVarID: vertexID,
+				vertexIndexVarID: shader.ValUint(vertexID),
 			}
 			if hasInstanceIndex {
-				inputs[instanceIndexVarID] = instanceID
+				inputs[instanceIndexVarID] = shader.ValUint(instanceID)
 			}
 
 			ctx.Inputs = inputs

--- a/hal/software/shader/compute.go
+++ b/hal/software/shader/compute.go
@@ -47,7 +47,7 @@ func (m *Module) ExecuteCompute(entryPoint string, ctx *ExecutionContext) error 
 	interp.prevBlock = 0
 	interp.iterationCount = 0
 	interp.callDepth = 0
-	interp.returnValue = nil
+	interp.returnValue = Value{}
 
 	// Seed constants.
 	for id, val := range m.Constants {
@@ -126,12 +126,12 @@ func (interp *interpreter) initComputeBuiltins() {
 		case BuiltInWorkgroupSize:
 			val = uvec3ToValue(ctx.WorkgroupSize)
 		case BuiltInLocalInvocationIdx:
-			val = ctx.LocalInvocationIndex
+			val = ValUint(ctx.LocalInvocationIndex)
 		default:
 			continue
 		}
 
-		interp.values[varID] = interp.allocPointer(val)
+		interp.values[varID] = ValPointer(interp.allocPointer(val))
 	}
 }
 
@@ -155,23 +155,23 @@ func (interp *interpreter) initWorkgroupVariables() {
 				pointeeType := m.PointeeType(vi.TypeID)
 				if pointeeType != nil {
 					val := interp.readValueFromBuffer(sharedBuf, 0, pointeeType)
-					interp.values[varID] = interp.allocPointer(val)
+					interp.values[varID] = ValPointer(interp.allocPointer(val))
 					continue
 				}
 			}
 		}
 
 		// Default: zero-initialized.
-		interp.values[varID] = interp.allocPointer(zeroValueForVar(m, vi.TypeID))
+		interp.values[varID] = ValPointer(interp.allocPointer(zeroValueForVar(m, vi.TypeID)))
 	}
 }
 
-// uvec3ToValue converts a [3]uint32 to a Vec3 of floats.
+// uvec3ToValue converts a [3]uint32 to an Array of 3 Uint32 values.
 // SPIR-V represents compute built-ins as uvec3 (vector of 3 uint32).
-// For simplicity, we store them as Vec3 but retrieve via toUint32.
 func uvec3ToValue(v [3]uint32) Value {
 	// Store as an Array of 3 Uint32 values for proper integer handling.
-	return Array{v[0], v[1], v[2]}
+	arr := []Value{ValUint(v[0]), ValUint(v[1]), ValUint(v[2])}
+	return ValArray(arr)
 }
 
 // DispatchCompute executes a compute shader for all invocations in the dispatch.
@@ -257,36 +257,37 @@ func (interp *interpreter) executeAtomicOp(inst Instruction) Value {
 	// Atomic ops: OpAtomicIAdd, OpAtomicISub, etc.
 	// Operands: pointer, scope, semantics [, value]
 	if len(inst.Operands) < 3 {
-		return Uint32(0)
+		return ValUint(0)
 	}
 
 	ptrID := inst.Operands[0]
 	// scope and semantics are inst.Operands[1] and [2] -- ignored in single-threaded.
 
-	ptr, ok := interp.values[ptrID].(*Pointer)
-	if !ok {
-		return Uint32(0)
+	pv := interp.values[ptrID]
+	if pv.Tag != TagPointer {
+		return ValUint(0)
 	}
+	ptr := pv.AsPointer()
 
 	atomicMu.Lock()
 	defer atomicMu.Unlock()
 
-	oldVal := toUint32(ptr.Value)
+	oldVal := toUint32(ptr.Val)
 
 	switch inst.Opcode {
 	case OpAtomicIAdd:
 		if len(inst.Operands) >= 4 {
 			addVal := toUint32(interp.values[inst.Operands[3]])
-			ptr.Value = oldVal + addVal
+			ptr.Val = ValUint(oldVal + addVal)
 		}
 	case OpAtomicISub:
 		if len(inst.Operands) >= 4 {
 			subVal := toUint32(interp.values[inst.Operands[3]])
-			ptr.Value = oldVal - subVal
+			ptr.Val = ValUint(oldVal - subVal)
 		}
 	case OpAtomicExchange:
 		if len(inst.Operands) >= 4 {
-			ptr.Value = interp.values[inst.Operands[3]]
+			ptr.Val = interp.values[inst.Operands[3]]
 		}
 	case OpAtomicCompareExchange:
 		// Operands: pointer, scope, equal_sem, unequal_sem, value, comparator
@@ -294,7 +295,7 @@ func (interp *interpreter) executeAtomicOp(inst Instruction) Value {
 			newVal := toUint32(interp.values[inst.Operands[4]])
 			comparator := toUint32(interp.values[inst.Operands[5]])
 			if oldVal == comparator {
-				ptr.Value = newVal
+				ptr.Val = ValUint(newVal)
 			}
 		}
 	case OpAtomicSMin:
@@ -302,14 +303,14 @@ func (interp *interpreter) executeAtomicOp(inst Instruction) Value {
 			v := int32(toUint32(interp.values[inst.Operands[3]]))
 			old := int32(oldVal)
 			if v < old {
-				ptr.Value = uint32(v)
+				ptr.Val = ValUint(uint32(v))
 			}
 		}
 	case OpAtomicUMin:
 		if len(inst.Operands) >= 4 {
 			v := toUint32(interp.values[inst.Operands[3]])
 			if v < oldVal {
-				ptr.Value = v
+				ptr.Val = ValUint(v)
 			}
 		}
 	case OpAtomicSMax:
@@ -317,31 +318,31 @@ func (interp *interpreter) executeAtomicOp(inst Instruction) Value {
 			v := int32(toUint32(interp.values[inst.Operands[3]]))
 			old := int32(oldVal)
 			if v > old {
-				ptr.Value = uint32(v)
+				ptr.Val = ValUint(uint32(v))
 			}
 		}
 	case OpAtomicUMax:
 		if len(inst.Operands) >= 4 {
 			v := toUint32(interp.values[inst.Operands[3]])
 			if v > oldVal {
-				ptr.Value = v
+				ptr.Val = ValUint(v)
 			}
 		}
 	case OpAtomicIIncrement:
-		ptr.Value = oldVal + 1
+		ptr.Val = ValUint(oldVal + 1)
 	case OpAtomicIDecrement:
-		ptr.Value = oldVal - 1
+		ptr.Val = ValUint(oldVal - 1)
 	case OpAtomicLoad:
 		// Load is just a read -- no modification.
 	case OpAtomicStore:
 		// Store is special: no return value.
 		if len(inst.Operands) >= 4 {
-			ptr.Value = interp.values[inst.Operands[3]]
+			ptr.Val = interp.values[inst.Operands[3]]
 		}
-		return nil
+		return Value{}
 	}
 
-	return oldVal
+	return ValUint(oldVal)
 }
 
 // writeStorageBufferBack writes modified storage buffer values back to the
@@ -366,8 +367,9 @@ func (interp *interpreter) writeStorageBufferBack() {
 		if bufData == nil {
 			continue
 		}
-		if ptr, ok := interp.values[varID].(*Pointer); ok {
-			writeValueToBuffer(bufData, 0, ptr.Value)
+		v := interp.values[varID]
+		if v.Tag == TagPointer {
+			writeValueToBuffer(bufData, 0, v.AsPointer().Val)
 		}
 	}
 }

--- a/hal/software/shader/compute_test.go
+++ b/hal/software/shader/compute_test.go
@@ -330,10 +330,10 @@ func TestAtomicOps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ptr := &Pointer{Value: tt.initial}
+			ptr := &Pointer{Val: ValUint(tt.initial)}
 			interp := &interpreter{
 				module: m,
-				values: testMakeValues(map[uint32]Value{
+				values: testMakeValues(map[uint32]any{
 					1: ptr,
 					2: tt.operand,
 				}),
@@ -354,7 +354,7 @@ func TestAtomicOps(t *testing.T) {
 
 			old := interp.executeAtomicOp(inst)
 			gotOld := toUint32(old)
-			gotNew := toUint32(ptr.Value)
+			gotNew := toUint32(ptr.Val)
 
 			if gotOld != tt.wantOld {
 				t.Errorf("old value = %d, want %d", gotOld, tt.wantOld)
@@ -373,13 +373,13 @@ func TestAtomicCompareExchange(t *testing.T) {
 	}
 
 	// CAS succeeds: value=10, comparator=10, newValue=42
-	ptr := &Pointer{Value: Uint32(10)}
+	ptr := &Pointer{Val: ValUint(10)}
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{
+		values: testMakeValues(map[uint32]any{
 			1: ptr,
-			2: Uint32(42), // new value
-			3: Uint32(10), // comparator
+			2: ValUint(42), // new value
+			3: ValUint(10), // comparator
 		}),
 	}
 
@@ -395,23 +395,23 @@ func TestAtomicCompareExchange(t *testing.T) {
 	if toUint32(old) != 10 {
 		t.Errorf("CAS old = %d, want 10", toUint32(old))
 	}
-	if toUint32(ptr.Value) != 42 {
-		t.Errorf("CAS new = %d, want 42 (should have swapped)", toUint32(ptr.Value))
+	if toUint32(ptr.Val) != 42 {
+		t.Errorf("CAS new = %d, want 42 (should have swapped)", toUint32(ptr.Val))
 	}
 
 	// CAS fails: value=42, comparator=99 (doesn't match)
-	ptr.Value = Uint32(42)
-	interp.values[3] = Uint32(99) // wrong comparator
+	ptr.Val = ValUint(42)
+	interp.values[3] = ValUint(99) // wrong comparator
 	old = interp.executeAtomicOp(inst)
-	if toUint32(ptr.Value) != 42 {
-		t.Errorf("failed CAS new = %d, want 42 (should NOT have swapped)", toUint32(ptr.Value))
+	if toUint32(ptr.Val) != 42 {
+		t.Errorf("failed CAS new = %d, want 42 (should NOT have swapped)", toUint32(ptr.Val))
 	}
 	_ = old
 }
 
 func TestUvec3ToValue(t *testing.T) {
 	v := uvec3ToValue([3]uint32{10, 20, 30})
-	arr, ok := v.(Array)
+	arr, ok := testIsArray(v)
 	if !ok || len(arr) != 3 {
 		t.Fatalf("uvec3ToValue returned %T, want Array of 3", v)
 	}
@@ -678,7 +678,7 @@ func TestTriangleStillWorks(t *testing.T) {
 		}
 	}
 
-	inputs := map[uint32]Value{idxVarID: Uint32(0)}
+	inputs := map[uint32]Value{idxVarID: ValUint(0)}
 	outputs, err := m.Execute("vs_main", inputs)
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)

--- a/hal/software/shader/coverage_boost_test.go
+++ b/hal/software/shader/coverage_boost_test.go
@@ -345,10 +345,10 @@ func TestAtomicMinMaxOps(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ptr := &Pointer{Value: tt.initial}
+			ptr := &Pointer{Val: ValUint(tt.initial)}
 			interp := &interpreter{
 				module: m,
-				values: testMakeValues(map[uint32]Value{
+				values: testMakeValues(map[uint32]any{
 					1: ptr,
 					2: tt.operand,
 				}),
@@ -360,7 +360,7 @@ func TestAtomicMinMaxOps(t *testing.T) {
 			}
 			old := interp.executeAtomicOp(inst)
 			gotOld := toUint32(old)
-			gotNew := toUint32(ptr.Value)
+			gotNew := toUint32(ptr.Val)
 			if gotOld != tt.wantOld {
 				t.Errorf("old = %d, want %d", gotOld, tt.wantOld)
 			}
@@ -378,10 +378,10 @@ func TestAtomicLoadAndStore(t *testing.T) {
 
 	// AtomicLoad: read value without modification.
 	t.Run("atomic_load", func(t *testing.T) {
-		ptr := &Pointer{Value: Uint32(42)}
+		ptr := &Pointer{Val: ValUint(42)}
 		interp := &interpreter{
 			module: m,
-			values: testMakeValues(map[uint32]Value{1: ptr}),
+			values: testMakeValues(map[uint32]any{1: ptr}),
 		}
 		inst := Instruction{
 			Opcode:   OpAtomicLoad,
@@ -393,19 +393,19 @@ func TestAtomicLoadAndStore(t *testing.T) {
 			t.Errorf("AtomicLoad returned %d, want 42", toUint32(result))
 		}
 		// Value unchanged.
-		if toUint32(ptr.Value) != 42 {
-			t.Errorf("AtomicLoad modified ptr to %d, should remain 42", toUint32(ptr.Value))
+		if toUint32(ptr.Val) != 42 {
+			t.Errorf("AtomicLoad modified ptr to %d, should remain 42", toUint32(ptr.Val))
 		}
 	})
 
 	// AtomicStore: write value, return nil.
 	t.Run("atomic_store", func(t *testing.T) {
-		ptr := &Pointer{Value: Uint32(0)}
+		ptr := &Pointer{Val: ValUint(0)}
 		interp := &interpreter{
 			module: m,
-			values: testMakeValues(map[uint32]Value{
+			values: testMakeValues(map[uint32]any{
 				1: ptr,
-				2: Uint32(99),
+				2: ValUint(99),
 			}),
 		}
 		inst := Instruction{
@@ -414,11 +414,11 @@ func TestAtomicLoadAndStore(t *testing.T) {
 			Operands: []uint32{1, 0, 0, 2},
 		}
 		result := interp.executeAtomicOp(inst)
-		if result != nil {
+		if !result.IsNone() {
 			t.Errorf("AtomicStore returned %v, want nil", result)
 		}
-		if toUint32(ptr.Value) != 99 {
-			t.Errorf("AtomicStore wrote %d, want 99", toUint32(ptr.Value))
+		if toUint32(ptr.Val) != 99 {
+			t.Errorf("AtomicStore wrote %d, want 99", toUint32(ptr.Val))
 		}
 	})
 }
@@ -429,8 +429,8 @@ func TestAtomicOpNonPointer(t *testing.T) {
 	m := &Module{Types: map[uint32]*TypeInfo{}, Constants: map[uint32]Value{}}
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{
-			1: Uint32(42), // Not a pointer
+		values: testMakeValues(map[uint32]any{
+			1: ValUint(42), // Not a pointer
 		}),
 	}
 	inst := Instruction{
@@ -438,7 +438,7 @@ func TestAtomicOpNonPointer(t *testing.T) {
 		ResultID: 100,
 		Operands: []uint32{1, 0, 0, 1},
 	}
-	// Should return Uint32(0), not crash.
+	// Should return ValUint(0), not crash.
 	result := interp.executeAtomicOp(inst)
 	if toUint32(result) != 0 {
 		t.Errorf("atomic on non-pointer returned %d, want 0", toUint32(result))
@@ -483,10 +483,10 @@ func TestGLSLSmoothStepEdgeCases(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			interp := &interpreter{
 				module: m,
-				values: testMakeValues(map[uint32]Value{
-					10: Float32(tt.edge0),
-					11: Float32(tt.edge1),
-					12: Float32(tt.x),
+				values: testMakeValues(map[uint32]any{
+					10: ValFloat(tt.edge0),
+					11: ValFloat(tt.edge1),
+					12: ValFloat(tt.x),
 				}),
 			}
 			got := interp.executeGLSLExtInst(GLSLSmoothStep, []uint32{10, 11, 12})
@@ -509,10 +509,10 @@ func TestGLSLFClampMinGreaterThanMax(t *testing.T) {
 	}
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{
-			10: Float32(5),  // x
-			11: Float32(10), // min (greater than max!)
-			12: Float32(3),  // max
+		values: testMakeValues(map[uint32]any{
+			10: ValFloat(5),  // x
+			11: ValFloat(10), // min (greater than max!)
+			12: ValFloat(3),  // max
 		}),
 	}
 	got := interp.executeGLSLExtInst(GLSLFClamp, []uint32{10, 11, 12})
@@ -536,9 +536,9 @@ func TestGLSLPowNegativeBase(t *testing.T) {
 	}
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{
-			10: Float32(-2),
-			11: Float32(3),
+		values: testMakeValues(map[uint32]any{
+			10: ValFloat(-2),
+			11: ValFloat(3),
 		}),
 	}
 	got := interp.executeGLSLExtInst(GLSLPow, []uint32{10, 11})
@@ -574,7 +574,7 @@ func TestGLSLAtan2Quadrants(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			interp := &interpreter{
 				module: m,
-				values: testMakeValues(map[uint32]Value{10: Float32(tt.y), 11: Float32(tt.x)}),
+				values: testMakeValues(map[uint32]any{10: ValFloat(tt.y), 11: ValFloat(tt.x)}),
 			}
 			got := interp.executeGLSLExtInst(GLSLAtan2, []uint32{10, 11})
 			f := toFloat32(got)
@@ -596,13 +596,13 @@ func TestGLSLReflectViaExtInst(t *testing.T) {
 	// Reflect incident (1, -1, 0) around normal (0, 1, 0) -> (1, 1, 0)
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{
+		values: testMakeValues(map[uint32]any{
 			10: Vec3{1, -1, 0},
 			11: Vec3{0, 1, 0},
 		}),
 	}
 	got := interp.executeGLSLExtInst(GLSLReflect, []uint32{10, 11})
-	gv, ok := got.(Vec3)
+	gv, ok := testIsVec3(got)
 	if !ok {
 		t.Fatalf("reflect returned %T, want Vec3", got)
 	}
@@ -635,10 +635,10 @@ func TestGLSLFMix(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			interp := &interpreter{
 				module: m,
-				values: testMakeValues(map[uint32]Value{
-					10: Float32(tt.x),
-					11: Float32(tt.y),
-					12: Float32(tt.a),
+				values: testMakeValues(map[uint32]any{
+					10: ValFloat(tt.x),
+					11: ValFloat(tt.y),
+					12: ValFloat(tt.a),
 				}),
 			}
 			got := interp.executeGLSLExtInst(GLSLFMix, []uint32{10, 11, 12})
@@ -659,7 +659,7 @@ func TestGLSLLengthScalar(t *testing.T) {
 	}
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{10: Float32(-5)}),
+		values: testMakeValues(map[uint32]any{10: ValFloat(-5)}),
 	}
 	got := interp.executeGLSLExtInst(GLSLLength, []uint32{10})
 	f := toFloat32(got)
@@ -677,7 +677,7 @@ func TestGLSLDistanceVec3(t *testing.T) {
 	}
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{
+		values: testMakeValues(map[uint32]any{
 			10: Vec3{1, 0, 0},
 			11: Vec3{4, 0, 0},
 		}),
@@ -707,14 +707,14 @@ func TestGLSLTernaryVec2Vec3(t *testing.T) {
 	t.Run("vec2", func(t *testing.T) {
 		interp := &interpreter{
 			module: m,
-			values: testMakeValues(map[uint32]Value{
+			values: testMakeValues(map[uint32]any{
 				1: Vec2{-1, 5},
 				2: Vec2{0, 0},
 				3: Vec2{1, 1},
 			}),
 		}
 		got := interp.glslTernaryFloat([]uint32{1, 2, 3}, clamp)
-		v, ok := got.(Vec2)
+		v, ok := testIsVec2(got)
 		if !ok {
 			t.Fatalf("returned %T, want Vec2", got)
 		}
@@ -726,14 +726,14 @@ func TestGLSLTernaryVec2Vec3(t *testing.T) {
 	t.Run("vec3", func(t *testing.T) {
 		interp := &interpreter{
 			module: m,
-			values: testMakeValues(map[uint32]Value{
+			values: testMakeValues(map[uint32]any{
 				1: Vec3{-1, 0.5, 5},
 				2: Vec3{0, 0, 0},
 				3: Vec3{1, 1, 1},
 			}),
 		}
 		got := interp.glslTernaryFloat([]uint32{1, 2, 3}, clamp)
-		v, ok := got.(Vec3)
+		v, ok := testIsVec3(got)
 		if !ok {
 			t.Fatalf("returned %T, want Vec3", got)
 		}
@@ -830,11 +830,12 @@ func TestInitWorkgroupVariablesFromSharedMemory(t *testing.T) {
 	}
 	interp.initWorkgroupVariables()
 
-	ptr, ok := interp.values[idVarID].(*Pointer)
+	ptr := interp.values[idVarID].AsPointer()
+	ok := ptr != nil
 	if !ok {
 		t.Fatalf("workgroup variable is %T, want *Pointer", interp.values[idVarID])
 	}
-	f := toFloat32(ptr.Value)
+	f := toFloat32(ptr.Val)
 	if math.Abs(float64(f-42.0)) > 1e-5 {
 		t.Errorf("workgroup variable value = %v, want 42.0", f)
 	}
@@ -871,11 +872,12 @@ func TestInitWorkgroupVariablesDefault(t *testing.T) {
 	}
 	interp.initWorkgroupVariables()
 
-	ptr, ok := interp.values[idVarID].(*Pointer)
+	ptr := interp.values[idVarID].AsPointer()
+	ok := ptr != nil
 	if !ok {
 		t.Fatalf("workgroup variable is %T, want *Pointer", interp.values[idVarID])
 	}
-	f := toFloat32(ptr.Value)
+	f := toFloat32(ptr.Val)
 	if f != 0 {
 		t.Errorf("default workgroup variable = %v, want 0", f)
 	}
@@ -945,23 +947,23 @@ func TestVectorShuffleVariants(t *testing.T) {
 		want       Value
 	}{
 		// Identity shuffle (first 4 from v1)
-		{"identity", 2, Vec4{1, 2, 3, 4}, Vec4{5, 6, 7, 8},
-			[]uint32{0, 1, 2, 3}, Vec4{1, 2, 3, 4}},
+		{"identity", 2, ValVec4(1, 2, 3, 4), ValVec4(5, 6, 7, 8),
+			[]uint32{0, 1, 2, 3}, ValVec4(1, 2, 3, 4)},
 		// Reverse shuffle
-		{"reverse", 2, Vec4{1, 2, 3, 4}, Vec4{5, 6, 7, 8},
-			[]uint32{3, 2, 1, 0}, Vec4{4, 3, 2, 1}},
+		{"reverse", 2, ValVec4(1, 2, 3, 4), ValVec4(5, 6, 7, 8),
+			[]uint32{3, 2, 1, 0}, ValVec4(4, 3, 2, 1)},
 		// Two-source shuffle: take last 2 from v1, first 2 from v2
-		{"cross_source", 2, Vec4{1, 2, 3, 4}, Vec4{5, 6, 7, 8},
-			[]uint32{2, 3, 4, 5}, Vec4{3, 4, 5, 6}},
+		{"cross_source", 2, ValVec4(1, 2, 3, 4), ValVec4(5, 6, 7, 8),
+			[]uint32{2, 3, 4, 5}, ValVec4(3, 4, 5, 6)},
 		// Vec3 result
-		{"to_vec3", 3, Vec4{10, 20, 30, 40}, Vec4{50, 60, 70, 80},
-			[]uint32{0, 4, 2}, Vec3{10, 50, 30}},
+		{"to_vec3", 3, ValVec4(10, 20, 30, 40), ValVec4(50, 60, 70, 80),
+			[]uint32{0, 4, 2}, ValVec3(10, 50, 30)},
 		// Vec2 from vec4 (single-component extract equivalent)
-		{"to_vec2", 4, Vec4{10, 20, 30, 40}, Vec4{0, 0, 0, 0},
-			[]uint32{1, 3}, Vec2{20, 40}},
+		{"to_vec2", 4, ValVec4(10, 20, 30, 40), ValVec4(0, 0, 0, 0),
+			[]uint32{1, 3}, ValVec2(20, 40)},
 		// With undefined component (0xFFFFFFFF)
-		{"with_undef", 3, Vec4{1, 2, 3, 4}, Vec4{5, 6, 7, 8},
-			[]uint32{0, 0xFFFFFFFF, 2}, Vec3{1, 0, 3}},
+		{"with_undef", 3, ValVec4(1, 2, 3, 4), ValVec4(5, 6, 7, 8),
+			[]uint32{0, 0xFFFFFFFF, 2}, ValVec3(1, 0, 3)},
 	}
 
 	for _, tt := range tests {
@@ -979,30 +981,30 @@ func TestVectorShuffleNoTypeInfo(t *testing.T) {
 	m := &Module{Types: map[uint32]*TypeInfo{}} // No type info for result
 
 	// Should fall back to inferring from component count.
-	got := vectorShuffle(m, 999, Vec4{1, 2, 3, 4}, Vec4{5, 6, 7, 8}, []uint32{0, 1, 2, 3})
-	_, ok := got.(Vec4)
+	got := vectorShuffle(m, 999, ValVec4From(Vec4{1, 2, 3, 4}), ValVec4From(Vec4{5, 6, 7, 8}), []uint32{0, 1, 2, 3})
+	_, ok := testIsVec4(got)
 	if !ok {
 		t.Errorf("vectorShuffle fallback returned %T, want Vec4", got)
 	}
 
 	// 3-component fallback
-	got = vectorShuffle(m, 999, Vec4{1, 2, 3, 4}, Vec4{5, 6, 7, 8}, []uint32{0, 1, 2})
-	_, ok = got.(Vec3)
+	got = vectorShuffle(m, 999, ValVec4From(Vec4{1, 2, 3, 4}), ValVec4From(Vec4{5, 6, 7, 8}), []uint32{0, 1, 2})
+	_, ok = testIsVec3(got)
 	if !ok {
 		t.Errorf("vectorShuffle 3-component fallback returned %T, want Vec3", got)
 	}
 
 	// 2-component fallback
-	got = vectorShuffle(m, 999, Vec4{1, 2, 3, 4}, Vec4{5, 6, 7, 8}, []uint32{0, 1})
-	_, ok = got.(Vec2)
+	got = vectorShuffle(m, 999, ValVec4From(Vec4{1, 2, 3, 4}), ValVec4From(Vec4{5, 6, 7, 8}), []uint32{0, 1})
+	_, ok = testIsVec2(got)
 	if !ok {
 		t.Errorf("vectorShuffle 2-component fallback returned %T, want Vec2", got)
 	}
 
-	// 1-component fallback (degenerate case: vectorShuffle returns Float32(0)
+	// 1-component fallback (degenerate case: vectorShuffle returns ValFloat(0)
 	// because it only handles 2/3/4 component counts)
-	got = vectorShuffle(m, 999, Vec4{42, 0, 0, 0}, Vec4{0, 0, 0, 0}, []uint32{0})
-	_, ok = got.(Float32)
+	got = vectorShuffle(m, 999, ValVec4From(Vec4{42, 0, 0, 0}), ValVec4From(Vec4{0, 0, 0, 0}), []uint32{0})
+	_, ok = testIsFloat32(got)
 	if !ok {
 		t.Fatalf("vectorShuffle 1-component returned %T, want Float32", got)
 	}
@@ -1085,10 +1087,11 @@ func TestFetchTexelNegativeCoords(t *testing.T) {
 			255, 255, 255, 255,
 		},
 	}
-	interp := &interpreter{ctx: &ExecutionContext{}}
+	bk := BindingKey{Group: 0, Binding: 0}
+	interp := &interpreter{ctx: &ExecutionContext{Textures: map[BindingKey]*Texture2D{bk: tex}}}
 
 	// Negative coords should clamp to 0.
-	got := interp.fetchTexel(tex, Vec2{-5, -5})
+	got := interp.fetchTexel(ValBindingKey(bk), ValVec2(-5, -5))
 	gv := Vec4ToFloat32(got)
 	// (0,0) is red
 	if math.Abs(float64(gv[0]-1)) > 0.01 || math.Abs(float64(gv[1])) > 0.01 {
@@ -1106,10 +1109,11 @@ func TestFetchTexelScalarCoord(t *testing.T) {
 			255, 255, 255, 255, // (2,0) white
 		},
 	}
-	interp := &interpreter{ctx: &ExecutionContext{}}
+	bk := BindingKey{Group: 0, Binding: 0}
+	interp := &interpreter{ctx: &ExecutionContext{Textures: map[BindingKey]*Texture2D{bk: tex}}}
 
 	// Scalar coord should be treated as x, y=0.
-	got := interp.fetchTexel(tex, Uint32(2))
+	got := interp.fetchTexel(ValBindingKey(bk), ValUint(2))
 	gv := Vec4ToFloat32(got)
 	if math.Abs(float64(gv[0]-1)) > 0.01 {
 		t.Errorf("fetchTexel(scalar 2) = %v, want white", gv)
@@ -1119,7 +1123,7 @@ func TestFetchTexelScalarCoord(t *testing.T) {
 // TestFetchTexelNilTexture verifies graceful handling of nil texture.
 func TestFetchTexelNilTexture(t *testing.T) {
 	interp := &interpreter{ctx: &ExecutionContext{}}
-	got := interp.fetchTexel(nil, Vec2{0, 0})
+	got := interp.fetchTexel(ValBindingKey(BindingKey{}), ValVec2(0, 0))
 	gv := Vec4ToFloat32(got)
 	if gv != (Vec4{0, 0, 0, 0}) {
 		t.Errorf("fetchTexel(nil) = %v, want zero", gv)
@@ -1137,17 +1141,18 @@ func TestFetchTexelVec3Vec4Coords(t *testing.T) {
 			255, 255, 255, 255, // (1,1)
 		},
 	}
-	interp := &interpreter{ctx: &ExecutionContext{}}
+	bk := BindingKey{Group: 0, Binding: 0}
+	interp := &interpreter{ctx: &ExecutionContext{Textures: map[BindingKey]*Texture2D{bk: tex}}}
 
 	// Vec3 coord: use x,y components
-	got := interp.fetchTexel(tex, Vec3{1, 1, 0})
+	got := interp.fetchTexel(ValBindingKey(bk), ValVec3(1, 1, 0))
 	gv := Vec4ToFloat32(got)
 	if gv != (Vec4{1, 1, 1, 1}) {
 		t.Errorf("fetchTexel(Vec3{1,1,0}) = %v, want white", gv)
 	}
 
 	// Vec4 coord: use x,y components
-	got = interp.fetchTexel(tex, Vec4{0, 1, 0, 0})
+	got = interp.fetchTexel(ValBindingKey(bk), ValVec4(0, 1, 0, 0))
 	gv = Vec4ToFloat32(got)
 	// (0,1) = blue
 	if math.Abs(float64(gv[2]-1)) > 0.01 {
@@ -1238,19 +1243,19 @@ func TestSampleTextureCoordTypes(t *testing.T) {
 	}
 
 	si := &SampledImageValue{
-		Image:   BindingKey{Group: 0, Binding: 0},
-		Sampler: BindingKey{Group: 0, Binding: 1},
+		Image:   ValBindingKey(BindingKey{Group: 0, Binding: 0}),
+		Sampler: ValBindingKey(BindingKey{Group: 0, Binding: 1}),
 	}
 
 	// Vec3 coord: should use first 2 components as UV.
-	got := interp.sampleTexture(si, Vec3{0, 0, 999}, 0)
+	got := interp.sampleTexture(ValSampledImage(si), ValVec3(0, 0, 999), 0)
 	gv := Vec4ToFloat32(got)
 	if math.Abs(float64(gv[0]-1)) > 0.05 { // Red at (0,0)
 		t.Errorf("sampleTexture(Vec3) = %v, want red", gv)
 	}
 
 	// Scalar coord: should use as U, V=0.
-	got = interp.sampleTexture(si, Float32(0), 0)
+	got = interp.sampleTexture(ValSampledImage(si), ValFloat(0), 0)
 	gv = Vec4ToFloat32(got)
 	// u=0, v=0 -> (0,0) = Red
 	if math.Abs(float64(gv[0]-1)) > 0.05 {
@@ -1276,19 +1281,19 @@ func TestReadValueFromBufferShortBuffers(t *testing.T) {
 
 	// Signed int on short buffer returns zero.
 	got := interp.readValueFromBuffer(short, 0, m.Types[1])
-	if v, ok := got.(Int32); !ok || v != 0 {
-		t.Errorf("short signed int = %v, want Int32(0)", got)
+	if got.Tag != TagInt32 || got.AsInt32() != 0 {
+		t.Errorf("short signed int = %v, want ValInt(0)", got)
 	}
 
 	// Unsigned int on short buffer returns zero.
 	got = interp.readValueFromBuffer(short, 0, m.Types[2])
-	if v, ok := got.(Uint32); !ok || v != 0 {
-		t.Errorf("short unsigned int = %v, want Uint32(0)", got)
+	if got.Tag != TagUint32 || got.AsUint32() != 0 {
+		t.Errorf("short unsigned int = %v, want ValUint(0)", got)
 	}
 
 	// Bool on short buffer returns false.
 	got = interp.readValueFromBuffer(short, 0, m.Types[3])
-	if v, ok := got.(bool); !ok || v != false {
+	if v, ok := testIsBool(got); !ok || v != false {
 		t.Errorf("short bool = %v, want false", got)
 	}
 }
@@ -1301,9 +1306,9 @@ func TestReadValueFromBufferShortBuffers(t *testing.T) {
 func TestWriteValueToBufferShortBuffer(t *testing.T) {
 	// Writing to a buffer that is too short should not panic.
 	short := make([]byte, 2)
-	writeValueToBuffer(short, 0, Float32(3.14))
-	writeValueToBuffer(short, 0, Uint32(42))
-	writeValueToBuffer(short, 0, Int32(-7))
+	writeValueToBuffer(short, 0, ValFloat(3.14))
+	writeValueToBuffer(short, 0, ValUint(42))
+	writeValueToBuffer(short, 0, ValInt(-7))
 	// If we get here without panic, the test passes.
 }
 
@@ -1378,7 +1383,7 @@ func TestOpUndef(t *testing.T) {
 		vi := m.Variables[varID]
 		if vi != nil && vi.StorageClass == StorageClassOutput {
 			color := Vec4ToFloat32(outputs[varID])
-			// OpUndef should produce 0 (our implementation uses Uint32(0)).
+			// OpUndef should produce 0 (our implementation uses ValUint(0)).
 			if color[0] != 0 {
 				t.Errorf("OpUndef produced %v, want 0", color[0])
 			}
@@ -1402,25 +1407,25 @@ func TestComparisonOpsViaInterpreter(t *testing.T) {
 		a, b   Value
 		want   bool
 	}{
-		{"u_gt_true", OpUGreaterThan, Uint32(10), Uint32(3), true},
-		{"u_gt_false", OpUGreaterThan, Uint32(3), Uint32(10), false},
-		{"u_le_true", OpULessThanEqual, Uint32(3), Uint32(3), true},
-		{"u_le_false", OpULessThanEqual, Uint32(4), Uint32(3), false},
-		{"u_ge_true", OpUGreaterThanEqual, Uint32(3), Uint32(3), true},
-		{"u_ge_false", OpUGreaterThanEqual, Uint32(2), Uint32(3), false},
-		{"s_gt_true", OpSGreaterThan, Uint32(5), Uint32(0xFFFFFFFB), true},            // 5 > -5 (signed)
-		{"s_le_true", OpSLessThanEqual, Uint32(0xFFFFFFFB), Uint32(0xFFFFFFFB), true}, // -5 <= -5 (signed)
-		{"s_ge_true", OpSGreaterThanEqual, Uint32(0), Uint32(0xFFFFFFFF), true},       // 0 >= -1 (signed)
-		{"ieq_true", OpIEqual, Uint32(42), Uint32(42), true},
-		{"ieq_false", OpIEqual, Uint32(1), Uint32(2), false},
-		{"ine_true", OpINotEqual, Uint32(1), Uint32(2), true},
-		{"ine_false", OpINotEqual, Uint32(5), Uint32(5), false},
-		{"ford_eq_true", OpFOrdEqual, Float32(3.14), Float32(3.14), true},
-		{"ford_eq_false", OpFOrdEqual, Float32(1), Float32(2), false},
-		{"ford_lt_true", OpFOrdLessThan, Float32(1), Float32(2), true},
-		{"ford_gt_true", OpFOrdGreaterThan, Float32(2), Float32(1), true},
-		{"ford_le_true", OpFOrdLessThanEqual, Float32(1), Float32(1), true},
-		{"ford_ge_true", OpFOrdGreaterThanEqual, Float32(2), Float32(2), true},
+		{"u_gt_true", OpUGreaterThan, ValUint(10), ValUint(3), true},
+		{"u_gt_false", OpUGreaterThan, ValUint(3), ValUint(10), false},
+		{"u_le_true", OpULessThanEqual, ValUint(3), ValUint(3), true},
+		{"u_le_false", OpULessThanEqual, ValUint(4), ValUint(3), false},
+		{"u_ge_true", OpUGreaterThanEqual, ValUint(3), ValUint(3), true},
+		{"u_ge_false", OpUGreaterThanEqual, ValUint(2), ValUint(3), false},
+		{"s_gt_true", OpSGreaterThan, ValUint(5), ValUint(0xFFFFFFFB), true},            // 5 > -5 (signed)
+		{"s_le_true", OpSLessThanEqual, ValUint(0xFFFFFFFB), ValUint(0xFFFFFFFB), true}, // -5 <= -5 (signed)
+		{"s_ge_true", OpSGreaterThanEqual, ValUint(0), ValUint(0xFFFFFFFF), true},       // 0 >= -1 (signed)
+		{"ieq_true", OpIEqual, ValUint(42), ValUint(42), true},
+		{"ieq_false", OpIEqual, ValUint(1), ValUint(2), false},
+		{"ine_true", OpINotEqual, ValUint(1), ValUint(2), true},
+		{"ine_false", OpINotEqual, ValUint(5), ValUint(5), false},
+		{"ford_eq_true", OpFOrdEqual, ValFloat(3.14), ValFloat(3.14), true},
+		{"ford_eq_false", OpFOrdEqual, ValFloat(1), ValFloat(2), false},
+		{"ford_lt_true", OpFOrdLessThan, ValFloat(1), ValFloat(2), true},
+		{"ford_gt_true", OpFOrdGreaterThan, ValFloat(2), ValFloat(1), true},
+		{"ford_le_true", OpFOrdLessThanEqual, ValFloat(1), ValFloat(1), true},
+		{"ford_ge_true", OpFOrdGreaterThanEqual, ValFloat(2), ValFloat(2), true},
 	}
 
 	for _, tt := range tests {
@@ -1438,7 +1443,7 @@ func TestComparisonOpsViaInterpreter(t *testing.T) {
 				fn:     fn,
 				ep:     &EntryPoint{},
 				ctx:    &ExecutionContext{},
-				values: testMakeValues(map[uint32]Value{1: tt.a, 2: tt.b}),
+				values: testMakeValues(map[uint32]any{1: tt.a, 2: tt.b}),
 			}
 
 			err := interp.run()
@@ -1446,7 +1451,7 @@ func TestComparisonOpsViaInterpreter(t *testing.T) {
 				t.Fatalf("run() failed: %v", err)
 			}
 
-			got, ok := interp.values[10].(bool)
+			got, ok := testIsBool(interp.values[10])
 			if !ok {
 				t.Fatalf("comparison result is %T, want bool", interp.values[10])
 			}
@@ -1464,7 +1469,7 @@ func TestComparisonOpsViaInterpreter(t *testing.T) {
 
 func TestValueByteSizeDefault(t *testing.T) {
 	// An unknown type (string, struct pointer, etc.) should return 4.
-	got := valueByteSize("not_a_value_type")
+	got := valueByteSize(Value{})
 	if got != 4 {
 		t.Errorf("valueByteSize(string) = %d, want 4", got)
 	}
@@ -1503,7 +1508,7 @@ func TestDivisionByZeroOpcodes(t *testing.T) {
 				},
 				ep:     &EntryPoint{},
 				ctx:    &ExecutionContext{},
-				values: testMakeValues(map[uint32]Value{1: Uint32(42), 2: Uint32(0)}),
+				values: testMakeValues(map[uint32]any{1: ValUint(42), 2: ValUint(0)}),
 			}
 
 			// Should not panic.

--- a/hal/software/shader/coverage_test.go
+++ b/hal/software/shader/coverage_test.go
@@ -19,16 +19,16 @@ func TestConvertSignedToFloat(t *testing.T) {
 		val  Value
 		want float32
 	}{
-		{"int32_pos", Int32(42), 42},
-		{"int32_neg", Int32(-7), -7},
-		{"uint32_as_signed", Uint32(100), 100},
-		{"float32_passthrough", Float32(3.14), 3.14},
-		{"nil", nil, 0},
+		{"int32_pos", ValInt(42), 42},
+		{"int32_neg", ValInt(-7), -7},
+		{"uint32_as_signed", ValUint(100), 100},
+		{"float32_passthrough", ValFloat(3.14), 3.14},
+		{"nil", Value{}, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convertSignedToFloat(tt.val)
-			f, ok := got.(Float32)
+			f, ok := testIsFloat32(got)
 			if !ok {
 				t.Fatalf("returned %T, want Float32", got)
 			}
@@ -45,10 +45,10 @@ func TestConvertFloatToUint(t *testing.T) {
 		val  Value
 		want uint32
 	}{
-		{"float_5", Float32(5), 5},
-		{"uint_pass", Uint32(10), 10},
-		{"int_pass", Int32(7), 7},
-		{"nil", nil, 0},
+		{"float_5", ValFloat(5), 5},
+		{"uint_pass", ValUint(10), 10},
+		{"int_pass", ValInt(7), 7},
+		{"nil", Value{}, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -67,15 +67,15 @@ func TestToBoolTypes(t *testing.T) {
 		val  Value
 		want bool
 	}{
-		{"bool_true", true, true},
-		{"bool_false", false, false},
-		{"uint_nonzero", Uint32(1), true},
-		{"uint_zero", Uint32(0), false},
-		{"int_nonzero", Int32(-1), true},
-		{"int_zero", Int32(0), false},
-		{"float_nonzero", Float32(0.1), true},
-		{"float_zero", Float32(0), false},
-		{"nil", nil, false},
+		{"bool_true", ValBool(true), true},
+		{"bool_false", ValBool(false), false},
+		{"uint_nonzero", ValUint(1), true},
+		{"uint_zero", ValUint(0), false},
+		{"int_nonzero", ValInt(-1), true},
+		{"int_zero", ValInt(0), false},
+		{"float_nonzero", ValFloat(0.1), true},
+		{"float_zero", ValFloat(0), false},
+		{"nil", Value{}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -93,10 +93,10 @@ func TestToFloat32Types(t *testing.T) {
 		val  Value
 		want float32
 	}{
-		{"float", Float32(3.14), 3.14},
-		{"uint", Uint32(42), 42},
-		{"int", Int32(-5), -5},
-		{"nil", nil, 0},
+		{"float", ValFloat(3.14), 3.14},
+		{"uint", ValUint(42), 42},
+		{"int", ValInt(-5), -5},
+		{"nil", Value{}, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -114,12 +114,12 @@ func TestToUint32Types(t *testing.T) {
 		val  Value
 		want uint32
 	}{
-		{"uint", Uint32(42), 42},
-		{"int", Int32(7), 7},
-		{"float", Float32(5.9), 5},
-		{"bool_true", true, 1},
-		{"bool_false", false, 0},
-		{"nil", nil, 0},
+		{"uint", ValUint(42), 42},
+		{"int", ValInt(7), 7},
+		{"float", ValFloat(5.9), 5},
+		{"bool_true", ValBool(true), 1},
+		{"bool_false", ValBool(false), 0},
+		{"nil", Value{}, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -133,13 +133,13 @@ func TestToUint32Types(t *testing.T) {
 
 func TestAppendComponentsAllTypes(t *testing.T) {
 	var out []float32
-	out = appendComponents(out, Float32(1))
-	out = appendComponents(out, Vec2{2, 3})
-	out = appendComponents(out, Vec3{4, 5, 6})
-	out = appendComponents(out, Vec4{7, 8, 9, 10})
-	out = appendComponents(out, Uint32(11))
-	out = appendComponents(out, Int32(12))
-	out = appendComponents(out, nil) // default
+	out = appendComponents(out, ValFloat(1))
+	out = appendComponents(out, ValVec2(2, 3))
+	out = appendComponents(out, ValVec3(4, 5, 6))
+	out = appendComponents(out, ValVec4(7, 8, 9, 10))
+	out = appendComponents(out, ValUint(11))
+	out = appendComponents(out, ValInt(12))
+	out = appendComponents(out, Value{}) // default
 
 	want := []float32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 0}
 	if len(out) != len(want) {
@@ -358,7 +358,7 @@ func TestZeroValueForVar(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			val := zeroValueForVar(m, tt.ptrType)
-			if val == nil {
+			if val.IsNone() {
 				t.Fatalf("zeroValueForVar returned nil")
 			}
 		})
@@ -405,17 +405,17 @@ func TestCompositeConstructStruct(t *testing.T) {
 			2: {Kind: TypeFloat, Width: 32},
 		},
 		Constants: map[uint32]Value{
-			10: Float32(1),
-			11: Float32(2),
+			10: ValFloat(1),
+			11: ValFloat(2),
 		},
 	}
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{10: Float32(1), 11: Float32(2)}),
+		values: testMakeValues(map[uint32]any{10: ValFloat(1), 11: ValFloat(2)}),
 	}
 
 	got := interp.compositeConstruct(1, []uint32{10, 11})
-	arr, ok := got.(Array)
+	arr, ok := testIsArray(got)
 	if !ok || len(arr) != 2 {
 		t.Fatalf("compositeConstruct struct returned %T", got)
 	}
@@ -429,14 +429,14 @@ func TestFloatBinOpMismatch(t *testing.T) {
 	add := func(a, b float32) float32 { return a + b }
 
 	// Vec2 + non-Vec2 returns a (unchanged).
-	got := floatBinOp(Vec2{1, 2}, Float32(3), add)
-	if _, ok := got.(Vec2); !ok {
+	got := floatBinOp(ValVec2From(Vec2{1, 2}), ValFloat(3), add)
+	if _, ok := testIsVec2(got); !ok {
 		t.Errorf("vec2 + scalar returned %T, want Vec2", got)
 	}
 
 	// Non-float types.
-	got = floatBinOp(nil, nil, add)
-	if _, ok := got.(Float32); !ok {
+	got = floatBinOp(Value{}, Value{}, add)
+	if _, ok := testIsFloat32(got); !ok {
 		t.Errorf("nil + nil returned %T, want Float32", got)
 	}
 }
@@ -448,16 +448,16 @@ func TestFloatUnaryOpAllTypes(t *testing.T) {
 		name string
 		val  Value
 	}{
-		{"scalar", Float32(5)},
-		{"vec2", Vec2{1, 2}},
-		{"vec3", Vec3{1, 2, 3}},
-		{"vec4", Vec4{1, 2, 3, 4}},
-		{"nil", nil},
+		{"scalar", ValFloat(5)},
+		{"vec2", ValVec2From(Vec2{1, 2})},
+		{"vec3", ValVec3From(Vec3{1, 2, 3})},
+		{"vec4", ValVec4From(Vec4{1, 2, 3, 4})},
+		{"nil", Value{}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := floatUnaryOp(tt.val, neg)
-			if got == nil {
+			if got.IsNone() {
 				t.Fatal("returned nil")
 			}
 		})
@@ -465,9 +465,9 @@ func TestFloatUnaryOpAllTypes(t *testing.T) {
 }
 
 func TestWriteValueToBufferArray(t *testing.T) {
-	arr := Array{Float32(1), Float32(2), Float32(3)}
+	arr := Array{ValFloat(1), ValFloat(2), ValFloat(3)}
 	buf := make([]byte, 12)
-	writeValueToBuffer(buf, 0, arr)
+	writeValueToBuffer(buf, 0, ValArray(arr))
 
 	for i := 0; i < 3; i++ {
 		got := readFloat32LE(buf[i*4:])
@@ -484,10 +484,10 @@ func TestGlslTernaryFloat(t *testing.T) {
 	}
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{
-			1: Float32(5),
-			2: Float32(0),
-			3: Float32(10),
+		values: testMakeValues(map[uint32]any{
+			1: ValFloat(5),
+			2: ValFloat(0),
+			3: ValFloat(10),
 			4: Vec4{5, 5, 5, 5},
 			5: Vec4{0, 0, 0, 0},
 			6: Vec4{10, 10, 10, 10},
@@ -506,13 +506,13 @@ func TestGlslTernaryFloat(t *testing.T) {
 	}
 
 	got := interp.glslTernaryFloat([]uint32{1, 2, 3}, clamp)
-	if f, ok := got.(Float32); !ok || f != 5 {
+	if f, ok := testIsFloat32(got); !ok || f != 5 {
 		t.Errorf("clamp(5, 0, 10) = %v, want 5", got)
 	}
 
 	// Test vec4 clamp.
 	got = interp.glslTernaryFloat([]uint32{4, 5, 6}, clamp)
-	if v, ok := got.(Vec4); !ok || v[0] != 5 {
+	if v, ok := testIsVec4(got); !ok || v[0] != 5 {
 		t.Errorf("vec4 clamp = %v, want all 5s", got)
 	}
 }
@@ -521,7 +521,7 @@ func TestGlslBinaryUint(t *testing.T) {
 	m := &Module{Types: map[uint32]*TypeInfo{}, Constants: map[uint32]Value{}}
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{1: Uint32(5), 2: Uint32(3)}),
+		values: testMakeValues(map[uint32]any{1: ValUint(5), 2: ValUint(3)}),
 	}
 	got := interp.glslBinaryUint([]uint32{1, 2}, func(a, b uint32) uint32 {
 		if a < b {
@@ -529,7 +529,7 @@ func TestGlslBinaryUint(t *testing.T) {
 		}
 		return b
 	})
-	if u, ok := got.(Uint32); !ok || u != 3 {
+	if got.Tag != TagUint32 || got.AsUint32() != 3 {
 		t.Errorf("umin(5,3) = %v, want 3", got)
 	}
 }
@@ -538,7 +538,7 @@ func TestGlslBinaryInt(t *testing.T) {
 	m := &Module{Types: map[uint32]*TypeInfo{}, Constants: map[uint32]Value{}}
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{1: Int32(-5), 2: Int32(3)}),
+		values: testMakeValues(map[uint32]any{1: ValInt(-5), 2: ValInt(3)}),
 	}
 	got := interp.glslBinaryInt([]uint32{1, 2}, func(a, b int32) int32 {
 		if a < b {
@@ -546,7 +546,7 @@ func TestGlslBinaryInt(t *testing.T) {
 		}
 		return b
 	})
-	if v, ok := got.(Int32); !ok || v != -5 {
+	if got.Tag != TagInt32 || got.AsInt32() != -5 {
 		t.Errorf("smin(-5,3) = %v, want -5", got)
 	}
 }
@@ -583,13 +583,13 @@ func TestReadValueFromBufferAllTypes(t *testing.T) {
 
 	// Test float read.
 	val := interp.readValueFromBuffer(buf, 0, m.Types[1])
-	if f, ok := val.(Float32); !ok || math.Abs(float64(f-3.14)) > 0.01 {
+	if val.Tag != TagFloat32 || math.Abs(float64(val.AsFloat32()-3.14)) > 0.01 {
 		t.Errorf("float read = %v, want ~3.14", val)
 	}
 
 	// Test signed int read.
 	val = interp.readValueFromBuffer(buf, 4, m.Types[2])
-	if v, ok := val.(Int32); !ok || v != -7 {
+	if val.Tag != TagInt32 || val.AsInt32() != -7 {
 		t.Errorf("signed int read = %v, want -7", val)
 	}
 
@@ -597,14 +597,14 @@ func TestReadValueFromBufferAllTypes(t *testing.T) {
 	putFloat32LE(buf[8:], 0)
 	buf[8] = 42
 	val = interp.readValueFromBuffer(buf, 8, m.Types[3])
-	if v, ok := val.(Uint32); !ok || v != 42 {
+	if val.Tag != TagUint32 || val.AsUint32() != 42 {
 		t.Errorf("unsigned int read = %v, want 42", val)
 	}
 
 	// Test bool read.
 	buf[12] = 1
 	val = interp.readValueFromBuffer(buf, 12, m.Types[4])
-	if v, ok := val.(bool); !ok || !v {
+	if val.Tag != TagBool || !val.AsBool() {
 		t.Errorf("bool read = %v, want true", val)
 	}
 
@@ -612,7 +612,7 @@ func TestReadValueFromBufferAllTypes(t *testing.T) {
 	putFloat32LE(buf[0:], 1.0)
 	putFloat32LE(buf[4:], 2.0)
 	val = interp.readValueFromBuffer(buf, 0, m.Types[5])
-	if v, ok := val.(Vec2); !ok || v[0] != 1.0 || v[1] != 2.0 {
+	if val.Tag != TagVec2 || val.F[0] != 1.0 || val.F[1] != 2.0 {
 		t.Errorf("vec2 read = %v, want {1, 2}", val)
 	}
 
@@ -621,7 +621,7 @@ func TestReadValueFromBufferAllTypes(t *testing.T) {
 	putFloat32LE(buf[4:], 2.0)
 	putFloat32LE(buf[8:], 3.0)
 	val = interp.readValueFromBuffer(buf, 0, m.Types[6])
-	if v, ok := val.(Vec3); !ok || v != (Vec3{1, 2, 3}) {
+	if val.Tag != TagVec3 || val.AsVec3() != (Vec3{1, 2, 3}) {
 		t.Errorf("vec3 read = %v, want {1, 2, 3}", val)
 	}
 
@@ -632,27 +632,27 @@ func TestReadValueFromBufferAllTypes(t *testing.T) {
 	buf[6] = 0
 	buf[7] = 0
 	val = interp.readValueFromBuffer(buf, 0, m.Types[9])
-	arr, ok := val.(Array)
+	arr, ok := testIsArray(val)
 	if !ok || len(arr) != 2 {
 		t.Fatalf("struct read returned unexpected type or length")
 	}
-	if f, ok := arr[0].(Float32); !ok || f != 5.0 {
+	if arr[0].Tag != TagFloat32 || arr[0].AsFloat32() != 5.0 {
 		t.Errorf("struct[0] = %v, want 5.0", arr[0])
 	}
-	if u, ok := arr[1].(Uint32); !ok || u != 10 {
+	if arr[1].Tag != TagUint32 || arr[1].AsUint32() != 10 {
 		t.Errorf("struct[1] = %v, want 10", arr[1])
 	}
 
 	// Test short buffer (should return zeros).
 	val = interp.readValueFromBuffer(buf[:2], 0, m.Types[1])
-	if f, ok := val.(Float32); !ok || f != 0 {
+	if val.Tag != TagFloat32 || val.AsFloat32() != 0 {
 		t.Errorf("short buffer read = %v, want 0", val)
 	}
 }
 
 func TestWriteValueToBufferVec3(t *testing.T) {
 	buf := make([]byte, 12)
-	writeValueToBuffer(buf, 0, Vec3{1, 2, 3})
+	writeValueToBuffer(buf, 0, ValVec3(1, 2, 3))
 	for i := 0; i < 3; i++ {
 		got := readFloat32LE(buf[i*4:])
 		if got != float32(i+1) {
@@ -661,9 +661,9 @@ func TestWriteValueToBufferVec3(t *testing.T) {
 	}
 }
 
-func TestWriteValueToBufferInt32(t *testing.T) {
+func TestWriteValueToBufferValInt(t *testing.T) {
 	buf := make([]byte, 4)
-	writeValueToBuffer(buf, 0, Int32(-42))
+	writeValueToBuffer(buf, 0, ValInt(-42))
 	got := readUint32LE(buf)
 	if int32(got) != -42 {
 		t.Errorf("int32 write = %d, want -42", int32(got))
@@ -677,11 +677,11 @@ func TestIndexCompositeAllTypes(t *testing.T) {
 		idx  uint32
 		want float32
 	}{
-		{"array", Array{Float32(10), Float32(20)}, 1, 20},
-		{"vec2", Vec2{1, 2}, 1, 2},
-		{"vec3", Vec3{1, 2, 3}, 2, 3},
-		{"vec4", Vec4{1, 2, 3, 4}, 3, 4},
-		{"oob_array", Array{Float32(10)}, 5, 0},
+		{"array", ValArray(Array{ValFloat(10), ValFloat(20)}), 1, 20},
+		{"vec2", ValVec2From(Vec2{1, 2}), 1, 2},
+		{"vec3", ValVec3From(Vec3{1, 2, 3}), 2, 3},
+		{"vec4", ValVec4From(Vec4{1, 2, 3, 4}), 3, 4},
+		{"oob_array", ValArray(Array{ValFloat(10)}), 5, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -703,13 +703,13 @@ func TestCompositeConstructArray(t *testing.T) {
 	}
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{
-			10: Float32(1), 11: Float32(2), 12: Float32(3),
+		values: testMakeValues(map[uint32]any{
+			10: ValFloat(1), 11: ValFloat(2), 12: ValFloat(3),
 		}),
 	}
 
 	got := interp.compositeConstruct(2, []uint32{10, 11, 12})
-	arr, ok := got.(Array)
+	arr, ok := testIsArray(got)
 	if !ok || len(arr) != 3 {
 		t.Fatalf("compositeConstruct array returned %T", got)
 	}
@@ -721,8 +721,8 @@ func TestVectorShuffleUndefined(t *testing.T) {
 		2: {Kind: TypeVector, ElemType: 1, Components: 2},
 	}}
 	// 0xFFFFFFFF = undefined component
-	got := vectorShuffle(m, 2, Vec4{1, 2, 3, 4}, Vec4{5, 6, 7, 8}, []uint32{0, 0xFFFFFFFF})
-	gv, ok := got.(Vec2)
+	got := vectorShuffle(m, 2, ValVec4From(Vec4{1, 2, 3, 4}), ValVec4From(Vec4{5, 6, 7, 8}), []uint32{0, 0xFFFFFFFF})
+	gv, ok := testIsVec2(got)
 	if !ok {
 		t.Fatalf("returned %T, want Vec2", got)
 	}
@@ -732,19 +732,19 @@ func TestVectorShuffleUndefined(t *testing.T) {
 }
 
 func TestMatrixTimesScalarAndMatrix(t *testing.T) {
-	identity := Array{Vec4{1, 0, 0, 0}, Vec4{0, 1, 0, 0}, Vec4{0, 0, 1, 0}, Vec4{0, 0, 0, 1}}
+	identity := Array{ValVec4(1, 0, 0, 0), ValVec4(0, 1, 0, 0), ValVec4(0, 0, 1, 0), ValVec4(0, 0, 0, 1)}
 
 	// Scale by 2.
-	scaled := matrixTimesScalar(identity, Float32(2))
-	cols, _ := scaled.(Array)
+	scaled := matrixTimesScalar(ValArray(identity), ValFloat(2))
+	cols := scaled.AsArray()
 	c0 := Vec4ToFloat32(cols[0])
 	if c0[0] != 2 {
 		t.Errorf("matrixTimesScalar: col0[0] = %f, want 2", c0[0])
 	}
 
 	// Identity * Identity = Identity.
-	product := matrixTimesMatrix(identity, identity)
-	pCols, _ := product.(Array)
+	product := matrixTimesMatrix(ValArray(identity), ValArray(identity))
+	pCols := product.AsArray()
 	p0 := Vec4ToFloat32(pCols[0])
 	if p0[0] != 1 || p0[1] != 0 {
 		t.Errorf("matrixTimesMatrix: col0 = %v, want {1,0,0,0}", p0)
@@ -796,10 +796,10 @@ func TestConstantTrueFalseParser(t *testing.T) {
 		t.Fatalf("ParseModule failed: %v", err)
 	}
 
-	if v, ok := m.Constants[idTrue]; !ok || v != true {
+	if v, ok := m.Constants[idTrue]; !ok || !v.AsBool() {
 		t.Errorf("OpConstantTrue not parsed correctly: %v", v)
 	}
-	if v, ok := m.Constants[idFalse]; !ok || v != false {
+	if v, ok := m.Constants[idFalse]; !ok || v.AsBool() {
 		t.Errorf("OpConstantFalse not parsed correctly: %v", v)
 	}
 }

--- a/hal/software/shader/debug.go
+++ b/hal/software/shader/debug.go
@@ -169,23 +169,27 @@ func writeTrace(_ io.Writer, enc *json.Encoder, entry *traceEntry, pc int, inst 
 // formatTraceValue converts a runtime Value into a JSON-friendly representation.
 // Vectors become float arrays, scalars become their native type.
 func formatTraceValue(val Value) any {
-	switch v := val.(type) {
-	case Float32:
-		return v
-	case Uint32:
-		return v
-	case Int32:
-		return v
-	case bool:
-		return v
-	case Vec2:
-		return [2]float32{v[0], v[1]}
-	case Vec3:
-		return [3]float32{v[0], v[1], v[2]}
-	case Vec4:
-		return [4]float32{v[0], v[1], v[2], v[3]}
-	case *Pointer:
-		return formatTraceValue(v.Value)
+	switch val.Tag {
+	case TagFloat32:
+		return val.F[0]
+	case TagUint32:
+		return val.U[0]
+	case TagInt32:
+		return int32(val.U[0])
+	case TagBool:
+		return val.U[0] != 0
+	case TagVec2:
+		return [2]float32{val.F[0], val.F[1]}
+	case TagVec3:
+		return [3]float32{val.F[0], val.F[1], val.F[2]}
+	case TagVec4:
+		return [4]float32{val.F[0], val.F[1], val.F[2], val.F[3]}
+	case TagPointer:
+		ptr := val.AsPointer()
+		if ptr != nil {
+			return formatTraceValue(ptr.Val)
+		}
+		return nil
 	default:
 		return nil
 	}
@@ -193,24 +197,24 @@ func formatTraceValue(val Value) any {
 
 // valueTypeName returns a human-readable type name for trace output.
 func valueTypeName(val Value) string {
-	switch val.(type) {
-	case Float32:
+	switch val.Tag {
+	case TagFloat32:
 		return typeNameFloat32
-	case Uint32:
+	case TagUint32:
 		return typeNameUint32
-	case Int32:
+	case TagInt32:
 		return typeNameInt32
-	case bool:
+	case TagBool:
 		return typeNameBool
-	case Vec2:
+	case TagVec2:
 		return typeNameVec2
-	case Vec3:
+	case TagVec3:
 		return typeNameVec3
-	case Vec4:
+	case TagVec4:
 		return typeNameVec4
-	case *Pointer:
+	case TagPointer:
 		return typeNamePtr
-	case Array:
+	case TagArray:
 		return typeNameArray
 	default:
 		return ""
@@ -220,37 +224,25 @@ func valueTypeName(val Value) string {
 // valuesEqual compares two Values for equality, used by watch variable tracking.
 // Returns true if the values are structurally identical.
 func valuesEqual(a, b Value) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
+	if a.Tag != b.Tag {
 		return false
 	}
-	switch av := a.(type) {
-	case Float32:
-		bv, ok := b.(Float32)
-		return ok && av == bv
-	case Uint32:
-		bv, ok := b.(Uint32)
-		return ok && av == bv
-	case Int32:
-		bv, ok := b.(Int32)
-		return ok && av == bv
-	case bool:
-		bv, ok := b.(bool)
-		return ok && av == bv
-	case Vec2:
-		bv, ok := b.(Vec2)
-		return ok && av == bv
-	case Vec3:
-		bv, ok := b.(Vec3)
-		return ok && av == bv
-	case Vec4:
-		bv, ok := b.(Vec4)
-		return ok && av == bv
+	switch a.Tag {
+	case TagNone:
+		return true
+	case TagFloat32:
+		return a.F[0] == b.F[0]
+	case TagUint32, TagInt32, TagBool:
+		return a.U[0] == b.U[0]
+	case TagVec2:
+		return a.F[0] == b.F[0] && a.F[1] == b.F[1]
+	case TagVec3:
+		return a.F[0] == b.F[0] && a.F[1] == b.F[1] && a.F[2] == b.F[2]
+	case TagVec4:
+		return a.F == b.F
 	default:
-		// For complex types (Array, Pointer), fall back to reference equality.
-		return a == b
+		// For complex types (Array, Pointer), fall back to pointer equality.
+		return a.Ref == b.Ref
 	}
 }
 

--- a/hal/software/shader/debug_test.go
+++ b/hal/software/shader/debug_test.go
@@ -187,7 +187,7 @@ func TestDebugWatchVariable(t *testing.T) {
 			// The OnInstruction fires when the watch triggers stepping.
 			// Check if the watched variable now has a value.
 			if int(watchID) < len(event.Values) {
-				if val := event.Values[watchID]; val != nil {
+				if val := event.Values[watchID]; !val.IsNone() {
 					watchTriggered = true
 					capturedValue = val
 				}
@@ -252,7 +252,7 @@ func TestDebugAbort(t *testing.T) {
 	}
 
 	ctx := &ExecutionContext{
-		Inputs: map[uint32]Value{idxVarID: Uint32(0)},
+		Inputs: map[uint32]Value{idxVarID: ValUint(0)},
 	}
 	_, err = m.ExecuteWithDebug("vs_main", ctx, debug)
 
@@ -292,7 +292,7 @@ func TestDebugZeroOverhead(t *testing.T) {
 	}
 
 	// Run both paths to verify they produce identical results.
-	inputs := map[uint32]Value{idxVarID: Uint32(0)}
+	inputs := map[uint32]Value{idxVarID: ValUint(0)}
 	ctx1 := &ExecutionContext{Inputs: inputs}
 	ctx2 := &ExecutionContext{Inputs: inputs}
 
@@ -502,7 +502,7 @@ func TestDebugTraceVertexShader(t *testing.T) {
 	}
 
 	ctx := &ExecutionContext{
-		Inputs: map[uint32]Value{idxVarID: Uint32(0)},
+		Inputs: map[uint32]Value{idxVarID: ValUint(0)},
 	}
 	_, err = m.ExecuteWithDebug("vs_main", ctx, debug)
 	if err != nil {
@@ -589,7 +589,7 @@ func TestDebugMultipleBreakpoints(t *testing.T) {
 	}
 
 	ctx := &ExecutionContext{
-		Inputs: map[uint32]Value{idxVarID: Uint32(0)},
+		Inputs: map[uint32]Value{idxVarID: ValUint(0)},
 	}
 	_, err = m.ExecuteWithDebug("vs_main", ctx, debug)
 	if err != nil {
@@ -697,24 +697,24 @@ func TestValuesEqual(t *testing.T) {
 		a, b Value
 		want bool
 	}{
-		{"nil_nil", nil, nil, true},
-		{"nil_val", nil, Float32(0), false},
-		{"val_nil", Float32(0), nil, false},
-		{"float_eq", Float32(1.5), Float32(1.5), true},
-		{"float_ne", Float32(1.0), Float32(2.0), false},
-		{"uint_eq", Uint32(42), Uint32(42), true},
-		{"uint_ne", Uint32(1), Uint32(2), false},
-		{"int_eq", Int32(-5), Int32(-5), true},
-		{"int_ne", Int32(-5), Int32(5), false},
-		{"bool_eq", true, true, true},
-		{"bool_ne", true, false, false},
-		{"vec2_eq", Vec2{1, 2}, Vec2{1, 2}, true},
-		{"vec2_ne", Vec2{1, 2}, Vec2{1, 3}, false},
-		{"vec3_eq", Vec3{1, 2, 3}, Vec3{1, 2, 3}, true},
-		{"vec3_ne", Vec3{1, 2, 3}, Vec3{1, 2, 4}, false},
-		{"vec4_eq", Vec4{1, 2, 3, 4}, Vec4{1, 2, 3, 4}, true},
-		{"vec4_ne", Vec4{1, 2, 3, 4}, Vec4{1, 2, 3, 5}, false},
-		{"type_mismatch", Float32(1), Uint32(1), false},
+		{"nil_nil", Value{}, Value{}, true},
+		{"nil_val", Value{}, ValFloat(0), false},
+		{"val_nil", ValFloat(0), Value{}, false},
+		{"float_eq", ValFloat(1.5), ValFloat(1.5), true},
+		{"float_ne", ValFloat(1.0), ValFloat(2.0), false},
+		{"uint_eq", ValUint(42), ValUint(42), true},
+		{"uint_ne", ValUint(1), ValUint(2), false},
+		{"int_eq", ValInt(-5), ValInt(-5), true},
+		{"int_ne", ValInt(-5), ValInt(5), false},
+		{"bool_eq", ValBool(true), ValBool(true), true},
+		{"bool_ne", ValBool(true), ValBool(false), false},
+		{"vec2_eq", ValVec2(1, 2), ValVec2(1, 2), true},
+		{"vec2_ne", ValVec2(1, 2), ValVec2(1, 3), false},
+		{"vec3_eq", ValVec3(1, 2, 3), ValVec3(1, 2, 3), true},
+		{"vec3_ne", ValVec3(1, 2, 3), ValVec3(1, 2, 4), false},
+		{"vec4_eq", ValVec4(1, 2, 3, 4), ValVec4(1, 2, 3, 4), true},
+		{"vec4_ne", ValVec4(1, 2, 3, 4), ValVec4(1, 2, 3, 5), false},
+		{"type_mismatch", ValFloat(1), ValUint(1), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -754,15 +754,15 @@ func TestFormatTraceValue(t *testing.T) {
 		name string
 		val  Value
 	}{
-		{"float", Float32(3.14)},
-		{"uint", Uint32(42)},
-		{"int", Int32(-7)},
-		{"bool", true},
-		{"vec2", Vec2{1, 2}},
-		{"vec3", Vec3{1, 2, 3}},
-		{"vec4", Vec4{1, 2, 3, 4}},
-		{"ptr", &Pointer{Value: Float32(5)}},
-		{"nil", nil},
+		{"float", ValFloat(3.14)},
+		{"uint", ValUint(42)},
+		{"int", ValInt(-7)},
+		{"bool", ValBool(true)},
+		{"vec2", ValVec2(1, 2)},
+		{"vec3", ValVec3(1, 2, 3)},
+		{"vec4", ValVec4(1, 2, 3, 4)},
+		{"ptr", ValPointer(&Pointer{Val: ValFloat(5)})},
+		{"nil", Value{}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -782,16 +782,16 @@ func TestValueTypeName(t *testing.T) {
 		val  Value
 		want string
 	}{
-		{Float32(0), "float32"},
-		{Uint32(0), "uint32"},
-		{Int32(0), "int32"},
-		{true, "bool"},
-		{Vec2{}, "vec2"},
-		{Vec3{}, "vec3"},
-		{Vec4{}, "vec4"},
-		{&Pointer{}, "ptr"},
-		{Array{}, "array"},
-		{nil, ""},
+		{ValFloat(0), "float32"},
+		{ValUint(0), "uint32"},
+		{ValInt(0), "int32"},
+		{ValBool(true), "bool"},
+		{ValVec2From(Vec2{}), "vec2"},
+		{ValVec3From(Vec3{}), "vec3"},
+		{ValVec4From(Vec4{}), "vec4"},
+		{ValPointer(&Pointer{}), "ptr"},
+		{ValArray(Array{}), "array"},
+		{Value{}, ""},
 	}
 	for _, tt := range tests {
 		got := valueTypeName(tt.val)
@@ -870,7 +870,7 @@ func BenchmarkExecuteBaseline(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		inputs := map[uint32]Value{idxVarID: uint32(i % 3)}
+		inputs := map[uint32]Value{idxVarID: ValUint(uint32(i % 3))}
 		_, _ = m.Execute("vs_main", inputs)
 	}
 }
@@ -895,7 +895,7 @@ func BenchmarkDebugNilOverhead(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		inputs := map[uint32]Value{idxVarID: uint32(i % 3)}
+		inputs := map[uint32]Value{idxVarID: ValUint(uint32(i % 3))}
 		ctx := &ExecutionContext{Inputs: inputs}
 		_, _ = m.ExecuteWithDebug("vs_main", ctx, nil)
 	}
@@ -924,7 +924,7 @@ func BenchmarkDebugWithTrace(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		inputs := map[uint32]Value{idxVarID: uint32(i % 3)}
+		inputs := map[uint32]Value{idxVarID: ValUint(uint32(i % 3))}
 		ctx := &ExecutionContext{Inputs: inputs}
 		debug := &DebugContext{
 			TraceEnabled: true,

--- a/hal/software/shader/glsl_ext.go
+++ b/hal/software/shader/glsl_ext.go
@@ -218,20 +218,20 @@ func (interp *interpreter) executeGLSLExtInst(instNum uint32, operands []uint32)
 		if len(operands) >= 1 {
 			v := int32(toUint32(interp.values[operands[0]]))
 			if v < 0 {
-				return -v
+				return ValInt(-v)
 			}
-			return v
+			return ValInt(v)
 		}
 	case GLSLSSign:
 		if len(operands) >= 1 {
 			v := int32(toUint32(interp.values[operands[0]]))
 			if v > 0 {
-				return Int32(1)
+				return ValInt(1)
 			}
 			if v < 0 {
-				return Int32(-1)
+				return ValInt(-1)
 			}
-			return Int32(0)
+			return ValInt(0)
 		}
 
 	// --- Interpolation ---
@@ -267,13 +267,13 @@ func (interp *interpreter) executeGLSLExtInst(instNum uint32, operands []uint32)
 	// --- Geometric ops ---
 	case GLSLLength:
 		if len(operands) >= 1 {
-			return Float32(vectorLength(interp.values[operands[0]]))
+			return ValFloat(vectorLength(interp.values[operands[0]]))
 		}
 	case GLSLDistance:
 		if len(operands) >= 2 {
 			diff := floatBinOp(interp.values[operands[0]], interp.values[operands[1]],
 				func(a, b float32) float32 { return a - b })
-			return Float32(vectorLength(diff))
+			return ValFloat(vectorLength(diff))
 		}
 	case GLSLNormalize:
 		if len(operands) >= 1 {
@@ -289,7 +289,7 @@ func (interp *interpreter) executeGLSLExtInst(instNum uint32, operands []uint32)
 		}
 	}
 
-	return Uint32(0)
+	return ValUint(0)
 }
 
 // =============================================================================
@@ -299,7 +299,7 @@ func (interp *interpreter) executeGLSLExtInst(instNum uint32, operands []uint32)
 // glslUnaryFloat applies a unary float function to a scalar or vector value.
 func (interp *interpreter) glslUnaryFloat(operands []uint32, fn func(float32) float32) Value {
 	if len(operands) < 1 {
-		return Float32(0)
+		return ValFloat(0)
 	}
 	return floatUnaryOp(interp.values[operands[0]], fn)
 }
@@ -307,7 +307,7 @@ func (interp *interpreter) glslUnaryFloat(operands []uint32, fn func(float32) fl
 // glslBinaryFloat applies a binary float function to two scalar or vector values.
 func (interp *interpreter) glslBinaryFloat(operands []uint32, fn func(float32, float32) float32) Value {
 	if len(operands) < 2 {
-		return Float32(0)
+		return ValFloat(0)
 	}
 	return floatBinOp(interp.values[operands[0]], interp.values[operands[1]], fn)
 }
@@ -315,52 +315,46 @@ func (interp *interpreter) glslBinaryFloat(operands []uint32, fn func(float32, f
 // glslTernaryFloat applies a ternary float function component-wise.
 func (interp *interpreter) glslTernaryFloat(operands []uint32, fn func(float32, float32, float32) float32) Value {
 	if len(operands) < 3 {
-		return Float32(0)
+		return ValFloat(0)
 	}
 	a := interp.values[operands[0]]
 	b := interp.values[operands[1]]
 	c := interp.values[operands[2]]
 
-	switch av := a.(type) {
-	case Float32:
-		return Float32(fn(av, toFloat32(b), toFloat32(c)))
-	case Vec2:
-		bv, _ := b.(Vec2)
-		cv, _ := c.(Vec2)
-		return Vec2{fn(av[0], bv[0], cv[0]), fn(av[1], bv[1], cv[1])}
-	case Vec3:
-		bv, _ := b.(Vec3)
-		cv, _ := c.(Vec3)
-		return Vec3{fn(av[0], bv[0], cv[0]), fn(av[1], bv[1], cv[1]), fn(av[2], bv[2], cv[2])}
-	case Vec4:
-		bv, _ := b.(Vec4)
-		cv, _ := c.(Vec4)
-		return Vec4{
-			fn(av[0], bv[0], cv[0]), fn(av[1], bv[1], cv[1]),
-			fn(av[2], bv[2], cv[2]), fn(av[3], bv[3], cv[3]),
-		}
+	switch a.Tag {
+	case TagFloat32:
+		return ValFloat(fn(a.F[0], toFloat32(b), toFloat32(c)))
+	case TagVec2:
+		return ValVec2(fn(a.F[0], b.F[0], c.F[0]), fn(a.F[1], b.F[1], c.F[1]))
+	case TagVec3:
+		return ValVec3(fn(a.F[0], b.F[0], c.F[0]), fn(a.F[1], b.F[1], c.F[1]), fn(a.F[2], b.F[2], c.F[2]))
+	case TagVec4:
+		return ValVec4(
+			fn(a.F[0], b.F[0], c.F[0]), fn(a.F[1], b.F[1], c.F[1]),
+			fn(a.F[2], b.F[2], c.F[2]), fn(a.F[3], b.F[3], c.F[3]),
+		)
 	}
-	return Float32(fn(toFloat32(a), toFloat32(b), toFloat32(c)))
+	return ValFloat(fn(toFloat32(a), toFloat32(b), toFloat32(c)))
 }
 
 // glslBinaryUint applies a binary uint function.
 func (interp *interpreter) glslBinaryUint(operands []uint32, fn func(uint32, uint32) uint32) Value {
 	if len(operands) < 2 {
-		return Uint32(0)
+		return ValUint(0)
 	}
 	a := toUint32(interp.values[operands[0]])
 	b := toUint32(interp.values[operands[1]])
-	return fn(a, b)
+	return ValUint(fn(a, b))
 }
 
 // glslBinaryInt applies a binary signed int function.
 func (interp *interpreter) glslBinaryInt(operands []uint32, fn func(int32, int32) int32) Value {
 	if len(operands) < 2 {
-		return Int32(0)
+		return ValInt(0)
 	}
 	a := int32(toUint32(interp.values[operands[0]]))
 	b := int32(toUint32(interp.values[operands[1]]))
-	return fn(a, b)
+	return ValInt(fn(a, b))
 }
 
 // =============================================================================
@@ -369,21 +363,20 @@ func (interp *interpreter) glslBinaryInt(operands []uint32, fn func(int32, int32
 
 // vectorLength computes the Euclidean length of a vector.
 func vectorLength(val Value) float32 {
-	switch v := val.(type) {
-	case Float32:
-		return float32(math.Abs(float64(v)))
-	case Vec2:
-		return float32(math.Sqrt(float64(v[0]*v[0] + v[1]*v[1])))
-	case Vec3:
-		return float32(math.Sqrt(float64(v[0]*v[0] + v[1]*v[1] + v[2]*v[2])))
-	case Vec4:
-		return float32(math.Sqrt(float64(v[0]*v[0] + v[1]*v[1] + v[2]*v[2] + v[3]*v[3])))
+	switch val.Tag {
+	case TagFloat32:
+		return float32(math.Abs(float64(val.F[0])))
+	case TagVec2:
+		return float32(math.Sqrt(float64(val.F[0]*val.F[0] + val.F[1]*val.F[1])))
+	case TagVec3:
+		return float32(math.Sqrt(float64(val.F[0]*val.F[0] + val.F[1]*val.F[1] + val.F[2]*val.F[2])))
+	case TagVec4:
+		return float32(math.Sqrt(float64(val.F[0]*val.F[0] + val.F[1]*val.F[1] + val.F[2]*val.F[2] + val.F[3]*val.F[3])))
 	}
 	return 0
 }
 
 // normalizeVector returns a unit-length vector in the same direction.
-// Returns zero vector if the input has zero length.
 func normalizeVector(val Value) Value {
 	length := vectorLength(val)
 	if length == 0 {
@@ -395,23 +388,20 @@ func normalizeVector(val Value) Value {
 
 // crossProduct computes the cross product of two Vec3 values.
 func crossProduct(a, b Value) Value {
-	av, aOK := a.(Vec3)
-	bv, bOK := b.(Vec3)
-	if !aOK || !bOK {
-		return Vec3{}
+	if a.Tag != TagVec3 || b.Tag != TagVec3 {
+		return ValVec3(0, 0, 0)
 	}
-	return Vec3{
-		av[1]*bv[2] - av[2]*bv[1],
-		av[2]*bv[0] - av[0]*bv[2],
-		av[0]*bv[1] - av[1]*bv[0],
-	}
+	return ValVec3(
+		a.F[1]*b.F[2]-a.F[2]*b.F[1],
+		a.F[2]*b.F[0]-a.F[0]*b.F[2],
+		a.F[0]*b.F[1]-a.F[1]*b.F[0],
+	)
 }
 
 // reflectVector computes the reflection of incident vector I around normal N.
 // reflect(I, N) = I - 2*dot(N, I)*N
 func reflectVector(incident, normal Value) Value {
 	d := toFloat32(dotProduct(normal, incident))
-	// 2 * dot(N, I) * N
 	scaled := vectorTimesScalar(normal, 2*d)
 	return floatBinOp(incident, scaled, func(a, b float32) float32 { return a - b })
 }

--- a/hal/software/shader/glsl_ext_test.go
+++ b/hal/software/shader/glsl_ext_test.go
@@ -343,11 +343,11 @@ func TestVectorLength(t *testing.T) {
 		val  Value
 		want float32
 	}{
-		{"scalar", Float32(3), 3},
-		{"vec2", Vec2{3, 4}, 5},
-		{"vec3", Vec3{1, 2, 2}, 3},
-		{"vec4", Vec4{1, 0, 0, 0}, 1},
-		{"zero", Vec3{0, 0, 0}, 0},
+		{"scalar", ValFloat(3), 3},
+		{"vec2", ValVec2From(Vec2{3, 4}), 5},
+		{"vec3", ValVec3From(Vec3{1, 2, 2}), 3},
+		{"vec4", ValVec4From(Vec4{1, 0, 0, 0}), 1},
+		{"zero", ValVec3From(Vec3{0, 0, 0}), 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -361,18 +361,18 @@ func TestVectorLength(t *testing.T) {
 
 func TestNormalizeVector(t *testing.T) {
 	// Normalize (3, 4, 0) -> (0.6, 0.8, 0)
-	got := normalizeVector(Vec3{3, 4, 0})
-	gv, ok := got.(Vec3)
+	got := normalizeVector(ValVec3From(Vec3{3, 4, 0}))
+	gv, ok := testIsVec3(got)
 	if !ok {
-		t.Fatalf("normalizeVector returned %T, want Vec3", got)
+		t.Fatalf("normalizeVector returned %T, want Value", got)
 	}
 	if math.Abs(float64(gv[0]-0.6)) > 1e-5 || math.Abs(float64(gv[1]-0.8)) > 1e-5 {
 		t.Errorf("normalize(3,4,0) = %v, want (0.6, 0.8, 0)", gv)
 	}
 
 	// Zero-length vector should return zero vector unchanged.
-	got = normalizeVector(Vec3{0, 0, 0})
-	gv, _ = got.(Vec3)
+	got = normalizeVector(ValVec3From(Vec3{0, 0, 0}))
+	gv = got.AsVec3()
 	if gv != (Vec3{0, 0, 0}) {
 		t.Errorf("normalize(0,0,0) = %v, want (0,0,0)", gv)
 	}
@@ -381,23 +381,24 @@ func TestNormalizeVector(t *testing.T) {
 func TestCrossProduct(t *testing.T) {
 	tests := []struct {
 		name string
-		a, b Vec3
-		want Vec3
+		a, b Value
+		want Value
 	}{
-		{"x_cross_y", Vec3{1, 0, 0}, Vec3{0, 1, 0}, Vec3{0, 0, 1}},
-		{"y_cross_x", Vec3{0, 1, 0}, Vec3{1, 0, 0}, Vec3{0, 0, -1}},
-		{"parallel", Vec3{1, 0, 0}, Vec3{2, 0, 0}, Vec3{0, 0, 0}},
+		{"x_cross_y", ValVec3(1, 0, 0), ValVec3(0, 1, 0), ValVec3(0, 0, 1)},
+		{"y_cross_x", ValVec3(0, 1, 0), ValVec3(1, 0, 0), ValVec3(0, 0, -1)},
+		{"parallel", ValVec3(1, 0, 0), ValVec3(2, 0, 0), ValVec3(0, 0, 0)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := crossProduct(tt.a, tt.b)
-			gv, ok := got.(Vec3)
+			gv, ok := testIsVec3(got)
 			if !ok {
-				t.Fatalf("crossProduct returned %T, want Vec3", got)
+				t.Fatalf("crossProduct returned %T, want Value", got)
 			}
 			for i := 0; i < 3; i++ {
-				if math.Abs(float64(gv[i]-tt.want[i])) > 1e-5 {
-					t.Errorf("cross[%d] = %v, want %v", i, gv[i], tt.want[i])
+				wv := tt.want.AsVec3()
+				if math.Abs(float64(gv[i]-wv[i])) > 1e-5 {
+					t.Errorf("cross[%d] = %v, want %v", i, gv[i], wv[i])
 				}
 			}
 		})
@@ -406,10 +407,10 @@ func TestCrossProduct(t *testing.T) {
 
 func TestReflectVector(t *testing.T) {
 	// Reflect (1, -1, 0) around normal (0, 1, 0) -> (1, 1, 0)
-	got := reflectVector(Vec3{1, -1, 0}, Vec3{0, 1, 0})
-	gv, ok := got.(Vec3)
+	got := reflectVector(ValVec3From(Vec3{1, -1, 0}), ValVec3From(Vec3{0, 1, 0}))
+	gv, ok := testIsVec3(got)
 	if !ok {
-		t.Fatalf("reflect returned %T, want Vec3", got)
+		t.Fatalf("reflect returned %T, want Value", got)
 	}
 	want := Vec3{1, 1, 0}
 	for i := 0; i < 3; i++ {
@@ -428,34 +429,34 @@ func TestGLSLIntOps(t *testing.T) {
 	}
 	interp := &interpreter{
 		module: m,
-		values: testMakeValues(map[uint32]Value{
-			10: Int32(-42),
-			11: Int32(0),
-			12: Int32(7),
+		values: testMakeValues(map[uint32]any{
+			10: ValInt(-42),
+			11: ValInt(0),
+			12: ValInt(7),
 		}),
 	}
 
 	// SAbs(-42) = 42
 	got := interp.executeGLSLExtInst(GLSLSAbs, []uint32{10})
-	if v, ok := got.(Int32); !ok || v != 42 {
+	if got.Tag != TagInt32 || got.AsInt32() != 42 {
 		t.Errorf("SAbs(-42) = %v, want 42", got)
 	}
 
 	// SSign(-42) = -1
 	got = interp.executeGLSLExtInst(GLSLSSign, []uint32{10})
-	if v, ok := got.(Int32); !ok || v != -1 {
+	if got.Tag != TagInt32 || got.AsInt32() != -1 {
 		t.Errorf("SSign(-42) = %v, want -1", got)
 	}
 
 	// SSign(0) = 0
 	got = interp.executeGLSLExtInst(GLSLSSign, []uint32{11})
-	if v, ok := got.(Int32); !ok || v != 0 {
+	if got.Tag != TagInt32 || got.AsInt32() != 0 {
 		t.Errorf("SSign(0) = %v, want 0", got)
 	}
 
 	// SSign(7) = 1
 	got = interp.executeGLSLExtInst(GLSLSSign, []uint32{12})
-	if v, ok := got.(Int32); !ok || v != 1 {
+	if got.Tag != TagInt32 || got.AsInt32() != 1 {
 		t.Errorf("SSign(7) = %v, want 1", got)
 	}
 }

--- a/hal/software/shader/interpreter.go
+++ b/hal/software/shader/interpreter.go
@@ -76,7 +76,7 @@ func (m *Module) ExecuteWithDebug(entryPoint string, ctx *ExecutionContext, debu
 	interp.prevBlock = 0
 	interp.iterationCount = 0
 	interp.callDepth = 0
-	interp.returnValue = nil
+	interp.returnValue = Value{}
 
 	// Seed constants into the value slice.
 	for id, val := range m.Constants {
@@ -104,8 +104,9 @@ func (m *Module) ExecuteWithDebug(entryPoint string, ctx *ExecutionContext, debu
 		if vi.StorageClass != StorageClassOutput {
 			continue
 		}
-		if ptr, ok := interp.values[varID].(*Pointer); ok {
-			outputs[varID] = ptr.Value
+		v := interp.values[varID]
+		if v.Tag == TagPointer {
+			outputs[varID] = v.AsPointer().Val
 		}
 	}
 
@@ -162,11 +163,11 @@ const ptrPoolSize = 32
 func (interp *interpreter) allocPointer(val Value) *Pointer {
 	if interp.ptrPoolIdx < len(interp.ptrPool) {
 		p := &interp.ptrPool[interp.ptrPoolIdx]
-		p.Value = val
+		p.Val = val
 		interp.ptrPoolIdx++
 		return p
 	}
-	return &Pointer{Value: val}
+	return &Pointer{Val: val}
 }
 
 // getInterpreter returns a pooled interpreter, allocating one if the pool is empty.
@@ -195,7 +196,7 @@ func (m *Module) putInterpreter(interp *interpreter) {
 	interp.fn = nil
 	interp.ctx = nil
 	interp.debug = nil
-	interp.returnValue = nil
+	interp.returnValue = Value{}
 	m.interpPool.Put(interp)
 }
 
@@ -213,14 +214,14 @@ func (interp *interpreter) initVariables(inputs map[uint32]Value) {
 		case StorageClassInput:
 			// Seed from caller-provided inputs.
 			val := inputs[varID]
-			if val == nil {
+			if val.IsNone() {
 				// Default zero value based on pointee type.
 				val = zeroValueForVar(m, vi.TypeID)
 			}
-			interp.values[varID] = interp.allocPointer(val)
+			interp.values[varID] = ValPointer(interp.allocPointer(val))
 
 		case StorageClassOutput:
-			interp.values[varID] = interp.allocPointer(zeroValueForVar(m, vi.TypeID))
+			interp.values[varID] = ValPointer(interp.allocPointer(zeroValueForVar(m, vi.TypeID)))
 		}
 	}
 }
@@ -247,22 +248,22 @@ func (interp *interpreter) initResourceVariables() {
 			}
 			if bufData == nil {
 				// No buffer bound -- initialize as zero.
-				interp.values[varID] = interp.allocPointer(zeroValueForVar(m, vi.TypeID))
+				interp.values[varID] = ValPointer(interp.allocPointer(zeroValueForVar(m, vi.TypeID)))
 				continue
 			}
 			pointeeType := m.PointeeType(vi.TypeID)
 			if pointeeType == nil {
-				interp.values[varID] = interp.allocPointer(zeroValueForVar(m, vi.TypeID))
+				interp.values[varID] = ValPointer(interp.allocPointer(zeroValueForVar(m, vi.TypeID)))
 				continue
 			}
 			if vi.StorageClass == StorageClassStorageBuffer {
 				// Storage buffers use BufferPointer for direct read/write to raw bytes.
 				// This ensures OpStore writes are immediately reflected in the buffer.
-				interp.values[varID] = &BufferPointer{Buffer: bufData, Offset: 0, Type: pointeeType}
+				interp.values[varID] = ValBufferPointer(&BufferPointer{Buffer: bufData, Offset: 0, Type: pointeeType})
 			} else {
 				// Uniform and push constant buffers are read-only -- deserialize once.
 				val := interp.readValueFromBuffer(bufData, 0, pointeeType)
-				interp.values[varID] = interp.allocPointer(val)
+				interp.values[varID] = ValPointer(interp.allocPointer(val))
 			}
 
 		case StorageClassUniformConstant:
@@ -272,7 +273,7 @@ func (interp *interpreter) initResourceVariables() {
 				continue
 			}
 			// Store the binding key as the value so OpLoad can resolve texture/sampler.
-			interp.values[varID] = interp.allocPointer(bk)
+			interp.values[varID] = ValPointer(interp.allocPointer(ValBindingKey(bk)))
 		}
 	}
 }
@@ -284,33 +285,33 @@ func (interp *interpreter) readValueFromBuffer(data []byte, offset uint32, ti *T
 	switch ti.Kind {
 	case TypeFloat:
 		if offset+4 > uint32(len(data)) {
-			return Float32(0)
+			return ValFloat(0)
 		}
 		bits := uint32(data[offset]) | uint32(data[offset+1])<<8 |
 			uint32(data[offset+2])<<16 | uint32(data[offset+3])<<24
-		return Float32(math.Float32frombits(bits))
+		return ValFloat(math.Float32frombits(bits))
 
 	case TypeInt:
 		if offset+4 > uint32(len(data)) {
 			if ti.Signed {
-				return Int32(0)
+				return ValInt(0)
 			}
-			return Uint32(0)
+			return ValUint(0)
 		}
 		bits := uint32(data[offset]) | uint32(data[offset+1])<<8 |
 			uint32(data[offset+2])<<16 | uint32(data[offset+3])<<24
 		if ti.Signed {
-			return int32(bits)
+			return ValInt(int32(bits))
 		}
-		return bits
+		return ValUint(bits)
 
 	case TypeBool:
 		if offset+4 > uint32(len(data)) {
-			return false
+			return ValBool(false)
 		}
 		bits := uint32(data[offset]) | uint32(data[offset+1])<<8 |
 			uint32(data[offset+2])<<16 | uint32(data[offset+3])<<24
-		return bits != 0
+		return ValBool(bits != 0)
 
 	case TypeVector:
 		elemType := m.Types[ti.ElemType]
@@ -320,59 +321,59 @@ func (interp *interpreter) readValueFromBuffer(data []byte, offset uint32, ti *T
 		elemSize := typeByteSize(m, elemType)
 		switch ti.Components {
 		case 2:
-			var v Vec2
+			var v [2]float32
 			for i := uint32(0); i < 2; i++ {
 				f := interp.readValueFromBuffer(data, offset+i*elemSize, elemType)
 				v[i] = toFloat32(f)
 			}
-			return v
+			return ValVec2(v[0], v[1])
 		case 3:
-			var v Vec3
+			var v [3]float32
 			for i := uint32(0); i < 3; i++ {
 				f := interp.readValueFromBuffer(data, offset+i*elemSize, elemType)
 				v[i] = toFloat32(f)
 			}
-			return v
+			return ValVec3(v[0], v[1], v[2])
 		case 4:
-			var v Vec4
+			var v [4]float32
 			for i := uint32(0); i < 4; i++ {
 				f := interp.readValueFromBuffer(data, offset+i*elemSize, elemType)
 				v[i] = toFloat32(f)
 			}
-			return v
+			return ValVec4(v[0], v[1], v[2], v[3])
 		}
-		return Uint32(0)
+		return ValUint(0)
 
 	case TypeArray:
 		elemType := m.Types[ti.ElemType]
 		if elemType == nil || ti.Length == 0 {
-			return Array{}
+			return ValArray(nil)
 		}
 		// Use ArrayStride decoration if available, otherwise compute.
 		elemSize := typeByteSize(m, elemType)
-		arr := make(Array, ti.Length)
+		arr := make([]Value, ti.Length)
 		for i := uint32(0); i < ti.Length; i++ {
 			arr[i] = interp.readValueFromBuffer(data, offset+i*elemSize, elemType)
 		}
-		return arr
+		return ValArray(arr)
 
 	case TypeStruct:
-		members := make(Array, len(ti.MemberIDs))
+		members := make([]Value, len(ti.MemberIDs))
 		// For each struct member, look up its type and use MemberDecorate Offset.
 		structTypeID := interp.findTypeID(ti)
 		for i, memberTypeID := range ti.MemberIDs {
 			memberType := m.Types[memberTypeID]
 			if memberType == nil {
-				members[i] = Uint32(0)
+				members[i] = ValUint(0)
 				continue
 			}
 			memberOffset := m.GetMemberOffset(structTypeID, uint32(i))
 			members[i] = interp.readValueFromBuffer(data, offset+memberOffset, memberType)
 		}
-		return members
+		return ValArray(members)
 
 	default:
-		return Uint32(0)
+		return ValUint(0)
 	}
 }
 
@@ -449,125 +450,6 @@ func typeByteSize(m *Module, ti *TypeInfo) uint32 {
 	default:
 		return 4
 	}
-}
-
-// writeValueToBuffer serializes a SPIR-V typed value into raw buffer bytes.
-// Used for storage buffer writes via OpStore.
-func writeValueToBuffer(data []byte, offset uint32, val Value) {
-	switch v := val.(type) {
-	case Float32:
-		if offset+4 > uint32(len(data)) {
-			return
-		}
-		bits := math.Float32bits(float32(v))
-		data[offset] = byte(bits)
-		data[offset+1] = byte(bits >> 8)
-		data[offset+2] = byte(bits >> 16)
-		data[offset+3] = byte(bits >> 24)
-	case Uint32:
-		if offset+4 > uint32(len(data)) {
-			return
-		}
-		data[offset] = byte(v)
-		data[offset+1] = byte(v >> 8)
-		data[offset+2] = byte(v >> 16)
-		data[offset+3] = byte(v >> 24)
-	case Int32:
-		if offset+4 > uint32(len(data)) {
-			return
-		}
-		u := uint32(v)
-		data[offset] = byte(u)
-		data[offset+1] = byte(u >> 8)
-		data[offset+2] = byte(u >> 16)
-		data[offset+3] = byte(u >> 24)
-	case Vec2:
-		writeValueToBuffer(data, offset, Float32(v[0]))
-		writeValueToBuffer(data, offset+4, Float32(v[1]))
-	case Vec3:
-		writeValueToBuffer(data, offset, Float32(v[0]))
-		writeValueToBuffer(data, offset+4, Float32(v[1]))
-		writeValueToBuffer(data, offset+8, Float32(v[2]))
-	case Vec4:
-		writeValueToBuffer(data, offset, Float32(v[0]))
-		writeValueToBuffer(data, offset+4, Float32(v[1]))
-		writeValueToBuffer(data, offset+8, Float32(v[2]))
-		writeValueToBuffer(data, offset+12, Float32(v[3]))
-	case Array:
-		off := offset
-		for _, elem := range v {
-			writeValueToBuffer(data, off, elem)
-			off += valueByteSize(elem)
-		}
-	}
-}
-
-// valueByteSize returns the byte size of a runtime Value.
-func valueByteSize(val Value) uint32 {
-	switch v := val.(type) {
-	case Float32:
-		return 4
-	case Uint32:
-		return 4
-	case Int32:
-		return 4
-	case Vec2:
-		return 8
-	case Vec3:
-		return 12
-	case Vec4:
-		return 16
-	case Array:
-		var total uint32
-		for _, elem := range v {
-			total += valueByteSize(elem)
-		}
-		return total
-	default:
-		_ = v
-		return 4
-	}
-}
-
-// zeroValueForVar creates a zero value matching the pointee type of a pointer type.
-func zeroValueForVar(m *Module, ptrTypeID uint32) Value {
-	ti := m.PointeeType(ptrTypeID)
-	if ti == nil {
-		return Uint32(0)
-	}
-	switch ti.Kind {
-	case TypeFloat:
-		return Float32(0)
-	case TypeInt:
-		if ti.Signed {
-			return Int32(0)
-		}
-		return Uint32(0)
-	case TypeVector:
-		switch ti.Components {
-		case 2:
-			return Vec2{}
-		case 3:
-			return Vec3{}
-		case 4:
-			return Vec4{}
-		}
-	case TypeArray:
-		if ti.Length > 0 {
-			arr := make(Array, ti.Length)
-			for i := range arr {
-				arr[i] = zeroValue(m.Types, ti.ElemType)
-			}
-			return arr
-		}
-	case TypeStruct:
-		members := make(Array, len(ti.MemberIDs))
-		for i, memberTypeID := range ti.MemberIDs {
-			members[i] = zeroValue(m.Types, memberTypeID)
-		}
-		return members
-	}
-	return Uint32(0)
 }
 
 // errDebugAbort is a sentinel error returned when a debug callback requests DebugAbort.
@@ -657,7 +539,7 @@ func (interp *interpreter) run() error {
 			storageClass := inst.Operands[0]
 			if storageClass == StorageClassFunction {
 				val := zeroValueForVar(interp.module, inst.TypeID)
-				interp.values[inst.ResultID] = interp.allocPointer(val)
+				interp.values[inst.ResultID] = ValPointer(interp.allocPointer(val))
 			}
 
 		case OpLoad:
@@ -666,18 +548,20 @@ func (interp *interpreter) run() error {
 				break
 			}
 			ptrID := inst.Operands[0]
-			switch p := interp.values[ptrID].(type) {
-			case *Pointer:
-				interp.values[inst.ResultID] = p.Value
-			case *SubPointer:
+			pv := interp.values[ptrID]
+			switch pv.Tag {
+			case TagPointer:
+				interp.values[inst.ResultID] = pv.AsPointer().Val
+			case TagSubPointer:
 				// Read through parent pointer, navigating the index path.
-				interp.values[inst.ResultID] = subPointerLoad(p)
-			case *BufferPointer:
+				interp.values[inst.ResultID] = subPointerLoad(pv.AsSubPointer())
+			case TagBufferPointer:
 				// Read directly from the raw buffer.
-				if p.Type != nil {
-					interp.values[inst.ResultID] = interp.readValueFromBuffer(p.Buffer, p.Offset, p.Type)
+				bp := pv.AsBufferPointer()
+				if bp.Type != nil {
+					interp.values[inst.ResultID] = interp.readValueFromBuffer(bp.Buffer, bp.Offset, bp.Type)
 				} else {
-					interp.values[inst.ResultID] = Uint32(0)
+					interp.values[inst.ResultID] = ValUint(0)
 				}
 			default:
 				// Direct value fallback (shouldn't happen in valid SPIR-V).
@@ -691,15 +575,16 @@ func (interp *interpreter) run() error {
 			}
 			ptrID := inst.Operands[0]
 			valID := inst.Operands[1]
-			switch p := interp.values[ptrID].(type) {
-			case *Pointer:
-				p.Value = interp.values[valID]
-			case *SubPointer:
+			pv := interp.values[ptrID]
+			switch pv.Tag {
+			case TagPointer:
+				pv.AsPointer().Val = interp.values[valID]
+			case TagSubPointer:
 				// Write through parent pointer, updating the composite at each level.
-				subPointerStore(p, interp.values[valID])
-			case *BufferPointer:
+				subPointerStore(pv.AsSubPointer(), interp.values[valID])
+			case TagBufferPointer:
 				// Write directly to the raw buffer.
-				writeValueToBuffer(p.Buffer, p.Offset, interp.values[valID])
+				writeValueToBuffer(pv.AsBufferPointer().Buffer, pv.AsBufferPointer().Offset, interp.values[valID])
 			}
 
 		case OpAccessChain:
@@ -867,49 +752,49 @@ func (interp *interpreter) run() error {
 			if len(inst.Operands) >= 2 {
 				a := toUint32(interp.values[inst.Operands[0]])
 				b := toUint32(interp.values[inst.Operands[1]])
-				interp.values[inst.ResultID] = a == b
+				interp.values[inst.ResultID] = ValBool(a == b)
 			}
 
 		case OpINotEqual:
 			if len(inst.Operands) >= 2 {
 				a := toUint32(interp.values[inst.Operands[0]])
 				b := toUint32(interp.values[inst.Operands[1]])
-				interp.values[inst.ResultID] = a != b
+				interp.values[inst.ResultID] = ValBool(a != b)
 			}
 
 		case OpFOrdEqual:
 			if len(inst.Operands) >= 2 {
 				a := toFloat32(interp.values[inst.Operands[0]])
 				b := toFloat32(interp.values[inst.Operands[1]])
-				interp.values[inst.ResultID] = a == b
+				interp.values[inst.ResultID] = ValBool(a == b)
 			}
 
 		case OpFOrdLessThan:
 			if len(inst.Operands) >= 2 {
 				a := toFloat32(interp.values[inst.Operands[0]])
 				b := toFloat32(interp.values[inst.Operands[1]])
-				interp.values[inst.ResultID] = a < b
+				interp.values[inst.ResultID] = ValBool(a < b)
 			}
 
 		case OpFOrdGreaterThan:
 			if len(inst.Operands) >= 2 {
 				a := toFloat32(interp.values[inst.Operands[0]])
 				b := toFloat32(interp.values[inst.Operands[1]])
-				interp.values[inst.ResultID] = a > b
+				interp.values[inst.ResultID] = ValBool(a > b)
 			}
 
 		case OpFOrdLessThanEqual:
 			if len(inst.Operands) >= 2 {
 				a := toFloat32(interp.values[inst.Operands[0]])
 				b := toFloat32(interp.values[inst.Operands[1]])
-				interp.values[inst.ResultID] = a <= b
+				interp.values[inst.ResultID] = ValBool(a <= b)
 			}
 
 		case OpFOrdGreaterThanEqual:
 			if len(inst.Operands) >= 2 {
 				a := toFloat32(interp.values[inst.Operands[0]])
 				b := toFloat32(interp.values[inst.Operands[1]])
-				interp.values[inst.ResultID] = a >= b
+				interp.values[inst.ResultID] = ValBool(a >= b)
 			}
 
 		case OpPhi:
@@ -1032,9 +917,9 @@ func (interp *interpreter) run() error {
 				a := int32(toUint32(interp.values[inst.Operands[0]]))
 				b := int32(toUint32(interp.values[inst.Operands[1]]))
 				if b != 0 {
-					interp.values[inst.ResultID] = a / b
+					interp.values[inst.ResultID] = ValInt(a / b)
 				} else {
-					interp.values[inst.ResultID] = Int32(0)
+					interp.values[inst.ResultID] = ValInt(0)
 				}
 			}
 
@@ -1043,9 +928,9 @@ func (interp *interpreter) run() error {
 				a := toUint32(interp.values[inst.Operands[0]])
 				b := toUint32(interp.values[inst.Operands[1]])
 				if b != 0 {
-					interp.values[inst.ResultID] = a / b
+					interp.values[inst.ResultID] = ValUint(a / b)
 				} else {
-					interp.values[inst.ResultID] = Uint32(0)
+					interp.values[inst.ResultID] = ValUint(0)
 				}
 			}
 
@@ -1054,9 +939,9 @@ func (interp *interpreter) run() error {
 				a := int32(toUint32(interp.values[inst.Operands[0]]))
 				b := int32(toUint32(interp.values[inst.Operands[1]]))
 				if b != 0 {
-					interp.values[inst.ResultID] = a % b
+					interp.values[inst.ResultID] = ValInt(a % b)
 				} else {
-					interp.values[inst.ResultID] = Int32(0)
+					interp.values[inst.ResultID] = ValInt(0)
 				}
 			}
 
@@ -1065,9 +950,9 @@ func (interp *interpreter) run() error {
 				a := toUint32(interp.values[inst.Operands[0]])
 				b := toUint32(interp.values[inst.Operands[1]])
 				if b != 0 {
-					interp.values[inst.ResultID] = a % b
+					interp.values[inst.ResultID] = ValUint(a % b)
 				} else {
-					interp.values[inst.ResultID] = Uint32(0)
+					interp.values[inst.ResultID] = ValUint(0)
 				}
 			}
 
@@ -1077,9 +962,9 @@ func (interp *interpreter) run() error {
 				b := int32(toUint32(interp.values[inst.Operands[1]]))
 				if b != 0 {
 					// SPIR-V SRem: remainder has same sign as dividend.
-					interp.values[inst.ResultID] = a % b
+					interp.values[inst.ResultID] = ValInt(a % b)
 				} else {
-					interp.values[inst.ResultID] = Int32(0)
+					interp.values[inst.ResultID] = ValInt(0)
 				}
 			}
 
@@ -1115,13 +1000,13 @@ func (interp *interpreter) run() error {
 		case OpSNegate:
 			if len(inst.Operands) >= 1 {
 				a := int32(toUint32(interp.values[inst.Operands[0]]))
-				interp.values[inst.ResultID] = -a
+				interp.values[inst.ResultID] = ValInt(-a)
 			}
 
 		case OpConvertFToS:
 			if len(inst.Operands) >= 1 {
 				f := toFloat32(interp.values[inst.Operands[0]])
-				interp.values[inst.ResultID] = int32(f)
+				interp.values[inst.ResultID] = ValInt(int32(f))
 			}
 
 		case OpSConvert, OpUConvert, OpFConvert:
@@ -1134,71 +1019,71 @@ func (interp *interpreter) run() error {
 			if len(inst.Operands) >= 2 {
 				a := toUint32(interp.values[inst.Operands[0]])
 				b := toUint32(interp.values[inst.Operands[1]])
-				interp.values[inst.ResultID] = a < b
+				interp.values[inst.ResultID] = ValBool(a < b)
 			}
 
 		case OpUGreaterThan:
 			if len(inst.Operands) >= 2 {
 				a := toUint32(interp.values[inst.Operands[0]])
 				b := toUint32(interp.values[inst.Operands[1]])
-				interp.values[inst.ResultID] = a > b
+				interp.values[inst.ResultID] = ValBool(a > b)
 			}
 
 		case OpULessThanEqual:
 			if len(inst.Operands) >= 2 {
 				a := toUint32(interp.values[inst.Operands[0]])
 				b := toUint32(interp.values[inst.Operands[1]])
-				interp.values[inst.ResultID] = a <= b
+				interp.values[inst.ResultID] = ValBool(a <= b)
 			}
 
 		case OpUGreaterThanEqual:
 			if len(inst.Operands) >= 2 {
 				a := toUint32(interp.values[inst.Operands[0]])
 				b := toUint32(interp.values[inst.Operands[1]])
-				interp.values[inst.ResultID] = a >= b
+				interp.values[inst.ResultID] = ValBool(a >= b)
 			}
 
 		case OpSLessThan:
 			if len(inst.Operands) >= 2 {
 				a := int32(toUint32(interp.values[inst.Operands[0]]))
 				b := int32(toUint32(interp.values[inst.Operands[1]]))
-				interp.values[inst.ResultID] = a < b
+				interp.values[inst.ResultID] = ValBool(a < b)
 			}
 
 		case OpSGreaterThan:
 			if len(inst.Operands) >= 2 {
 				a := int32(toUint32(interp.values[inst.Operands[0]]))
 				b := int32(toUint32(interp.values[inst.Operands[1]]))
-				interp.values[inst.ResultID] = a > b
+				interp.values[inst.ResultID] = ValBool(a > b)
 			}
 
 		case OpSLessThanEqual:
 			if len(inst.Operands) >= 2 {
 				a := int32(toUint32(interp.values[inst.Operands[0]]))
 				b := int32(toUint32(interp.values[inst.Operands[1]]))
-				interp.values[inst.ResultID] = a <= b
+				interp.values[inst.ResultID] = ValBool(a <= b)
 			}
 
 		case OpSGreaterThanEqual:
 			if len(inst.Operands) >= 2 {
 				a := int32(toUint32(interp.values[inst.Operands[0]]))
 				b := int32(toUint32(interp.values[inst.Operands[1]]))
-				interp.values[inst.ResultID] = a >= b
+				interp.values[inst.ResultID] = ValBool(a >= b)
 			}
 
 		case OpLogicalAnd:
 			if len(inst.Operands) >= 2 {
-				interp.values[inst.ResultID] = toBool(interp.values[inst.Operands[0]]) && toBool(interp.values[inst.Operands[1]])
+				interp.values[inst.ResultID] = ValBool(toBool(interp.values[inst.Operands[0]]) && toBool(interp.values[inst.Operands[1]]))
 			}
 
 		case OpLogicalOr:
 			if len(inst.Operands) >= 2 {
-				interp.values[inst.ResultID] = toBool(interp.values[inst.Operands[0]]) || toBool(interp.values[inst.Operands[1]])
+				interp.values[inst.ResultID] = ValBool(toBool(interp.values[inst.Operands[0]]) || toBool(interp.values[inst.Operands[1]]))
 			}
 
 		case OpLogicalNot:
 			if len(inst.Operands) >= 1 {
-				interp.values[inst.ResultID] = !toBool(interp.values[inst.Operands[0]])
+				interp.values[inst.ResultID] = ValBool(!toBool(interp.values[inst.Operands[0]]))
 			}
 
 		case OpBitwiseAnd:
@@ -1219,7 +1104,7 @@ func (interp *interpreter) run() error {
 		case OpNot:
 			if len(inst.Operands) >= 1 {
 				a := toUint32(interp.values[inst.Operands[0]])
-				interp.values[inst.ResultID] = ^a
+				interp.values[inst.ResultID] = ValUint(^a)
 			}
 
 		case OpShiftLeftLogical:
@@ -1236,7 +1121,7 @@ func (interp *interpreter) run() error {
 			if len(inst.Operands) >= 2 {
 				a := int32(toUint32(interp.values[inst.Operands[0]]))
 				b := toUint32(interp.values[inst.Operands[1]]) & 31
-				interp.values[inst.ResultID] = a >> b
+				interp.values[inst.ResultID] = ValInt(a >> b)
 			}
 
 		case OpAtomicIAdd, OpAtomicISub, OpAtomicExchange, OpAtomicCompareExchange,
@@ -1254,7 +1139,7 @@ func (interp *interpreter) run() error {
 
 		case OpUndef:
 			// OpUndef produces an undefined value -- use zero.
-			interp.values[inst.ResultID] = Uint32(0)
+			interp.values[inst.ResultID] = ValUint(0)
 
 		case OpExtInst:
 			// OpExtInst: type resultID setID instructionNumber operands...
@@ -1277,7 +1162,7 @@ func (interp *interpreter) run() error {
 			if len(inst.Operands) >= 2 {
 				imgVal := interp.values[inst.Operands[0]]
 				sampVal := interp.values[inst.Operands[1]]
-				interp.values[inst.ResultID] = &SampledImageValue{Image: imgVal, Sampler: sampVal}
+				interp.values[inst.ResultID] = ValSampledImage(&SampledImageValue{Image: imgVal, Sampler: sampVal})
 			}
 
 		case OpImageSampleImplicitLod:
@@ -1363,12 +1248,12 @@ const maxCallDepth = 64
 // allocating a new values slice per call.
 func (interp *interpreter) callFunction(funcID uint32, argIDs []uint32) (Value, error) {
 	if interp.callDepth >= maxCallDepth {
-		return nil, fmt.Errorf("spirv: exceeded maximum call depth (%d)", maxCallDepth)
+		return Value{}, fmt.Errorf("spirv: exceeded maximum call depth (%d)", maxCallDepth)
 	}
 
 	fn, ok := interp.module.FunctionsByID[funcID]
 	if !ok {
-		return nil, fmt.Errorf("spirv: function %d not found", funcID)
+		return Value{}, fmt.Errorf("spirv: function %d not found", funcID)
 	}
 
 	// Acquire a pooled child interpreter to avoid allocating per call.
@@ -1379,7 +1264,7 @@ func (interp *interpreter) callFunction(funcID uint32, argIDs []uint32) (Value, 
 	child.callDepth = interp.callDepth + 1
 	child.prevBlock = 0
 	child.iterationCount = 0
-	child.returnValue = nil
+	child.returnValue = Value{}
 
 	// Seed constants into the child value slice.
 	for id, val := range interp.module.Constants {
@@ -1401,7 +1286,8 @@ func (interp *interpreter) callFunction(funcID uint32, argIDs []uint32) (Value, 
 	for varID, vi := range interp.module.Variables {
 		if vi.StorageClass == StorageClassUniform || vi.StorageClass == StorageClassStorageBuffer ||
 			vi.StorageClass == StorageClassPushConstant || vi.StorageClass == StorageClassUniformConstant {
-			if v := interp.values[varID]; v != nil {
+			v := interp.values[varID]
+			if !v.IsNone() {
 				child.values[varID] = v
 			}
 		}
@@ -1410,7 +1296,7 @@ func (interp *interpreter) callFunction(funcID uint32, argIDs []uint32) (Value, 
 	// Execute the callee.
 	if err := child.run(); err != nil {
 		interp.module.putInterpreter(child)
-		return nil, err
+		return Value{}, err
 	}
 
 	retVal := child.returnValue
@@ -1431,27 +1317,28 @@ func (interp *interpreter) accessChain(baseID uint32, indexes []uint32) Value {
 	baseVal := interp.values[baseID]
 
 	// If base is a BufferPointer, compute byte offset through the chain.
-	if bp, ok := baseVal.(*BufferPointer); ok {
-		return interp.bufferAccessChain(bp, indexes)
+	if baseVal.Tag == TagBufferPointer {
+		return ValBufferPointer(interp.bufferAccessChain(baseVal.AsBufferPointer(), indexes))
 	}
 
 	// If base is a SubPointer, extend the index path.
-	if sp, ok := baseVal.(*SubPointer); ok {
+	if baseVal.Tag == TagSubPointer {
+		sp := baseVal.AsSubPointer()
 		resolvedIndexes := make([]uint32, len(sp.Indexes), len(sp.Indexes)+len(indexes))
 		copy(resolvedIndexes, sp.Indexes)
 		for _, idxID := range indexes {
 			resolvedIndexes = append(resolvedIndexes, toUint32(interp.values[idxID]))
 		}
-		return &SubPointer{Parent: sp.Parent, Indexes: resolvedIndexes}
+		return ValSubPointer(&SubPointer{Parent: sp.Parent, Indexes: resolvedIndexes})
 	}
 
 	// If base is a Pointer to a composite, return a SubPointer for write-through.
-	if ptr, ok := baseVal.(*Pointer); ok {
+	if baseVal.Tag == TagPointer {
 		resolvedIndexes := make([]uint32, 0, len(indexes))
 		for _, idxID := range indexes {
 			resolvedIndexes = append(resolvedIndexes, toUint32(interp.values[idxID]))
 		}
-		return &SubPointer{Parent: ptr, Indexes: resolvedIndexes}
+		return ValSubPointer(&SubPointer{Parent: baseVal.AsPointer(), Indexes: resolvedIndexes})
 	}
 
 	// Fallback: navigate through each index on a raw value.
@@ -1461,7 +1348,7 @@ func (interp *interpreter) accessChain(baseID uint32, indexes []uint32) Value {
 		current = indexComposite(current, idx)
 	}
 
-	return interp.allocPointer(current)
+	return ValPointer(interp.allocPointer(current))
 }
 
 // bufferAccessChain computes a byte offset through a chain of indexes into
@@ -1518,34 +1405,10 @@ func (interp *interpreter) bufferAccessChain(bp *BufferPointer, indexes []uint32
 	return &BufferPointer{Buffer: bp.Buffer, Offset: offset, Type: currentType}
 }
 
-// indexComposite extracts element at the given index from a composite value.
-func indexComposite(composite Value, index uint32) Value {
-	switch v := composite.(type) {
-	case Array:
-		if int(index) < len(v) {
-			return v[index]
-		}
-	case Vec2:
-		if index < 2 {
-			return Float32(v[index])
-		}
-	case Vec3:
-		if index < 3 {
-			return Float32(v[index])
-		}
-	case Vec4:
-		if index < 4 {
-			return Float32(v[index])
-		}
-	}
-	return Float32(0)
-}
-
 // subPointerLoad reads the current value of a sub-element through the parent
-// Pointer by navigating the index path. Each index dereferences one level of
-// composite (struct member or array element or vector component).
+// Pointer by navigating the index path.
 func subPointerLoad(sp *SubPointer) Value {
-	current := sp.Parent.Value
+	current := sp.Parent.Val
 	for _, idx := range sp.Indexes {
 		current = indexComposite(current, idx)
 	}
@@ -1553,83 +1416,20 @@ func subPointerLoad(sp *SubPointer) Value {
 }
 
 // subPointerStore writes a value to a sub-element of the parent Pointer's
-// composite, rebuilding the composite at each level so the parent reflects the
-// change. This is the key operation that makes function-local struct member
-// updates work correctly (e.g. p.pos = newPos modifies the struct in p).
+// composite, rebuilding the composite at each level so the parent reflects the change.
 func subPointerStore(sp *SubPointer, val Value) {
 	if len(sp.Indexes) == 0 {
-		sp.Parent.Value = val
+		sp.Parent.Val = val
 		return
 	}
-	sp.Parent.Value = setCompositeElement(sp.Parent.Value, sp.Indexes, val)
-}
-
-// setCompositeElement returns a copy of composite with the element at the
-// given index path replaced by val. Handles Array, Vec2, Vec3, Vec4 composites.
-// For nested composites (e.g. struct containing struct), the function recurses
-// through the index path.
-func setCompositeElement(composite Value, indexes []uint32, val Value) Value {
-	if len(indexes) == 0 {
-		return val
-	}
-	idx := indexes[0]
-	rest := indexes[1:]
-
-	switch v := composite.(type) {
-	case Array:
-		if int(idx) >= len(v) {
-			return composite
-		}
-		// Clone the array to avoid mutating shared references.
-		newArr := make(Array, len(v))
-		copy(newArr, v)
-		if len(rest) == 0 {
-			newArr[idx] = val
-		} else {
-			newArr[idx] = setCompositeElement(v[idx], rest, val)
-		}
-		return newArr
-
-	case Vec2:
-		if idx >= 2 {
-			return composite
-		}
-		newVec := v // copy (fixed-size array = value type)
-		if len(rest) == 0 {
-			newVec[idx] = toFloat32(val)
-		}
-		return newVec
-
-	case Vec3:
-		if idx >= 3 {
-			return composite
-		}
-		newVec := v
-		if len(rest) == 0 {
-			newVec[idx] = toFloat32(val)
-		}
-		return newVec
-
-	case Vec4:
-		if idx >= 4 {
-			return composite
-		}
-		newVec := v
-		if len(rest) == 0 {
-			newVec[idx] = toFloat32(val)
-		}
-		return newVec
-
-	default:
-		return composite
-	}
+	sp.Parent.Val = setCompositeElement(sp.Parent.Val, sp.Indexes, val)
 }
 
 // compositeConstruct builds a composite value from constituent IDs.
 func (interp *interpreter) compositeConstruct(typeID uint32, constituentIDs []uint32) Value {
 	ti, ok := interp.module.Types[typeID]
 	if !ok {
-		return Vec4{}
+		return ValVec4(0, 0, 0, 0)
 	}
 
 	switch ti.Kind {
@@ -1639,36 +1439,32 @@ func (interp *interpreter) compositeConstruct(typeID uint32, constituentIDs []ui
 		if uint32(len(constituentIDs)) == ti.Components {
 			allScalar := true
 			for _, id := range constituentIDs {
-				switch interp.values[id].(type) {
-				case Float32, Uint32, Int32:
-					// scalar -- OK
-				default:
+				tag := interp.values[id].Tag
+				if tag != TagFloat32 && tag != TagUint32 && tag != TagInt32 {
 					allScalar = false
-				}
-				if !allScalar {
 					break
 				}
 			}
 			if allScalar {
 				switch ti.Components {
 				case 2:
-					return Vec2{
+					return ValVec2(
 						toFloat32(interp.values[constituentIDs[0]]),
 						toFloat32(interp.values[constituentIDs[1]]),
-					}
+					)
 				case 3:
-					return Vec3{
+					return ValVec3(
 						toFloat32(interp.values[constituentIDs[0]]),
 						toFloat32(interp.values[constituentIDs[1]]),
 						toFloat32(interp.values[constituentIDs[2]]),
-					}
+					)
 				case 4:
-					return Vec4{
+					return ValVec4(
 						toFloat32(interp.values[constituentIDs[0]]),
 						toFloat32(interp.values[constituentIDs[1]]),
 						toFloat32(interp.values[constituentIDs[2]]),
 						toFloat32(interp.values[constituentIDs[3]]),
-					}
+					)
 				}
 			}
 		}
@@ -1679,35 +1475,35 @@ func (interp *interpreter) compositeConstruct(typeID uint32, constituentIDs []ui
 		n := 0
 		for _, id := range constituentIDs {
 			val := interp.values[id]
-			switch v := val.(type) {
-			case Float32:
+			switch val.Tag {
+			case TagFloat32:
 				if n < len(buf) {
-					buf[n] = v
+					buf[n] = val.F[0]
 					n++
 				}
-			case Uint32:
+			case TagUint32:
 				if n < len(buf) {
-					buf[n] = float32(v)
+					buf[n] = float32(val.U[0])
 					n++
 				}
-			case Int32:
+			case TagInt32:
 				if n < len(buf) {
-					buf[n] = float32(v)
+					buf[n] = float32(int32(val.U[0]))
 					n++
 				}
-			case Vec2:
+			case TagVec2:
 				for j := 0; j < 2 && n < len(buf); j++ {
-					buf[n] = v[j]
+					buf[n] = val.F[j]
 					n++
 				}
-			case Vec3:
+			case TagVec3:
 				for j := 0; j < 3 && n < len(buf); j++ {
-					buf[n] = v[j]
+					buf[n] = val.F[j]
 					n++
 				}
-			case Vec4:
+			case TagVec4:
 				for j := 0; j < 4 && n < len(buf); j++ {
-					buf[n] = v[j]
+					buf[n] = val.F[j]
 					n++
 				}
 			default:
@@ -1719,29 +1515,29 @@ func (interp *interpreter) compositeConstruct(typeID uint32, constituentIDs []ui
 		}
 		switch ti.Components {
 		case 2:
-			return Vec2{buf[0], buf[1]}
+			return ValVec2(buf[0], buf[1])
 		case 3:
-			return Vec3{buf[0], buf[1], buf[2]}
+			return ValVec3(buf[0], buf[1], buf[2])
 		case 4:
-			return Vec4{buf[0], buf[1], buf[2], buf[3]}
+			return ValVec4(buf[0], buf[1], buf[2], buf[3])
 		}
 
 	case TypeArray:
-		arr := make(Array, len(constituentIDs))
+		arr := make([]Value, len(constituentIDs))
 		for i, id := range constituentIDs {
 			arr[i] = interp.values[id]
 		}
-		return arr
+		return ValArray(arr)
 
 	case TypeStruct:
-		arr := make(Array, len(constituentIDs))
+		arr := make([]Value, len(constituentIDs))
 		for i, id := range constituentIDs {
 			arr[i] = interp.values[id]
 		}
-		return arr
+		return ValArray(arr)
 	}
 
-	return Uint32(0)
+	return ValUint(0)
 }
 
 // compositeExtract navigates literal indexes to extract a scalar from a composite.
@@ -1753,298 +1549,76 @@ func (interp *interpreter) compositeExtract(composite Value, indexes []uint32) V
 	return current
 }
 
-// appendComponents flattens a value into float32 components.
-func appendComponents(dst []float32, val Value) []float32 {
-	switch v := val.(type) {
-	case Float32:
-		return append(dst, v)
-	case Vec2:
-		return append(dst, v[0], v[1])
-	case Vec3:
-		return append(dst, v[0], v[1], v[2])
-	case Vec4:
-		return append(dst, v[0], v[1], v[2], v[3])
-	case Uint32:
-		return append(dst, float32(v))
-	case Int32:
-		return append(dst, float32(v))
-	default:
-		return append(dst, 0)
-	}
-}
-
-// convertToFloat converts an unsigned integer value to float32.
-func convertToFloat(val Value) Value {
-	switch v := val.(type) {
-	case Uint32:
-		return Float32(float32(v))
-	case Int32:
-		return Float32(float32(v))
-	case Float32:
-		return v
-	default:
-		return Float32(0)
-	}
-}
-
-// convertSignedToFloat converts a signed integer value to float32.
-func convertSignedToFloat(val Value) Value {
-	switch v := val.(type) {
-	case Int32:
-		return Float32(float32(v))
-	case Uint32:
-		return Float32(float32(int32(v)))
-	case Float32:
-		return v
-	default:
-		return Float32(0)
-	}
-}
-
-// convertFloatToUint converts a float value to uint32.
-func convertFloatToUint(val Value) Value {
-	switch v := val.(type) {
-	case Float32:
-		return uint32(v)
-	case Uint32:
-		return v
-	case Int32:
-		return uint32(v)
-	default:
-		return Uint32(0)
-	}
-}
-
-// toFloat32 extracts a float32 from a Value.
-func toFloat32(val Value) float32 {
-	switch v := val.(type) {
-	case Float32:
-		return v
-	case Uint32:
-		return float32(v)
-	case Int32:
-		return float32(v)
-	default:
-		return 0
-	}
-}
-
-// toUint32 extracts a uint32 from a Value.
-func toUint32(val Value) uint32 {
-	switch v := val.(type) {
-	case Uint32:
-		return v
-	case Int32:
-		return uint32(v)
-	case Float32:
-		return uint32(v)
-	case bool:
-		if v {
-			return 1
-		}
-		return 0
-	default:
-		return 0
-	}
-}
-
-// toBool converts a Value to boolean.
-func toBool(val Value) bool {
-	switch v := val.(type) {
-	case bool:
-		return v
-	case Uint32:
-		return v != 0
-	case Int32:
-		return v != 0
-	case Float32:
-		return v != 0
-	default:
-		return false
-	}
-}
-
-// floatBinOp applies a binary operation to two float-typed values.
-// Works on scalars and vectors component-wise.
-func floatBinOp(a, b Value, op func(float32, float32) float32) Value {
-	switch av := a.(type) {
-	case Float32:
-		bv := toFloat32(b)
-		return Float32(op(av, bv))
-	case Vec2:
-		bv, ok := b.(Vec2)
-		if !ok {
-			return a
-		}
-		return Vec2{op(av[0], bv[0]), op(av[1], bv[1])}
-	case Vec3:
-		bv, ok := b.(Vec3)
-		if !ok {
-			return a
-		}
-		return Vec3{op(av[0], bv[0]), op(av[1], bv[1]), op(av[2], bv[2])}
-	case Vec4:
-		bv, ok := b.(Vec4)
-		if !ok {
-			return a
-		}
-		return Vec4{op(av[0], bv[0]), op(av[1], bv[1]), op(av[2], bv[2]), op(av[3], bv[3])}
-	default:
-		return Float32(0)
-	}
-}
-
-// floatUnaryOp applies a unary operation to a float-typed value.
-func floatUnaryOp(a Value, op func(float32) float32) Value {
-	switch av := a.(type) {
-	case Float32:
-		return Float32(op(av))
-	case Vec2:
-		return Vec2{op(av[0]), op(av[1])}
-	case Vec3:
-		return Vec3{op(av[0]), op(av[1]), op(av[2])}
-	case Vec4:
-		return Vec4{op(av[0]), op(av[1]), op(av[2]), op(av[3])}
-	default:
-		return Float32(0)
-	}
-}
-
-// intBinOp applies a binary operation to two integer values.
-func intBinOp(a, b Value, op func(uint32, uint32) uint32) Value {
-	av := toUint32(a)
-	bv := toUint32(b)
-	return op(av, bv)
-}
-
-// Vec4ToFloat32 extracts a Vec4 from a Value, returning zeros if type doesn't match.
-func Vec4ToFloat32(val Value) [4]float32 {
-	switch v := val.(type) {
-	case Vec4:
-		return v
-	case Vec3:
-		return [4]float32{v[0], v[1], v[2], 0}
-	case Vec2:
-		return [4]float32{v[0], v[1], 0, 0}
-	case Float32:
-		return [4]float32{v, 0, 0, 0}
-	default:
-		return [4]float32{}
-	}
-}
-
-// Float32BitsToUint32 converts a float32 to its bit representation as uint32.
-// Used for SPIR-V constant encoding in tests.
-func Float32BitsToUint32(f float32) uint32 {
-	return math.Float32bits(f)
-}
-
-// vectorTimesScalar multiplies each component of a vector by a scalar.
-func vectorTimesScalar(vec Value, s float32) Value {
-	switch v := vec.(type) {
-	case Vec2:
-		return Vec2{v[0] * s, v[1] * s}
-	case Vec3:
-		return Vec3{v[0] * s, v[1] * s, v[2] * s}
-	case Vec4:
-		return Vec4{v[0] * s, v[1] * s, v[2] * s, v[3] * s}
-	default:
-		return Float32(toFloat32(vec) * s)
-	}
-}
-
-// dotProduct computes the dot product of two vectors.
-func dotProduct(a, b Value) Value {
-	switch av := a.(type) {
-	case Vec2:
-		bv, ok := b.(Vec2)
-		if !ok {
-			return Float32(0)
-		}
-		return Float32(av[0]*bv[0] + av[1]*bv[1])
-	case Vec3:
-		bv, ok := b.(Vec3)
-		if !ok {
-			return Float32(0)
-		}
-		return Float32(av[0]*bv[0] + av[1]*bv[1] + av[2]*bv[2])
-	case Vec4:
-		bv, ok := b.(Vec4)
-		if !ok {
-			return Float32(0)
-		}
-		return Float32(av[0]*bv[0] + av[1]*bv[1] + av[2]*bv[2] + av[3]*bv[3])
-	default:
-		return Float32(toFloat32(a) * toFloat32(b))
-	}
-}
+// =============================================================================
+// Matrix Operations
+// =============================================================================
 
 // matrixTimesVector multiplies a matrix (Array of column vectors) by a vector.
 // SPIR-V stores matrices in column-major order as arrays of column vectors.
 func matrixTimesVector(mat, vec Value) Value {
-	cols, ok := mat.(Array)
-	if !ok {
+	if mat.Tag != TagArray {
 		return vec
 	}
-	v, ok := vec.(Vec4)
-	if !ok {
+	cols := mat.AsArray()
+	if vec.Tag != TagVec4 {
 		return vec
 	}
+	v := vec.F
 	numCols := len(cols)
 	if numCols < 2 {
 		return vec
 	}
 
 	// Extract columns as Vec4 (padding with zeros if needed).
-	colVecs := make([]Vec4, numCols)
+	colVecs := make([][4]float32, numCols)
 	for i, c := range cols {
 		colVecs[i] = Vec4ToFloat32(c)
 	}
 
 	// result = col[0]*v[0] + col[1]*v[1] + ...
-	var result Vec4
+	var result [4]float32
 	for i := 0; i < numCols && i < 4; i++ {
 		for j := 0; j < 4; j++ {
 			result[j] += colVecs[i][j] * v[i]
 		}
 	}
-	return result
+	return ValVec4(result[0], result[1], result[2], result[3])
 }
 
 // matrixTimesScalar multiplies every element of a matrix by a scalar.
 func matrixTimesScalar(mat, scalar Value) Value {
-	cols, ok := mat.(Array)
-	if !ok {
+	if mat.Tag != TagArray {
 		return mat
 	}
+	cols := mat.AsArray()
 	s := toFloat32(scalar)
-	result := make(Array, len(cols))
+	result := make([]Value, len(cols))
 	for i, c := range cols {
 		result[i] = vectorTimesScalar(c, s)
 	}
-	return result
+	return ValArray(result)
 }
 
 // matrixTimesMatrix multiplies two matrices (both stored as Array of column vectors).
 // C = A * B means C[j] = A * B[j] for each column j of B.
 func matrixTimesMatrix(left, right Value) Value {
-	rightCols, ok := right.(Array)
-	if !ok {
+	if right.Tag != TagArray {
 		return right
 	}
-	result := make(Array, len(rightCols))
+	rightCols := right.AsArray()
+	result := make([]Value, len(rightCols))
 	for j, col := range rightCols {
 		result[j] = matrixTimesVector(left, col)
 	}
-	return result
+	return ValArray(result)
 }
 
 // transposeMatrix transposes a matrix stored as Array of column vectors.
 func transposeMatrix(mat Value) Value {
-	cols, ok := mat.(Array)
-	if !ok {
+	if mat.Tag != TagArray {
 		return mat
 	}
+	cols := mat.AsArray()
 	numCols := len(cols)
 	if numCols == 0 {
 		return mat
@@ -2052,40 +1626,38 @@ func transposeMatrix(mat Value) Value {
 
 	// Determine the number of rows from the first column.
 	var numRows int
-	switch cols[0].(type) {
-	case Vec2:
+	switch cols[0].Tag {
+	case TagVec2:
 		numRows = 2
-	case Vec3:
+	case TagVec3:
 		numRows = 3
-	case Vec4:
+	case TagVec4:
 		numRows = 4
 	default:
 		return mat
 	}
 
 	// Build transposed columns (each row of the original becomes a column).
-	result := make(Array, numRows)
+	result := make([]Value, numRows)
 	for r := 0; r < numRows; r++ {
-		var row Vec4
+		var row [4]float32
 		for c := 0; c < numCols && c < 4; c++ {
 			row[c] = toFloat32(indexComposite(cols[c], uint32(r)))
 		}
 		// Return the correct vector type based on column count.
 		switch numCols {
 		case 2:
-			result[r] = Vec2{row[0], row[1]}
+			result[r] = ValVec2(row[0], row[1])
 		case 3:
-			result[r] = Vec3{row[0], row[1], row[2]}
+			result[r] = ValVec3(row[0], row[1], row[2])
 		default:
-			result[r] = row
+			result[r] = ValVec4(row[0], row[1], row[2], row[3])
 		}
 	}
-	return result
+	return ValArray(result)
 }
 
 // vectorShuffle creates a new vector by selecting components from two input vectors.
-// Components are literal indices where 0..N-1 select from vec1 and N..2N-1 from vec2.
-// A component value of 0xFFFFFFFF means the result component is undefined (zero).
 func vectorShuffle(m *Module, typeID uint32, vec1, vec2 Value, components []uint32) Value {
 	// Flatten both vectors into a combined component array.
 	var pool []float32
@@ -2108,36 +1680,36 @@ func vectorShuffle(m *Module, typeID uint32, vec1, vec2 Value, components []uint
 	if ti != nil && ti.Kind == TypeVector {
 		switch ti.Components {
 		case 2:
-			var v Vec2
+			var v [2]float32
 			for i := 0; i < 2 && i < len(out); i++ {
 				v[i] = out[i]
 			}
-			return v
+			return ValVec2(v[0], v[1])
 		case 3:
-			var v Vec3
+			var v [3]float32
 			for i := 0; i < 3 && i < len(out); i++ {
 				v[i] = out[i]
 			}
-			return v
+			return ValVec3(v[0], v[1], v[2])
 		case 4:
-			var v Vec4
+			var v [4]float32
 			for i := 0; i < 4 && i < len(out); i++ {
 				v[i] = out[i]
 			}
-			return v
+			return ValVec4(v[0], v[1], v[2], v[3])
 		}
 	}
 
 	// Fallback: infer from component count.
 	switch len(out) {
 	case 2:
-		return Vec2{out[0], out[1]}
+		return ValVec2(out[0], out[1])
 	case 3:
-		return Vec3{out[0], out[1], out[2]}
+		return ValVec3(out[0], out[1], out[2])
 	case 4:
-		return Vec4{out[0], out[1], out[2], out[3]}
+		return ValVec4(out[0], out[1], out[2], out[3])
 	default:
-		return Float32(0)
+		return ValFloat(0)
 	}
 }
 
@@ -2146,46 +1718,40 @@ func vectorShuffle(m *Module, typeID uint32, vec1, vec2 Value, components []uint
 // =============================================================================
 
 // resolveTexture looks up a Texture2D from a value that may be a BindingKey
-// or already a *Texture2D.
+// or already stored via another mechanism.
 func (interp *interpreter) resolveTexture(val Value) *Texture2D {
-	switch v := val.(type) {
-	case *Texture2D:
-		return v
-	case BindingKey:
+	if val.Tag == TagBindingKey {
+		bk := val.AsBindingKey()
 		if interp.ctx != nil && interp.ctx.Textures != nil {
-			return interp.ctx.Textures[v]
+			return interp.ctx.Textures[bk]
 		}
 	}
 	return nil
 }
 
-// resolveSampler looks up a Sampler from a value that may be a BindingKey
-// or already a *Sampler.
+// resolveSampler looks up a Sampler from a value that may be a BindingKey.
 func (interp *interpreter) resolveSampler(val Value) *Sampler {
-	switch v := val.(type) {
-	case *Sampler:
-		return v
-	case BindingKey:
+	if val.Tag == TagBindingKey {
+		bk := val.AsBindingKey()
 		if interp.ctx != nil && interp.ctx.Samplers != nil {
-			return interp.ctx.Samplers[v]
+			return interp.ctx.Samplers[bk]
 		}
 	}
 	return nil
 }
 
 // sampleTexture samples a texture using the given sampled image and UV coordinates.
-// lod is the level-of-detail (only LOD 0 is supported).
 func (interp *interpreter) sampleTexture(sampledImg Value, coord Value, lod float32) Value {
 	_ = lod // LOD levels not implemented; always sample base level.
 
-	si, ok := sampledImg.(*SampledImageValue)
-	if !ok {
-		return Vec4{1, 0, 1, 1} // Magenta for error.
+	if sampledImg.Tag != TagSampledImage {
+		return ValVec4(1, 0, 1, 1) // Magenta for error.
 	}
+	si := sampledImg.AsSampledImage()
 
 	tex := interp.resolveTexture(si.Image)
 	if tex == nil || tex.Width == 0 || tex.Height == 0 || len(tex.Data) == 0 {
-		return Vec4{1, 0, 1, 1} // Magenta for missing texture.
+		return ValVec4(1, 0, 1, 1) // Magenta for missing texture.
 	}
 
 	samp := interp.resolveSampler(si.Sampler)
@@ -2195,13 +1761,13 @@ func (interp *interpreter) sampleTexture(sampledImg Value, coord Value, lod floa
 
 	// Extract UV coordinates.
 	var u, v float32
-	switch c := coord.(type) {
-	case Vec2:
-		u, v = c[0], c[1]
-	case Vec3:
-		u, v = c[0], c[1]
-	case Vec4:
-		u, v = c[0], c[1]
+	switch coord.Tag {
+	case TagVec2:
+		u, v = coord.F[0], coord.F[1]
+	case TagVec3:
+		u, v = coord.F[0], coord.F[1]
+	case TagVec4:
+		u, v = coord.F[0], coord.F[1]
 	default:
 		u = toFloat32(coord)
 	}
@@ -2213,26 +1779,26 @@ func (interp *interpreter) sampleTexture(sampledImg Value, coord Value, lod floa
 	// Determine filter from the magnification filter.
 	filter := samp.MagFilter
 	if filter == FilterLinear {
-		return sampleBilinear(tex, u, v)
+		return ValVec4From(sampleBilinear(tex, u, v))
 	}
-	return sampleNearest(tex, u, v)
+	return ValVec4From(sampleNearest(tex, u, v))
 }
 
 // fetchTexel fetches a single texel by integer coordinates (no filtering).
 func (interp *interpreter) fetchTexel(imgVal Value, coord Value) Value {
 	tex := interp.resolveTexture(imgVal)
 	if tex == nil || tex.Width == 0 || tex.Height == 0 || len(tex.Data) == 0 {
-		return Vec4{0, 0, 0, 0}
+		return ValVec4(0, 0, 0, 0)
 	}
 
 	var x, y int
-	switch c := coord.(type) {
-	case Vec2:
-		x, y = int(c[0]), int(c[1])
-	case Vec3:
-		x, y = int(c[0]), int(c[1])
-	case Vec4:
-		x, y = int(c[0]), int(c[1])
+	switch coord.Tag {
+	case TagVec2:
+		x, y = int(coord.F[0]), int(coord.F[1])
+	case TagVec3:
+		x, y = int(coord.F[0]), int(coord.F[1])
+	case TagVec4:
+		x, y = int(coord.F[0]), int(coord.F[1])
 	default:
 		x = int(toUint32(coord))
 	}
@@ -2251,20 +1817,19 @@ func (interp *interpreter) fetchTexel(imgVal Value, coord Value) Value {
 		y = int(tex.Height) - 1
 	}
 
-	return readTexel(tex, x, y)
+	return ValVec4From(readTexel(tex, x, y))
 }
 
 // queryImageSize returns the size of a texture as a vec2 of uint32 values.
 func (interp *interpreter) queryImageSize(imgVal Value) Value {
 	tex := interp.resolveTexture(imgVal)
 	if tex == nil {
-		return Vec2{0, 0}
+		return ValVec2(0, 0)
 	}
-	return Vec2{float32(tex.Width), float32(tex.Height)}
+	return ValVec2(float32(tex.Width), float32(tex.Height))
 }
 
 // applyWrapMode wraps a texture coordinate according to the specified mode.
-// The result is in [0, 1) for repeat modes and [0, 1] for clamp.
 func applyWrapMode(coord float32, mode uint32) float32 {
 	switch mode {
 	case WrapClampToEdge:
@@ -2277,7 +1842,6 @@ func applyWrapMode(coord float32, mode uint32) float32 {
 		return coord
 
 	case WrapMirroredRepeat:
-		// Mirror: period is 2.0; within [0,1] normal, [1,2] reflected.
 		coord = float32(math.Abs(float64(coord)))
 		period := int(coord)
 		frac := coord - float32(period)
@@ -2300,7 +1864,6 @@ func sampleNearest(tex *Texture2D, u, v float32) Vec4 {
 	x := int(u * float32(tex.Width))
 	y := int(v * float32(tex.Height))
 
-	// Clamp to valid pixel range.
 	if x < 0 {
 		x = 0
 	}
@@ -2319,7 +1882,6 @@ func sampleNearest(tex *Texture2D, u, v float32) Vec4 {
 
 // sampleBilinear samples a texture at the given UV using bilinear (4-tap) filtering.
 func sampleBilinear(tex *Texture2D, u, v float32) Vec4 {
-	// Map UV to texel space (center of pixel 0 is at 0.5/width).
 	fx := u*float32(tex.Width) - 0.5
 	fy := v*float32(tex.Height) - 0.5
 
@@ -2328,11 +1890,9 @@ func sampleBilinear(tex *Texture2D, u, v float32) Vec4 {
 	x1 := x0 + 1
 	y1 := y0 + 1
 
-	// Fractional part for interpolation.
 	fracX := fx - float32(x0)
 	fracY := fy - float32(y0)
 
-	// Clamp coordinates.
 	w := int(tex.Width)
 	h := int(tex.Height)
 	x0 = clampInt(x0, w-1)
@@ -2340,13 +1900,11 @@ func sampleBilinear(tex *Texture2D, u, v float32) Vec4 {
 	x1 = clampInt(x1, w-1)
 	y1 = clampInt(y1, h-1)
 
-	// Fetch the four texels.
 	c00 := readTexel(tex, x0, y0)
 	c10 := readTexel(tex, x1, y0)
 	c01 := readTexel(tex, x0, y1)
 	c11 := readTexel(tex, x1, y1)
 
-	// Bilinear interpolation.
 	var result Vec4
 	for i := 0; i < 4; i++ {
 		top := c00[i]*(1-fracX) + c10[i]*fracX
@@ -2357,7 +1915,6 @@ func sampleBilinear(tex *Texture2D, u, v float32) Vec4 {
 }
 
 // readTexel reads a single RGBA texel from the texture at pixel coordinates (x, y).
-// Returns normalized [0,1] float values.
 func readTexel(tex *Texture2D, x, y int) Vec4 {
 	idx := (y*int(tex.Width) + x) * 4
 	if idx+3 >= len(tex.Data) {

--- a/hal/software/shader/interpreter_test.go
+++ b/hal/software/shader/interpreter_test.go
@@ -277,7 +277,7 @@ func TestSPIRVTriangleVertexShader(t *testing.T) {
 
 	for idx, want := range expected {
 		inputs := map[uint32]Value{
-			idxVarID: uint32(idx),
+			idxVarID: ValUint(uint32(idx)),
 		}
 
 		outputs, err := m.Execute("vs_main", inputs)
@@ -393,7 +393,7 @@ func TestSPIRVAccessChainOutOfBounds(t *testing.T) {
 	// Index 10 is out of bounds for a 3-element array.
 	// The interpreter should not crash; it returns a zero element.
 	inputs := map[uint32]Value{
-		idxVarID: Uint32(10),
+		idxVarID: ValUint(10),
 	}
 	_, err = m.Execute("vs_main", inputs)
 	// Should not error — out-of-bounds returns zero.
@@ -409,16 +409,16 @@ func TestSPIRVConvertUToF(t *testing.T) {
 		val  Value
 		want float32
 	}{
-		{"uint32_0", Uint32(0), 0},
-		{"uint32_42", Uint32(42), 42},
-		{"int32_neg", Int32(-5), -5},
-		{"float32", Float32(3.14), 3.14},
+		{"uint32_0", ValUint(0), 0},
+		{"uint32_42", ValUint(42), 42},
+		{"int32_neg", ValInt(-5), -5},
+		{"float32", ValFloat(3.14), 3.14},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := convertToFloat(tt.val)
-			f, ok := result.(Float32)
+			f, ok := testIsFloat32(result)
 			if !ok {
 				t.Fatalf("convertToFloat returned %T, want Float32", result)
 			}
@@ -449,7 +449,7 @@ func TestSPIRVCompositeConstruct(t *testing.T) {
 		}
 	}
 
-	inputs := map[uint32]Value{idxVarID: Uint32(0)}
+	inputs := map[uint32]Value{idxVarID: ValUint(0)}
 	outputs, err := m.Execute("vs_main", inputs)
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
@@ -501,11 +501,11 @@ func TestVec4ToFloat32(t *testing.T) {
 		val  Value
 		want [4]float32
 	}{
-		{"vec4", Vec4{1, 2, 3, 4}, [4]float32{1, 2, 3, 4}},
-		{"vec3", Vec3{1, 2, 3}, [4]float32{1, 2, 3, 0}},
-		{"vec2", Vec2{1, 2}, [4]float32{1, 2, 0, 0}},
-		{"float", Float32(5), [4]float32{5, 0, 0, 0}},
-		{"nil", nil, [4]float32{0, 0, 0, 0}},
+		{"vec4", ValVec4From(Vec4{1, 2, 3, 4}), [4]float32{1, 2, 3, 4}},
+		{"vec3", ValVec3From(Vec3{1, 2, 3}), [4]float32{1, 2, 3, 0}},
+		{"vec2", ValVec2From(Vec2{1, 2}), [4]float32{1, 2, 0, 0}},
+		{"float", ValFloat(5), [4]float32{5, 0, 0, 0}},
+		{"nil", Value{}, [4]float32{0, 0, 0, 0}},
 	}
 
 	for _, tt := range tests {
@@ -519,17 +519,16 @@ func TestVec4ToFloat32(t *testing.T) {
 }
 
 func TestIndexComposite(t *testing.T) {
-	arr := Array{Float32(10), Float32(20), Float32(30)}
-	v := indexComposite(arr, 1)
-	f, ok := v.(Float32)
+	arr := Array{ValFloat(10), ValFloat(20), ValFloat(30)}
+	v := indexComposite(ValArray(arr), 1)
+	f, ok := testIsFloat32(v)
 	if !ok || f != 20 {
-		t.Errorf("indexComposite(arr, 1) = %v, want Float32(20)", v)
+		t.Errorf("indexComposite(ValArray(arr), 1) = %v, want Float32(20)", v)
 	}
 
 	vec := Vec4{1, 2, 3, 4}
-	v = indexComposite(vec, 2)
-	f, ok = v.(Float32)
-	if !ok || f != 3 {
+	v = indexComposite(ValVec4From(vec), 2)
+	if v.Tag != TagFloat32 || v.F[0] != 3 {
 		t.Errorf("indexComposite(vec4, 2) = %v, want Float32(3)", v)
 	}
 }
@@ -537,13 +536,13 @@ func TestIndexComposite(t *testing.T) {
 func TestFloatBinOp(t *testing.T) {
 	add := func(a, b float32) float32 { return a + b }
 
-	result := floatBinOp(Float32(3), Float32(4), add)
-	if f, ok := result.(Float32); !ok || f != 7 {
+	result := floatBinOp(ValFloat(3), ValFloat(4), add)
+	if f, ok := testIsFloat32(result); !ok || f != 7 {
 		t.Errorf("floatBinOp scalar = %v, want 7", result)
 	}
 
-	result = floatBinOp(Vec2{1, 2}, Vec2{3, 4}, add)
-	if v, ok := result.(Vec2); !ok || v != (Vec2{4, 6}) {
+	result = floatBinOp(ValVec2(1, 2), ValVec2(3, 4), add)
+	if result.Tag != TagVec2 || result.AsVec2() != (Vec2{4, 6}) {
 		t.Errorf("floatBinOp vec2 = %v, want [4, 6]", result)
 	}
 }
@@ -551,8 +550,8 @@ func TestFloatBinOp(t *testing.T) {
 func TestIntBinOp(t *testing.T) {
 	add := func(a, b uint32) uint32 { return a + b }
 
-	result := intBinOp(Uint32(3), Uint32(4), add)
-	if u, ok := result.(Uint32); !ok || u != 7 {
+	result := intBinOp(ValUint(3), ValUint(4), add)
+	if u, ok := testIsUint32(result); !ok || u != 7 {
 		t.Errorf("intBinOp = %v, want 7", result)
 	}
 }
@@ -568,11 +567,11 @@ func TestVectorTimesScalar(t *testing.T) {
 		s    float32
 		want Value
 	}{
-		{"vec2", Vec2{1, 2}, 3, Vec2{3, 6}},
-		{"vec3", Vec3{1, 2, 3}, 2, Vec3{2, 4, 6}},
-		{"vec4", Vec4{1, 2, 3, 4}, 0.5, Vec4{0.5, 1, 1.5, 2}},
-		{"scalar", Float32(5), 3, Float32(15)},
-		{"zero_scalar", Vec3{1, 2, 3}, 0, Vec3{0, 0, 0}},
+		{"vec2", ValVec2From(Vec2{1, 2}), 3, ValVec2From(Vec2{3, 6})},
+		{"vec3", ValVec3From(Vec3{1, 2, 3}), 2, ValVec3From(Vec3{2, 4, 6})},
+		{"vec4", ValVec4From(Vec4{1, 2, 3, 4}), 0.5, ValVec4From(Vec4{0.5, 1, 1.5, 2})},
+		{"scalar", ValFloat(5), 3, ValFloat(15)},
+		{"zero_scalar", ValVec3From(Vec3{1, 2, 3}), 0, ValVec3From(Vec3{0, 0, 0})},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -590,16 +589,16 @@ func TestDotProduct(t *testing.T) {
 		a, b Value
 		want float32
 	}{
-		{"vec2", Vec2{1, 2}, Vec2{3, 4}, 11},
-		{"vec3", Vec3{1, 0, 0}, Vec3{0, 1, 0}, 0},
-		{"vec3_self", Vec3{1, 2, 3}, Vec3{1, 2, 3}, 14},
-		{"vec4", Vec4{1, 2, 3, 4}, Vec4{4, 3, 2, 1}, 20},
-		{"scalar", Float32(3), Float32(4), 12},
+		{"vec2", ValVec2(1, 2), ValVec2(3, 4), 11},
+		{"vec3", ValVec3(1, 0, 0), ValVec3(0, 1, 0), 0},
+		{"vec3_self", ValVec3(1, 2, 3), ValVec3(1, 2, 3), 14},
+		{"vec4", ValVec4(1, 2, 3, 4), ValVec4(4, 3, 2, 1), 20},
+		{"scalar", ValFloat(3), ValFloat(4), 12},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := dotProduct(tt.a, tt.b)
-			f, ok := got.(Float32)
+			f, ok := testIsFloat32(got)
 			if !ok {
 				t.Fatalf("dotProduct returned %T, want Float32", got)
 			}
@@ -613,26 +612,26 @@ func TestDotProduct(t *testing.T) {
 func TestMatrixTimesVector(t *testing.T) {
 	// Identity matrix as Array of 4 Vec4 columns (column-major).
 	identity := Array{
-		Vec4{1, 0, 0, 0},
-		Vec4{0, 1, 0, 0},
-		Vec4{0, 0, 1, 0},
-		Vec4{0, 0, 0, 1},
+		ValVec4(1, 0, 0, 0),
+		ValVec4(0, 1, 0, 0),
+		ValVec4(0, 0, 1, 0),
+		ValVec4(0, 0, 0, 1),
 	}
-	v := Vec4{1, 2, 3, 1}
-	got := matrixTimesVector(identity, v)
+	v := ValVec4(1, 2, 3, 1)
+	got := matrixTimesVector(ValArray(identity), v)
 	gv := Vec4ToFloat32(got)
-	if gv != v {
+	if gv != v.AsVec4() {
 		t.Errorf("identity * v = %v, want %v", gv, v)
 	}
 
 	// Scale matrix: diag(2, 3, 4, 1)
 	scale := Array{
-		Vec4{2, 0, 0, 0},
-		Vec4{0, 3, 0, 0},
-		Vec4{0, 0, 4, 0},
-		Vec4{0, 0, 0, 1},
+		ValVec4(2, 0, 0, 0),
+		ValVec4(0, 3, 0, 0),
+		ValVec4(0, 0, 4, 0),
+		ValVec4(0, 0, 0, 1),
 	}
-	got = matrixTimesVector(scale, Vec4{1, 1, 1, 1})
+	got = matrixTimesVector(ValArray(scale), ValVec4(1, 1, 1, 1))
 	gv = Vec4ToFloat32(got)
 	want := Vec4{2, 3, 4, 1}
 	if gv != want {
@@ -642,15 +641,15 @@ func TestMatrixTimesVector(t *testing.T) {
 
 func TestTransposeMatrix(t *testing.T) {
 	// 2x2 matrix stored as 2 Vec2 columns.
-	mat := Array{Vec2{1, 3}, Vec2{2, 4}}
-	got := transposeMatrix(mat)
-	cols, ok := got.(Array)
+	mat := Array{ValVec2(1, 3), ValVec2(2, 4)}
+	got := transposeMatrix(ValArray(mat))
+	cols, ok := testIsArray(got)
 	if !ok || len(cols) != 2 {
 		t.Fatalf("transpose returned unexpected type or length")
 	}
 	// After transpose: col0 = {1,2}, col1 = {3,4}
-	c0, _ := cols[0].(Vec2)
-	c1, _ := cols[1].(Vec2)
+	c0 := cols[0].AsVec2()
+	c1 := cols[1].AsVec2()
 	if c0 != (Vec2{1, 2}) || c1 != (Vec2{3, 4}) {
 		t.Errorf("transpose = [%v, %v], want [{1,2}, {3,4}]", c0, c1)
 	}
@@ -665,8 +664,8 @@ func TestVectorShuffle(t *testing.T) {
 	// Shuffle from two Vec4: select components (3, 4) -> (w from first, x from second)
 	v1 := Vec4{10, 20, 30, 40}
 	v2 := Vec4{50, 60, 70, 80}
-	got := vectorShuffle(m, 3, v1, v2, []uint32{3, 4})
-	gv, ok := got.(Vec2)
+	got := vectorShuffle(m, 3, ValVec4From(v1), ValVec4From(v2), []uint32{3, 4})
+	gv, ok := testIsVec2(got)
 	if !ok {
 		t.Fatalf("vectorShuffle returned %T, want Vec2", got)
 	}
@@ -685,22 +684,22 @@ func TestIntDivisionOps(t *testing.T) {
 	}{
 		{"udiv", func(a, b uint32) Value {
 			if b == 0 {
-				return Uint32(0)
+				return ValUint(0)
 			}
-			return a / b
-		}, 10, 3, Uint32(3)},
+			return ValUint(a / b)
+		}, 10, 3, ValUint(3)},
 		{"udiv_zero", func(a, b uint32) Value {
 			if b == 0 {
-				return Uint32(0)
+				return ValUint(0)
 			}
-			return a / b
-		}, 10, 0, Uint32(0)},
+			return ValUint(a / b)
+		}, 10, 0, ValUint(0)},
 		{"umod", func(a, b uint32) Value {
 			if b == 0 {
-				return Uint32(0)
+				return ValUint(0)
 			}
-			return a % b
-		}, 10, 3, Uint32(1)},
+			return ValUint(a % b)
+		}, 10, 3, ValUint(1)},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -729,8 +728,9 @@ func TestBitwiseOps(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := intBinOp(tt.a, tt.b, tt.op)
-			u, ok := got.(Uint32)
+			got := intBinOp(ValUint(tt.a), ValUint(tt.b), tt.op)
+			u := got.AsUint32()
+			ok := got.Tag == TagUint32
 			if !ok || u != tt.want {
 				t.Errorf("%s(0x%X, 0x%X) = %v, want 0x%X", tt.name, tt.a, tt.b, got, tt.want)
 			}
@@ -868,27 +868,7 @@ func TestSPIRVStorageBufferWrite(t *testing.T) {
 	}
 }
 
-// valueApproxEqual compares two Values for approximate equality.
-func valueApproxEqual(a, b Value, eps float64) bool {
-	switch av := a.(type) {
-	case Float32:
-		bv, ok := b.(Float32)
-		return ok && math.Abs(float64(av-bv)) <= eps
-	case Vec2:
-		bv, ok := b.(Vec2)
-		return ok && math.Abs(float64(av[0]-bv[0])) <= eps && math.Abs(float64(av[1]-bv[1])) <= eps
-	case Vec3:
-		bv, ok := b.(Vec3)
-		return ok && math.Abs(float64(av[0]-bv[0])) <= eps && math.Abs(float64(av[1]-bv[1])) <= eps &&
-			math.Abs(float64(av[2]-bv[2])) <= eps
-	case Vec4:
-		bv, ok := b.(Vec4)
-		return ok && math.Abs(float64(av[0]-bv[0])) <= eps && math.Abs(float64(av[1]-bv[1])) <= eps &&
-			math.Abs(float64(av[2]-bv[2])) <= eps && math.Abs(float64(av[3]-bv[3])) <= eps
-	default:
-		return a == b
-	}
-}
+// valueApproxEqual is defined in testhelpers_test.go
 
 func BenchmarkSPIRVVertexShaderExecution(b *testing.B) {
 	words := buildTriangleVertexSPIRV()
@@ -908,7 +888,7 @@ func BenchmarkSPIRVVertexShaderExecution(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		inputs := map[uint32]Value{
-			idxVarID: uint32(i % 3),
+			idxVarID: ValUint(uint32(i % 3)),
 		}
 		_, _ = m.Execute("vs_main", inputs)
 	}
@@ -927,25 +907,4 @@ func BenchmarkSPIRVFragmentShaderExecution(b *testing.B) {
 	}
 }
 
-// testMakeValues creates a []Value slice from a map of ID->Value entries.
-// The slice is sized to hold the maximum ID + 1. This is a test helper
-// that converts the old map-based test patterns to the new slice-based
-// interpreter values representation.
-func testMakeValues(entries map[uint32]Value) []Value {
-	var maxID uint32
-	for id := range entries {
-		if id > maxID {
-			maxID = id
-		}
-	}
-	// Add headroom for result IDs that tests may write into (e.g., ResultID=100).
-	size := maxID + 1
-	if size < 128 {
-		size = 128
-	}
-	values := make([]Value, size)
-	for id, val := range entries {
-		values[id] = val
-	}
-	return values
-}
+// testMakeValues is defined in testhelpers_test.go

--- a/hal/software/shader/module.go
+++ b/hal/software/shader/module.go
@@ -270,12 +270,7 @@ func ParseModule(words []uint32) (*Module, error) {
 			// operands[2] is the ID of the constant holding the length.
 			length := uint32(0)
 			if cval, ok := m.Constants[operands[2]]; ok {
-				switch cv := cval.(type) {
-				case Uint32:
-					length = cv
-				case Int32:
-					length = uint32(cv)
-				}
+				length = toUint32(cval)
 			}
 			m.Types[operands[0]] = &TypeInfo{
 				Kind:     TypeArray,
@@ -366,22 +361,22 @@ func ParseModule(words []uint32) (*Module, error) {
 			}
 			resultID := operands[1]
 			constituents := operands[2:]
-			elems := make(Array, len(constituents))
+			elems := make([]Value, len(constituents))
 			for i, cid := range constituents {
 				if v, ok := m.Constants[cid]; ok {
 					elems[i] = v
 				}
 			}
-			m.Constants[resultID] = elems
+			m.Constants[resultID] = ValArray(elems)
 
 		case OpConstantTrue:
 			if len(operands) >= 2 {
-				m.Constants[operands[1]] = true
+				m.Constants[operands[1]] = ValBool(true)
 			}
 
 		case OpConstantFalse:
 			if len(operands) >= 2 {
-				m.Constants[operands[1]] = false
+				m.Constants[operands[1]] = ValBool(false)
 			}
 
 		case OpConstantNull:
@@ -738,52 +733,17 @@ func decodeString(words []uint32) (string, uint32) {
 func resolveConstant(types map[uint32]*TypeInfo, typeID uint32, literals []uint32) Value {
 	ti, ok := types[typeID]
 	if !ok || len(literals) == 0 {
-		return Uint32(0)
+		return ValUint(0)
 	}
 	switch ti.Kind {
 	case TypeFloat:
-		return math.Float32frombits(literals[0])
+		return ValFloat(math.Float32frombits(literals[0]))
 	case TypeInt:
 		if ti.Signed {
-			return int32(literals[0])
+			return ValInt(int32(literals[0]))
 		}
-		return literals[0]
+		return ValUint(literals[0])
 	default:
-		return literals[0]
+		return ValUint(literals[0])
 	}
-}
-
-// zeroValue returns the zero/default value for a given type.
-func zeroValue(types map[uint32]*TypeInfo, typeID uint32) Value {
-	ti, ok := types[typeID]
-	if !ok {
-		return Uint32(0)
-	}
-	switch ti.Kind {
-	case TypeFloat:
-		return Float32(0)
-	case TypeInt:
-		if ti.Signed {
-			return Int32(0)
-		}
-		return Uint32(0)
-	case TypeVector:
-		switch ti.Components {
-		case 2:
-			return Vec2{}
-		case 3:
-			return Vec3{}
-		case 4:
-			return Vec4{}
-		}
-	case TypeArray:
-		if ti.Length > 0 {
-			arr := make(Array, ti.Length)
-			for i := range arr {
-				arr[i] = zeroValue(types, ti.ElemType)
-			}
-			return arr
-		}
-	}
-	return Uint32(0)
 }

--- a/hal/software/shader/testhelpers_test.go
+++ b/hal/software/shader/testhelpers_test.go
@@ -1,0 +1,136 @@
+//go:build !(js && wasm)
+
+package shader
+
+import "unsafe"
+
+// testval converts old-style Go values to tagged union Value for test compatibility.
+// This avoids rewriting every test that creates Values from raw Go types.
+// For test-only types like *Texture2D, we store the pointer in Ref with TagPointer
+// so resolveTexture/resolveSampler can find it.
+func testval(v any) Value {
+	switch x := v.(type) {
+	case float32:
+		return ValFloat(x)
+	case uint32:
+		return ValUint(x)
+	case int32:
+		return ValInt(x)
+	case int:
+		return ValUint(uint32(x))
+	case bool:
+		return ValBool(x)
+	case [2]float32:
+		return ValVec2(x[0], x[1])
+	case [3]float32:
+		return ValVec3(x[0], x[1], x[2])
+	case [4]float32:
+		return ValVec4(x[0], x[1], x[2], x[3])
+	case []Value:
+		return ValArray(x)
+	case *Pointer:
+		return ValPointer(x)
+	case *SubPointer:
+		return ValSubPointer(x)
+	case *BufferPointer:
+		return ValBufferPointer(x)
+	case *SampledImageValue:
+		return ValSampledImage(x)
+	case BindingKey:
+		return ValBindingKey(x)
+	case *Texture2D:
+		// Store texture pointer using Ref with a special tag for test use.
+		return Value{Tag: TagPointer, Ref: unsafe.Pointer(x)}
+	case *Sampler:
+		return Value{Tag: TagPointer, Ref: unsafe.Pointer(x)}
+	case Value:
+		return x
+	default:
+		return Value{}
+	}
+}
+
+// testMakeValues creates a []Value slice from a map of ID->any entries.
+// Values are automatically converted from raw Go types (float32, uint32, etc.)
+// to tagged union Values.
+func testMakeValues(entries map[uint32]any) []Value {
+	var maxID uint32
+	for id := range entries {
+		if id > maxID {
+			maxID = id
+		}
+	}
+	// Add headroom for result IDs that tests may write into (e.g., ResultID=100).
+	size := maxID + 1
+	if size < 128 {
+		size = 128
+	}
+	values := make([]Value, size)
+	for id, val := range entries {
+		values[id] = testval(val)
+	}
+	return values
+}
+
+// testIsFloat32 checks if a Value is a float32 scalar and returns it.
+func testIsFloat32(v Value) (float32, bool) {
+	return v.F[0], v.Tag == TagFloat32
+}
+
+// testIsUint32 checks if a Value is a uint32 scalar and returns it.
+func testIsUint32(v Value) (uint32, bool) {
+	return v.U[0], v.Tag == TagUint32
+}
+
+// testIsVec2 checks if a Value is a Vec2 and returns it.
+func testIsVec2(v Value) (Vec2, bool) {
+	return v.AsVec2(), v.Tag == TagVec2
+}
+
+// testIsVec3 checks if a Value is a Vec3 and returns it.
+func testIsVec3(v Value) (Vec3, bool) {
+	return v.AsVec3(), v.Tag == TagVec3
+}
+
+// testIsVec4 checks if a Value is a Vec4 and returns it.
+func testIsVec4(v Value) (Vec4, bool) {
+	return v.AsVec4(), v.Tag == TagVec4
+}
+
+// testIsBool checks if a Value is a bool and returns it.
+func testIsBool(v Value) (bool, bool) {
+	return v.AsBool(), v.Tag == TagBool
+}
+
+// testIsArray checks if a Value is an Array and returns it.
+func testIsArray(v Value) ([]Value, bool) {
+	return v.AsArray(), v.Tag == TagArray
+}
+
+// valueApproxEqual compares two Values for approximate equality.
+func valueApproxEqual(a, b Value, eps float64) bool {
+	if a.Tag != b.Tag {
+		return false
+	}
+	switch a.Tag {
+	case TagFloat32:
+		return abs64(float64(a.F[0]-b.F[0])) <= eps
+	case TagVec2:
+		return abs64(float64(a.F[0]-b.F[0])) <= eps && abs64(float64(a.F[1]-b.F[1])) <= eps
+	case TagVec3:
+		return abs64(float64(a.F[0]-b.F[0])) <= eps && abs64(float64(a.F[1]-b.F[1])) <= eps &&
+			abs64(float64(a.F[2]-b.F[2])) <= eps
+	case TagVec4:
+		return abs64(float64(a.F[0]-b.F[0])) <= eps && abs64(float64(a.F[1]-b.F[1])) <= eps &&
+			abs64(float64(a.F[2]-b.F[2])) <= eps && abs64(float64(a.F[3]-b.F[3])) <= eps
+	default:
+		return valuesEqual(a, b)
+	}
+}
+
+func abs64(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/hal/software/shader/texture_test.go
+++ b/hal/software/shader/texture_test.go
@@ -316,7 +316,7 @@ func TestSPIRVTextureSample(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := &ExecutionContext{
-				Inputs: map[uint32]Value{uvVarID: tt.uv},
+				Inputs: map[uint32]Value{uvVarID: testval(tt.uv)},
 				Textures: map[BindingKey]*Texture2D{
 					{Group: 0, Binding: 0}: tex,
 				},
@@ -382,7 +382,7 @@ func TestSPIRVTextureSampleBilinear(t *testing.T) {
 
 	// Bilinear at center of 2x2: average of all four texels.
 	ctx := &ExecutionContext{
-		Inputs: map[uint32]Value{uvVarID: Vec2{0.5, 0.5}},
+		Inputs: map[uint32]Value{uvVarID: ValVec2(0.5, 0.5)},
 		Textures: map[BindingKey]*Texture2D{
 			{Group: 0, Binding: 0}: tex,
 		},
@@ -433,7 +433,7 @@ func TestSPIRVTextureMissing(t *testing.T) {
 
 	// No texture bound -- should return magenta.
 	ctx := &ExecutionContext{
-		Inputs: map[uint32]Value{uvVarID: Vec2{0.5, 0.5}},
+		Inputs: map[uint32]Value{uvVarID: ValVec2(0.5, 0.5)},
 	}
 	outputs, err := m.ExecuteWithContext("fs_main", ctx)
 	if err != nil {
@@ -460,24 +460,25 @@ func TestFetchTexel(t *testing.T) {
 			255, 255, 255, 255, // (1,1) white
 		},
 	}
-
-	interp := &interpreter{ctx: &ExecutionContext{}}
+	bk := BindingKey{Group: 0, Binding: 0}
+	interp := &interpreter{ctx: &ExecutionContext{Textures: map[BindingKey]*Texture2D{bk: tex}}}
 
 	tests := []struct {
 		name  string
 		coord Value
 		want  Vec4
 	}{
-		{"pixel_00", Vec2{0, 0}, Vec4{1, 0, 0, 1}},
-		{"pixel_10", Vec2{1, 0}, Vec4{0, 1, 0, 1}},
-		{"pixel_01", Vec2{0, 1}, Vec4{0, 0, 1, 1}},
-		{"pixel_11", Vec2{1, 1}, Vec4{1, 1, 1, 1}},
-		{"clamped", Vec2{5, 5}, Vec4{1, 1, 1, 1}}, // Clamped to (1,1)
+		{"pixel_00", ValVec2(0, 0), Vec4{1, 0, 0, 1}},
+		{"pixel_10", ValVec2(1, 0), Vec4{0, 1, 0, 1}},
+		{"pixel_01", ValVec2(0, 1), Vec4{0, 0, 1, 1}},
+		{"pixel_11", ValVec2(1, 1), Vec4{1, 1, 1, 1}},
+		{"clamped", ValVec2(5, 5), Vec4{1, 1, 1, 1}}, // Clamped to (1,1)
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := interp.fetchTexel(tex, tt.coord)
+			got := interp.fetchTexel(ValBindingKey(bk), tt.coord)
+			_ = bk // used in test setup
 			gv := Vec4ToFloat32(got)
 			for i := 0; i < 4; i++ {
 				if math.Abs(float64(gv[i]-tt.want[i])) > 0.01 {
@@ -491,26 +492,25 @@ func TestFetchTexel(t *testing.T) {
 func TestSampledImageValue(t *testing.T) {
 	// Verify SampledImageValue correctly combines image and sampler references.
 	si := &SampledImageValue{
-		Image:   BindingKey{Group: 0, Binding: 0},
-		Sampler: BindingKey{Group: 0, Binding: 1},
+		Image:   ValBindingKey(BindingKey{Group: 0, Binding: 0}),
+		Sampler: ValBindingKey(BindingKey{Group: 0, Binding: 1}),
 	}
 
-	imgBK, ok := si.Image.(BindingKey)
-	if !ok || imgBK.Binding != 0 {
+	if si.Image.Tag != TagBindingKey || si.Image.AsBindingKey().Binding != 0 {
 		t.Errorf("SampledImageValue.Image = %v, want BindingKey{0,0}", si.Image)
 	}
-	sampBK, ok := si.Sampler.(BindingKey)
-	if !ok || sampBK.Binding != 1 {
+	if si.Sampler.Tag != TagBindingKey || si.Sampler.AsBindingKey().Binding != 1 {
 		t.Errorf("SampledImageValue.Sampler = %v, want BindingKey{0,1}", si.Sampler)
 	}
 }
 
 func TestQueryImageSize(t *testing.T) {
-	interp := &interpreter{ctx: &ExecutionContext{}}
-
 	tex := &Texture2D{Width: 512, Height: 256}
-	got := interp.queryImageSize(tex)
-	gv, ok := got.(Vec2)
+	bk := BindingKey{Group: 0, Binding: 0}
+	interp := &interpreter{ctx: &ExecutionContext{Textures: map[BindingKey]*Texture2D{bk: tex}}}
+
+	got := interp.queryImageSize(ValBindingKey(bk))
+	gv, ok := testIsVec2(got)
 	if !ok {
 		t.Fatalf("queryImageSize returned %T, want Vec2", got)
 	}
@@ -519,9 +519,9 @@ func TestQueryImageSize(t *testing.T) {
 	}
 
 	// Nil texture returns zero.
-	got = interp.queryImageSize(nil)
-	gv, ok = got.(Vec2)
-	if !ok || gv != (Vec2{0, 0}) {
+	got = interp.queryImageSize(Value{})
+	gv = got.AsVec2()
+	if got.Tag != TagVec2 || gv != (Vec2{0, 0}) {
 		t.Errorf("queryImageSize(nil) = %v, want {0, 0}", got)
 	}
 }

--- a/hal/software/shader/uniform_test.go
+++ b/hal/software/shader/uniform_test.go
@@ -466,11 +466,11 @@ func TestWriteValueToBuffer(t *testing.T) {
 		val  Value
 		size uint32
 	}{
-		{"float32", Float32(3.14), 4},
-		{"uint32", Uint32(42), 4},
-		{"int32", Int32(-7), 4},
-		{"vec2", Vec2{1.0, 2.0}, 8},
-		{"vec4", Vec4{1, 2, 3, 4}, 16},
+		{"float32", ValFloat(3.14), 4},
+		{"uint32", ValUint(42), 4},
+		{"int32", ValInt(-7), 4},
+		{"vec2", ValVec2From(Vec2{1.0, 2.0}), 8},
+		{"vec4", ValVec4From(Vec4{1, 2, 3, 4}), 16},
 	}
 
 	for _, tt := range tests {
@@ -479,18 +479,19 @@ func TestWriteValueToBuffer(t *testing.T) {
 			writeValueToBuffer(buf, 0, tt.val)
 
 			// Verify round-trip through readFloat/readUint.
-			switch v := tt.val.(type) {
-			case Float32:
+			switch tt.val.Tag {
+			case TagFloat32:
 				got := readFloat32LE(buf[0:])
-				if math.Abs(float64(got-float32(v))) > 1e-6 {
-					t.Errorf("round-trip float = %f, want %f", got, v)
+				if math.Abs(float64(got-tt.val.AsFloat32())) > 1e-6 {
+					t.Errorf("round-trip float = %f, want %f", got, tt.val.AsFloat32())
 				}
-			case Uint32:
+			case TagUint32:
 				got := readUint32LE(buf[0:])
-				if got != v {
-					t.Errorf("round-trip uint = %d, want %d", got, v)
+				if got != tt.val.AsUint32() {
+					t.Errorf("round-trip uint = %d, want %d", got, tt.val.AsUint32())
 				}
-			case Vec4:
+			case TagVec4:
+				v := tt.val.AsVec4()
 				for i := 0; i < 4; i++ {
 					got := readFloat32LE(buf[i*4:])
 					if math.Abs(float64(got-v[i])) > 1e-6 {
@@ -508,13 +509,13 @@ func TestValueByteSize(t *testing.T) {
 		val  Value
 		want uint32
 	}{
-		{"float32", Float32(0), 4},
-		{"uint32", Uint32(0), 4},
-		{"int32", Int32(0), 4},
-		{"vec2", Vec2{}, 8},
-		{"vec3", Vec3{}, 12},
-		{"vec4", Vec4{}, 16},
-		{"array_of_float", Array{Float32(0), Float32(0)}, 8},
+		{"float32", ValFloat(0), 4},
+		{"uint32", ValUint(0), 4},
+		{"int32", ValInt(0), 4},
+		{"vec2", ValVec2(0, 0), 8},
+		{"vec3", ValVec3(0, 0, 0), 12},
+		{"vec4", ValVec4(0, 0, 0, 0), 16},
+		{"array_of_float", ValArray(Array{ValFloat(0), ValFloat(0)}), 8},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/hal/software/shader/value.go
+++ b/hal/software/shader/value.go
@@ -2,41 +2,68 @@
 
 // SPIR-V runtime value types for the software backend interpreter.
 //
-// These types represent values during SPIR-V execution. The interpreter uses
-// Go interface{} (aliased as Value) for dynamic typing, matching SPIR-V's
-// untyped SSA register model.
+// Values are stored as a tagged union struct instead of Go interfaces.
+// This eliminates heap allocations for scalars and vectors (the hot path
+// in per-pixel shading), keeping all data inline in a fixed-size struct
+// that fits in a single cache line.
 
 package shader
 
-// Value is a runtime value in the SPIR-V interpreter.
-// Concrete types: Float32, Uint32, Int32, Vec2, Vec3, Vec4, Array, Pointer.
-type Value = any
+import (
+	"math"
+	"unsafe"
+)
 
-// Float32 is a 32-bit floating point scalar.
-type Float32 = float32
+// ValueTag identifies the concrete type stored in a Value.
+type ValueTag byte
 
-// Uint32 is a 32-bit unsigned integer scalar.
-type Uint32 = uint32
+const (
+	TagNone          ValueTag = iota
+	TagFloat32                // scalar float32 in F[0]
+	TagUint32                 // scalar uint32 in U[0]
+	TagInt32                  // scalar int32 (stored as uint32 in U[0])
+	TagBool                   // boolean (U[0]: 0=false, 1=true)
+	TagVec2                   // [2]float32 in F[0..1]
+	TagVec3                   // [3]float32 in F[0..2]
+	TagVec4                   // [4]float32 in F[0..3]
+	TagArray                  // []Value stored via Ref
+	TagPointer                // *Pointer stored via Ref
+	TagSubPointer             // *SubPointer stored via Ref
+	TagBufferPointer          // *BufferPointer stored via Ref
+	TagSampledImage           // *SampledImageValue stored via Ref
+	TagBindingKey             // BindingKey stored in U[0..1]
+)
 
-// Int32 is a 32-bit signed integer scalar.
-type Int32 = int32
+// Value is a tagged union representing a runtime value in the SPIR-V interpreter.
+// Scalars and vectors (up to vec4) are stored inline with zero heap allocation.
+// Composite types (arrays, pointers) use the Ref field.
+//
+// Size: 40 bytes (1 tag + 3 pad + 16 F + 16 U + 8 Ref = 44, but compiler may align to 48).
+// This is intentionally larger than an interface (16 bytes) because it eliminates
+// the heap allocation that every interface boxing requires.
+type Value struct {
+	Tag ValueTag
+	F   [4]float32     // float scalars + vectors
+	U   [4]uint32      // uint/int scalars, bool, binding key
+	Ref unsafe.Pointer // Array, Pointer, SubPointer, BufferPointer, SampledImageValue
+}
 
-// Vec2 is a 2-component float32 vector.
-type Vec2 = [2]float32
-
-// Vec3 is a 3-component float32 vector.
-type Vec3 = [3]float32
-
-// Vec4 is a 4-component float32 vector.
-type Vec4 = [4]float32
-
-// Array is a dynamically-sized collection of values.
-type Array = []Value
+// Type aliases kept for backward compatibility with external code and tests.
+// These are the underlying Go types used for construction only.
+type (
+	Float32 = float32
+	Uint32  = uint32
+	Int32   = int32
+	Vec2    = [2]float32
+	Vec3    = [3]float32
+	Vec4    = [4]float32
+	Array   = []Value
+)
 
 // Pointer wraps a mutable reference to a Value stored in a variable.
 // SPIR-V OpVariable creates a Pointer; OpLoad dereferences it; OpStore writes to it.
 type Pointer struct {
-	Value Value
+	Val Value
 }
 
 // Mat4 is a 4x4 column-major matrix stored as an Array of 4 Vec4 columns.
@@ -101,8 +128,8 @@ type SubPointer struct {
 // SampledImageValue combines a texture reference and a sampler reference.
 // Created by OpSampledImage, consumed by OpImageSample* opcodes.
 type SampledImageValue struct {
-	Image   Value // BindingKey or *Texture2D
-	Sampler Value // BindingKey or *Sampler
+	Image   Value // BindingKey or *Texture2D (stored as Value)
+	Sampler Value // BindingKey or *Sampler (stored as Value)
 }
 
 // ExecutionContext provides bound resources for shader execution.
@@ -131,4 +158,595 @@ type ExecutionContext struct {
 	NumWorkgroups        [3]uint32
 	WorkgroupSize        [3]uint32
 	LocalInvocationIndex uint32
+}
+
+// =============================================================================
+// Value Constructors -- zero allocation for scalars and vectors
+// =============================================================================
+
+// ValNone returns the zero/nil Value.
+func ValNone() Value { return Value{} }
+
+// ValFloat returns a float32 scalar Value.
+func ValFloat(f float32) Value { return Value{Tag: TagFloat32, F: [4]float32{f}} }
+
+// ValUint returns a uint32 scalar Value.
+func ValUint(u uint32) Value { return Value{Tag: TagUint32, U: [4]uint32{u}} }
+
+// ValInt returns an int32 scalar Value.
+func ValInt(i int32) Value { return Value{Tag: TagInt32, U: [4]uint32{uint32(i)}} }
+
+// ValBool returns a boolean Value.
+func ValBool(b bool) Value {
+	v := Value{Tag: TagBool}
+	if b {
+		v.U[0] = 1
+	}
+	return v
+}
+
+// ValVec2 returns a 2-component float vector Value.
+func ValVec2(x, y float32) Value { return Value{Tag: TagVec2, F: [4]float32{x, y}} }
+
+// ValVec3 returns a 3-component float vector Value.
+func ValVec3(x, y, z float32) Value { return Value{Tag: TagVec3, F: [4]float32{x, y, z}} }
+
+// ValVec4 returns a 4-component float vector Value.
+func ValVec4(x, y, z, w float32) Value { return Value{Tag: TagVec4, F: [4]float32{x, y, z, w}} }
+
+// ValVec2From returns a Value from a Vec2 array.
+func ValVec2From(v Vec2) Value { return Value{Tag: TagVec2, F: [4]float32{v[0], v[1]}} }
+
+// ValVec3From returns a Value from a Vec3 array.
+func ValVec3From(v Vec3) Value { return Value{Tag: TagVec3, F: [4]float32{v[0], v[1], v[2]}} }
+
+// ValVec4From returns a Value from a Vec4 array.
+func ValVec4From(v Vec4) Value { return Value{Tag: TagVec4, F: [4]float32{v[0], v[1], v[2], v[3]}} }
+
+// ValArray returns an Array Value. The slice is stored on the heap via Ref.
+func ValArray(a []Value) Value {
+	return Value{Tag: TagArray, Ref: unsafe.Pointer(&a)}
+}
+
+// ValPointer returns a Pointer Value.
+func ValPointer(p *Pointer) Value {
+	return Value{Tag: TagPointer, Ref: unsafe.Pointer(p)}
+}
+
+// ValSubPointer returns a SubPointer Value.
+func ValSubPointer(sp *SubPointer) Value {
+	return Value{Tag: TagSubPointer, Ref: unsafe.Pointer(sp)}
+}
+
+// ValBufferPointer returns a BufferPointer Value.
+func ValBufferPointer(bp *BufferPointer) Value {
+	return Value{Tag: TagBufferPointer, Ref: unsafe.Pointer(bp)}
+}
+
+// ValSampledImage returns a SampledImageValue.
+func ValSampledImage(si *SampledImageValue) Value {
+	return Value{Tag: TagSampledImage, Ref: unsafe.Pointer(si)}
+}
+
+// ValBindingKey returns a BindingKey Value stored inline in U[0..1].
+func ValBindingKey(bk BindingKey) Value {
+	return Value{Tag: TagBindingKey, U: [4]uint32{bk.Group, bk.Binding}}
+}
+
+// =============================================================================
+// Value Accessors
+// =============================================================================
+
+// IsNone returns true if the value is uninitialized/nil.
+func (v Value) IsNone() bool { return v.Tag == TagNone }
+
+// AsFloat32 extracts a float32. Returns 0 for non-float tags.
+func (v Value) AsFloat32() float32 { return v.F[0] }
+
+// AsUint32 extracts a uint32. Returns 0 for non-uint tags.
+func (v Value) AsUint32() uint32 { return v.U[0] }
+
+// AsInt32 extracts an int32. Returns 0 for non-int tags.
+func (v Value) AsInt32() int32 { return int32(v.U[0]) }
+
+// AsBool extracts a bool. Returns false for non-bool tags.
+func (v Value) AsBool() bool { return v.U[0] != 0 }
+
+// AsVec2 extracts a [2]float32.
+func (v Value) AsVec2() Vec2 { return Vec2{v.F[0], v.F[1]} }
+
+// AsVec3 extracts a [3]float32.
+func (v Value) AsVec3() Vec3 { return Vec3{v.F[0], v.F[1], v.F[2]} }
+
+// AsVec4 extracts a [4]float32.
+func (v Value) AsVec4() Vec4 { return v.F }
+
+// AsArray extracts a []Value from the Ref field.
+func (v Value) AsArray() []Value {
+	if v.Ref == nil {
+		return nil
+	}
+	return *(*[]Value)(v.Ref)
+}
+
+// AsPointer extracts a *Pointer from the Ref field.
+func (v Value) AsPointer() *Pointer {
+	if v.Ref == nil {
+		return nil
+	}
+	return (*Pointer)(v.Ref)
+}
+
+// AsSubPointer extracts a *SubPointer from the Ref field.
+func (v Value) AsSubPointer() *SubPointer {
+	if v.Ref == nil {
+		return nil
+	}
+	return (*SubPointer)(v.Ref)
+}
+
+// AsBufferPointer extracts a *BufferPointer from the Ref field.
+func (v Value) AsBufferPointer() *BufferPointer {
+	if v.Ref == nil {
+		return nil
+	}
+	return (*BufferPointer)(v.Ref)
+}
+
+// AsSampledImage extracts a *SampledImageValue from the Ref field.
+func (v Value) AsSampledImage() *SampledImageValue {
+	if v.Ref == nil {
+		return nil
+	}
+	return (*SampledImageValue)(v.Ref)
+}
+
+// AsBindingKey extracts a BindingKey from U[0..1].
+func (v Value) AsBindingKey() BindingKey {
+	return BindingKey{Group: v.U[0], Binding: v.U[1]}
+}
+
+// =============================================================================
+// Conversion helpers -- used throughout the interpreter
+// =============================================================================
+
+// toFloat32 extracts a float32 from a Value, converting if needed.
+func toFloat32(v Value) float32 {
+	switch v.Tag {
+	case TagFloat32:
+		return v.F[0]
+	case TagUint32:
+		return float32(v.U[0])
+	case TagInt32:
+		return float32(int32(v.U[0]))
+	default:
+		return 0
+	}
+}
+
+// toUint32 extracts a uint32 from a Value, converting if needed.
+func toUint32(v Value) uint32 {
+	switch v.Tag {
+	case TagUint32:
+		return v.U[0]
+	case TagInt32:
+		return v.U[0] // same bits
+	case TagFloat32:
+		return uint32(v.F[0])
+	case TagBool:
+		return v.U[0]
+	default:
+		return 0
+	}
+}
+
+// toBool converts a Value to boolean.
+func toBool(v Value) bool {
+	switch v.Tag {
+	case TagBool:
+		return v.U[0] != 0
+	case TagUint32, TagInt32:
+		return v.U[0] != 0
+	case TagFloat32:
+		return v.F[0] != 0
+	default:
+		return false
+	}
+}
+
+// =============================================================================
+// Arithmetic / vector helpers
+// =============================================================================
+
+// floatBinOp applies a binary operation to two float-typed values.
+// Works on scalars and vectors component-wise.
+func floatBinOp(a, b Value, op func(float32, float32) float32) Value {
+	switch a.Tag {
+	case TagFloat32:
+		return ValFloat(op(a.F[0], toFloat32(b)))
+	case TagVec2:
+		return ValVec2(op(a.F[0], b.F[0]), op(a.F[1], b.F[1]))
+	case TagVec3:
+		return ValVec3(op(a.F[0], b.F[0]), op(a.F[1], b.F[1]), op(a.F[2], b.F[2]))
+	case TagVec4:
+		return ValVec4(op(a.F[0], b.F[0]), op(a.F[1], b.F[1]), op(a.F[2], b.F[2]), op(a.F[3], b.F[3]))
+	default:
+		return ValFloat(0)
+	}
+}
+
+// floatUnaryOp applies a unary operation to a float-typed value.
+func floatUnaryOp(a Value, op func(float32) float32) Value {
+	switch a.Tag {
+	case TagFloat32:
+		return ValFloat(op(a.F[0]))
+	case TagVec2:
+		return ValVec2(op(a.F[0]), op(a.F[1]))
+	case TagVec3:
+		return ValVec3(op(a.F[0]), op(a.F[1]), op(a.F[2]))
+	case TagVec4:
+		return ValVec4(op(a.F[0]), op(a.F[1]), op(a.F[2]), op(a.F[3]))
+	default:
+		return ValFloat(0)
+	}
+}
+
+// intBinOp applies a binary operation to two integer values.
+func intBinOp(a, b Value, op func(uint32, uint32) uint32) Value {
+	return ValUint(op(toUint32(a), toUint32(b)))
+}
+
+// vectorTimesScalar multiplies each component of a vector by a scalar.
+func vectorTimesScalar(vec Value, s float32) Value {
+	switch vec.Tag {
+	case TagVec2:
+		return ValVec2(vec.F[0]*s, vec.F[1]*s)
+	case TagVec3:
+		return ValVec3(vec.F[0]*s, vec.F[1]*s, vec.F[2]*s)
+	case TagVec4:
+		return ValVec4(vec.F[0]*s, vec.F[1]*s, vec.F[2]*s, vec.F[3]*s)
+	default:
+		return ValFloat(toFloat32(vec) * s)
+	}
+}
+
+// dotProduct computes the dot product of two vectors.
+func dotProduct(a, b Value) Value {
+	switch a.Tag {
+	case TagVec2:
+		return ValFloat(a.F[0]*b.F[0] + a.F[1]*b.F[1])
+	case TagVec3:
+		return ValFloat(a.F[0]*b.F[0] + a.F[1]*b.F[1] + a.F[2]*b.F[2])
+	case TagVec4:
+		return ValFloat(a.F[0]*b.F[0] + a.F[1]*b.F[1] + a.F[2]*b.F[2] + a.F[3]*b.F[3])
+	default:
+		return ValFloat(toFloat32(a) * toFloat32(b))
+	}
+}
+
+// Vec4ToFloat32 extracts a Vec4 from a Value, returning zeros if type doesn't match.
+func Vec4ToFloat32(val Value) [4]float32 {
+	switch val.Tag {
+	case TagVec4:
+		return val.F
+	case TagVec3:
+		return [4]float32{val.F[0], val.F[1], val.F[2], 0}
+	case TagVec2:
+		return [4]float32{val.F[0], val.F[1], 0, 0}
+	case TagFloat32:
+		return [4]float32{val.F[0], 0, 0, 0}
+	default:
+		return [4]float32{}
+	}
+}
+
+// Float32BitsToUint32 converts a float32 to its bit representation as uint32.
+// Used for SPIR-V constant encoding in tests.
+func Float32BitsToUint32(f float32) uint32 {
+	return math.Float32bits(f)
+}
+
+// convertToFloat converts an unsigned integer value to float32.
+func convertToFloat(val Value) Value {
+	switch val.Tag {
+	case TagUint32:
+		return ValFloat(float32(val.U[0]))
+	case TagInt32:
+		return ValFloat(float32(int32(val.U[0])))
+	case TagFloat32:
+		return val
+	default:
+		return ValFloat(0)
+	}
+}
+
+// convertSignedToFloat converts a signed integer value to float32.
+func convertSignedToFloat(val Value) Value {
+	switch val.Tag {
+	case TagInt32:
+		return ValFloat(float32(int32(val.U[0])))
+	case TagUint32:
+		return ValFloat(float32(int32(val.U[0])))
+	case TagFloat32:
+		return val
+	default:
+		return ValFloat(0)
+	}
+}
+
+// convertFloatToUint converts a float value to uint32.
+func convertFloatToUint(val Value) Value {
+	switch val.Tag {
+	case TagFloat32:
+		return ValUint(uint32(val.F[0]))
+	case TagUint32:
+		return val
+	case TagInt32:
+		return ValUint(val.U[0])
+	default:
+		return ValUint(0)
+	}
+}
+
+// =============================================================================
+// Composite operations
+// =============================================================================
+
+// indexComposite extracts element at the given index from a composite value.
+func indexComposite(composite Value, index uint32) Value {
+	switch composite.Tag {
+	case TagArray:
+		arr := composite.AsArray()
+		if int(index) < len(arr) {
+			return arr[index]
+		}
+	case TagVec2:
+		if index < 2 {
+			return ValFloat(composite.F[index])
+		}
+	case TagVec3:
+		if index < 3 {
+			return ValFloat(composite.F[index])
+		}
+	case TagVec4:
+		if index < 4 {
+			return ValFloat(composite.F[index])
+		}
+	}
+	return ValFloat(0)
+}
+
+// setCompositeElement returns a copy of composite with the element at the
+// given index path replaced by val. Handles Array, Vec2, Vec3, Vec4 composites.
+func setCompositeElement(composite Value, indexes []uint32, val Value) Value {
+	if len(indexes) == 0 {
+		return val
+	}
+	idx := indexes[0]
+	rest := indexes[1:]
+
+	switch composite.Tag {
+	case TagArray:
+		arr := composite.AsArray()
+		if int(idx) >= len(arr) {
+			return composite
+		}
+		newArr := make([]Value, len(arr))
+		copy(newArr, arr)
+		if len(rest) == 0 {
+			newArr[idx] = val
+		} else {
+			newArr[idx] = setCompositeElement(arr[idx], rest, val)
+		}
+		return ValArray(newArr)
+
+	case TagVec2:
+		if idx >= 2 {
+			return composite
+		}
+		v := composite
+		if len(rest) == 0 {
+			v.F[idx] = toFloat32(val)
+		}
+		return v
+
+	case TagVec3:
+		if idx >= 3 {
+			return composite
+		}
+		v := composite
+		if len(rest) == 0 {
+			v.F[idx] = toFloat32(val)
+		}
+		return v
+
+	case TagVec4:
+		if idx >= 4 {
+			return composite
+		}
+		v := composite
+		if len(rest) == 0 {
+			v.F[idx] = toFloat32(val)
+		}
+		return v
+
+	default:
+		return composite
+	}
+}
+
+// appendComponents flattens a value into float32 components.
+func appendComponents(dst []float32, val Value) []float32 {
+	switch val.Tag {
+	case TagFloat32:
+		return append(dst, val.F[0])
+	case TagVec2:
+		return append(dst, val.F[0], val.F[1])
+	case TagVec3:
+		return append(dst, val.F[0], val.F[1], val.F[2])
+	case TagVec4:
+		return append(dst, val.F[0], val.F[1], val.F[2], val.F[3])
+	case TagUint32:
+		return append(dst, float32(val.U[0]))
+	case TagInt32:
+		return append(dst, float32(int32(val.U[0])))
+	default:
+		return append(dst, 0)
+	}
+}
+
+// writeValueToBuffer serializes a SPIR-V typed value into raw buffer bytes.
+// Used for storage buffer writes via OpStore.
+func writeValueToBuffer(data []byte, offset uint32, val Value) {
+	switch val.Tag {
+	case TagFloat32:
+		if offset+4 > uint32(len(data)) {
+			return
+		}
+		bits := math.Float32bits(val.F[0])
+		data[offset] = byte(bits)
+		data[offset+1] = byte(bits >> 8)
+		data[offset+2] = byte(bits >> 16)
+		data[offset+3] = byte(bits >> 24)
+	case TagUint32:
+		if offset+4 > uint32(len(data)) {
+			return
+		}
+		v := val.U[0]
+		data[offset] = byte(v)
+		data[offset+1] = byte(v >> 8)
+		data[offset+2] = byte(v >> 16)
+		data[offset+3] = byte(v >> 24)
+	case TagInt32:
+		if offset+4 > uint32(len(data)) {
+			return
+		}
+		v := val.U[0]
+		data[offset] = byte(v)
+		data[offset+1] = byte(v >> 8)
+		data[offset+2] = byte(v >> 16)
+		data[offset+3] = byte(v >> 24)
+	case TagVec2:
+		writeValueToBuffer(data, offset, ValFloat(val.F[0]))
+		writeValueToBuffer(data, offset+4, ValFloat(val.F[1]))
+	case TagVec3:
+		writeValueToBuffer(data, offset, ValFloat(val.F[0]))
+		writeValueToBuffer(data, offset+4, ValFloat(val.F[1]))
+		writeValueToBuffer(data, offset+8, ValFloat(val.F[2]))
+	case TagVec4:
+		writeValueToBuffer(data, offset, ValFloat(val.F[0]))
+		writeValueToBuffer(data, offset+4, ValFloat(val.F[1]))
+		writeValueToBuffer(data, offset+8, ValFloat(val.F[2]))
+		writeValueToBuffer(data, offset+12, ValFloat(val.F[3]))
+	case TagArray:
+		arr := val.AsArray()
+		off := offset
+		for _, elem := range arr {
+			writeValueToBuffer(data, off, elem)
+			off += valueByteSize(elem)
+		}
+	}
+}
+
+// valueByteSize returns the byte size of a runtime Value.
+func valueByteSize(val Value) uint32 {
+	switch val.Tag {
+	case TagFloat32, TagUint32, TagInt32, TagBool:
+		return 4
+	case TagVec2:
+		return 8
+	case TagVec3:
+		return 12
+	case TagVec4:
+		return 16
+	case TagArray:
+		arr := val.AsArray()
+		var total uint32
+		for _, elem := range arr {
+			total += valueByteSize(elem)
+		}
+		return total
+	default:
+		return 4
+	}
+}
+
+// zeroValueForVar creates a zero value matching the pointee type of a pointer type.
+func zeroValueForVar(m *Module, ptrTypeID uint32) Value {
+	ti := m.PointeeType(ptrTypeID)
+	if ti == nil {
+		return ValUint(0)
+	}
+	switch ti.Kind {
+	case TypeFloat:
+		return ValFloat(0)
+	case TypeInt:
+		if ti.Signed {
+			return ValInt(0)
+		}
+		return ValUint(0)
+	case TypeVector:
+		switch ti.Components {
+		case 2:
+			return ValVec2(0, 0)
+		case 3:
+			return ValVec3(0, 0, 0)
+		case 4:
+			return ValVec4(0, 0, 0, 0)
+		}
+	case TypeArray:
+		if ti.Length > 0 {
+			arr := make([]Value, ti.Length)
+			for i := range arr {
+				arr[i] = zeroValue(m.Types, ti.ElemType)
+			}
+			return ValArray(arr)
+		}
+	case TypeStruct:
+		members := make([]Value, len(ti.MemberIDs))
+		for i, memberTypeID := range ti.MemberIDs {
+			members[i] = zeroValue(m.Types, memberTypeID)
+		}
+		return ValArray(members)
+	case TypeBool:
+		return ValBool(false)
+	}
+	return ValUint(0)
+}
+
+// zeroValue returns the zero/default value for a given type.
+func zeroValue(types map[uint32]*TypeInfo, typeID uint32) Value {
+	ti, ok := types[typeID]
+	if !ok {
+		return ValUint(0)
+	}
+	switch ti.Kind {
+	case TypeFloat:
+		return ValFloat(0)
+	case TypeInt:
+		if ti.Signed {
+			return ValInt(0)
+		}
+		return ValUint(0)
+	case TypeVector:
+		switch ti.Components {
+		case 2:
+			return ValVec2(0, 0)
+		case 3:
+			return ValVec3(0, 0, 0)
+		case 4:
+			return ValVec4(0, 0, 0, 0)
+		}
+	case TypeArray:
+		if ti.Length > 0 {
+			arr := make([]Value, ti.Length)
+			for i := range arr {
+				arr[i] = zeroValue(types, ti.ElemType)
+			}
+			return ValArray(arr)
+		}
+	case TypeBool:
+		return ValBool(false)
+	}
+	return ValUint(0)
 }


### PR DESCRIPTION
## Summary

- **naga v0.17.11** — fix #170 (SIGSEGV → error for `dot(v)` with wrong arg count) + BUG-DXIL-041 (fine.wgsl 100% valid)
- **Tagged union Value** — replace `any` interface boxing with 48-byte inline struct. Fragment -25% allocs, -11% ns/op.
- **Docs** — mark SPIR-V interpreter as debugging/testing tool, not production rendering

## Test plan
- [x] `go test ./...` — all pass
- [x] `golangci-lint` — 0 issues
- [x] `gofmt` — clean
- [x] naga v0.17.11 verified: `dot(diff)` → error, not SIGSEGV
- [ ] CI