### PR TITLE
v0.27.2: DX12 timestamps, Queue mutex, GLES barriers, VK timestampPeriod fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -403,6 +403,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **[ADR: Validation Phases](docs/dev/research/ADR-VALIDATION-PHASES.md)** — phased implementation
   plan (A: crash prevention, B: correctness, C: spec compliance)
 
+## [0.25.4] - 2026-04-23
+
+### Fixed
+
+- **Vulkan: GetTimestampPeriod returned hardcoded 1.0** — now reads
+  `VkPhysicalDeviceLimits.TimestampPeriod` from the physical device at init.
+  Previously all timestamp durations were incorrect on AMD/NVIDIA GPUs
+  (Intel typically has period=1.0, but others vary).
+
 ## [0.25.3] - 2026-04-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.2] - 2026-05-10
+
+### Added
+
+- **DX12: timestamp queries** — `CreateQuerySet`, `DestroyQuerySet`, `ResolveQuerySet`,
+  begin/end-of-pass timestamp writes. Uses `EndQuery` for timestamps (DX12 pattern, not
+  begin/end pair). FFI wrappers: `EndQuery`, `ResolveQueryData`. Matches Rust wgpu-hal
+  dx12 command.rs:834-887.
+
+### Fixed
+
+- **Vulkan: GetTimestampPeriod** returned hardcoded 1.0 — now reads
+  `VkPhysicalDeviceLimits.TimestampPeriod` at device init. Previously incorrect on
+  AMD/NVIDIA GPUs.
+- **GLES: compute memory barriers** — `TransitionBuffers`/`TransitionTextures` were no-ops.
+  Compute shader writes not guaranteed visible to subsequent draw/dispatch. Now emits
+  `glMemoryBarrier` with appropriate barrier bits when transitioning from storage usage.
+  Matches Rust wgpu-hal/gles command.rs:279-327.
+- **Queue thread safety** — `Submit`, `WriteBuffer`, `WriteTexture`, `LastSubmissionIndex`
+  serialized via `sync.Mutex`. Matches Rust wgpu-core which uses `RwLock::write()` on
+  `device.fence` + `device.command_indices` during submit (queue.rs:1171-1173). Prevents
+  data race on `lastSubmissionIndex` from concurrent goroutines.
+
 ## [0.27.1] - 2026-05-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ full design rationale and comparison with Rust wgpu.
 
 **Guides:** [Getting Started](docs/COMPUTE-SHADERS.md) | [Backend Differences](docs/COMPUTE-BACKENDS.md)
 
-Features: WGSL compute shaders, storage/uniform buffers, indirect dispatch, GPU timestamp queries (Vulkan), WebGPU-compliant `Buffer.Map` / `MapAsync` GPU→CPU readback with `context.Context` integration.
+Features: WGSL compute shaders, storage/uniform buffers, indirect dispatch, GPU timestamp queries (Vulkan, DX12), WebGPU-compliant `Buffer.Map` / `MapAsync` GPU→CPU readback with `context.Context` integration.
 
 ---
 

--- a/docs/COMPUTE-BACKENDS.md
+++ b/docs/COMPUTE-BACKENDS.md
@@ -8,7 +8,7 @@ This document describes compute shader support across wgpu's HAL backends.
 |---------|:------:|:----:|:-----:|:----:|:--------:|:----:|
 | Compute shaders | Yes | Yes | Yes | Partial | Yes (interpreted) | No |
 | Storage buffers | Yes | Yes | Yes | Yes | Yes (interpreted) | No |
-| Timestamp queries | Yes | Stub | Stub | Stub | No | No |
+| Timestamp queries | Yes | Yes | Stub | Stub | No | No |
 | Indirect dispatch | Yes | Yes | Yes | Yes | No | No |
 | Buffer mapping (GPU->CPU) | Yes | Yes | Yes | Yes | Yes | No |
 | Max workgroup size X | 1024+ | 1024 | 1024 | 1024 | 1024 | N/A |
@@ -35,10 +35,10 @@ Vulkan provides the most complete compute shader implementation:
 
 ## DirectX 12
 
-**Status:** Compute shaders work. Timestamp queries are stubbed.
+**Status:** Compute shaders work. Timestamp queries supported.
 
 - **Shader compilation:** WGSL -> HLSL -> DXBC via FXC (default), or WGSL -> DXIL direct via `gogpu/naga/dxil` (`GOGPU_DX12_DXIL=1`, SM 6.0+, no external dependencies).
-- **Timestamp queries:** `CreateQuerySet` currently returns `ErrTimestampsNotSupported`. The underlying D3D12 API supports timestamp queries via `ID3D12Device::CreateQueryHeap` with `D3D12_QUERY_TYPE_TIMESTAMP` and `ID3D12GraphicsCommandList::EndQuery` + `ResolveQueryData`. Implementation is planned.
+- **Timestamp queries:** Fully implemented using `ID3D12Device::CreateQueryHeap` with `D3D12_QUERY_TYPE_TIMESTAMP` and `ID3D12GraphicsCommandList::EndQuery` + `ResolveQueryData`. Begin/end-of-pass timestamps written automatically.
 - **Workgroup size limits:** Maximum 1024 invocations per workgroup (D3D12 spec).
 - **Indirect dispatch:** `DispatchIndirect` via `ExecuteIndirect` with pre-created `ID3D12CommandSignature` (dispatch args: 3 × uint32 = 12 bytes). Also supports `DrawIndirect` (16B) and `DrawIndexedIndirect` (20B).
 - **Root signature:** Compute pipelines use a separate root signature from graphics pipelines. Descriptor heaps are bound lazily on first `SetBindGroup` call.

--- a/hal/dx12/command.go
+++ b/hal/dx12/command.go
@@ -431,9 +431,66 @@ func (e *CommandEncoder) CopyTextureToTexture(src, dst hal.Texture, regions []ha
 }
 
 // ResolveQuerySet copies query results from a query set into a destination buffer.
-// TODO: implement using ID3D12GraphicsCommandList::ResolveQueryData when QuerySet is implemented.
-func (e *CommandEncoder) ResolveQuerySet(_ hal.QuerySet, _, _ uint32, _ hal.Buffer, _ uint64) {
-	// Stub: DX12 timestamp query implementation pending.
+// Each timestamp result is a uint64 (8 bytes).
+// Rust wgpu-hal reference: dx12/command.rs copy_query_results.
+func (e *CommandEncoder) ResolveQuerySet(querySet hal.QuerySet, firstQuery, queryCount uint32, destination hal.Buffer, destinationOffset uint64) {
+	if !e.isRecording {
+		return
+	}
+	qs, ok := querySet.(*QuerySet)
+	if !ok || qs == nil || qs.raw == nil {
+		return
+	}
+	buf, ok := destination.(*Buffer)
+	if !ok || buf == nil || buf.raw == nil {
+		return
+	}
+	e.cmdList.ResolveQueryData(qs.raw, qs.rawTy, firstQuery, queryCount, buf.raw, destinationOffset)
+}
+
+// timestampWrites is a common interface for render/compute pass timestamp writes.
+// Both hal.RenderPassTimestampWrites and hal.ComputePassTimestampWrites share
+// the same fields; this interface avoids duplicating extraction logic.
+type timestampWrites interface {
+	querySet() hal.QuerySet
+	beginIndex() *uint32
+	endIndex() *uint32
+}
+
+type renderTSW struct {
+	w *hal.RenderPassTimestampWrites
+}
+
+func (r renderTSW) querySet() hal.QuerySet { return r.w.QuerySet }
+func (r renderTSW) beginIndex() *uint32    { return r.w.BeginningOfPassWriteIndex }
+func (r renderTSW) endIndex() *uint32      { return r.w.EndOfPassWriteIndex }
+
+type computeTSW struct {
+	w *hal.ComputePassTimestampWrites
+}
+
+func (c computeTSW) querySet() hal.QuerySet { return c.w.QuerySet }
+func (c computeTSW) beginIndex() *uint32    { return c.w.BeginningOfPassWriteIndex }
+func (c computeTSW) endIndex() *uint32      { return c.w.EndOfPassWriteIndex }
+
+// writeBeginTimestamp writes the beginning-of-pass timestamp (if requested) and
+// returns the query heap + index for the end-of-pass timestamp write.
+// DX12 uses EndQuery for timestamps (NOT begin/end pair).
+// Rust wgpu-hal reference: dx12/command.rs begin_render_pass / begin_compute_pass.
+func (e *CommandEncoder) writeBeginTimestamp(halQS hal.QuerySet, tw timestampWrites) (*d3d12.ID3D12QueryHeap, uint32) {
+	qs, ok := halQS.(*QuerySet)
+	if !ok || qs == nil || qs.raw == nil {
+		return nil, 0
+	}
+
+	if idx := tw.beginIndex(); idx != nil {
+		e.cmdList.EndQuery(qs.raw, d3d12.D3D12_QUERY_TYPE_TIMESTAMP, *idx)
+	}
+
+	if idx := tw.endIndex(); idx != nil {
+		return qs.raw, *idx
+	}
+	return nil, 0
 }
 
 // BeginRenderPass begins a render pass.
@@ -532,15 +589,27 @@ func (e *CommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.Ren
 		e.cmdList.RSSetScissorRects(1, &scissor)
 	}
 
+	// Write beginning-of-pass timestamp and store end-of-pass for later.
+	if desc.TimestampWrites != nil {
+		tw := renderTSW{desc.TimestampWrites}
+		rpe.endOfPassTimerHeap, rpe.endOfPassTimerIndex = e.writeBeginTimestamp(tw.querySet(), tw)
+	}
+
 	return rpe
 }
 
 // BeginComputePass begins a compute pass.
 func (e *CommandEncoder) BeginComputePass(desc *hal.ComputePassDescriptor) hal.ComputePassEncoder {
-	_ = desc // Compute passes don't need special setup in D3D12
-	return &ComputePassEncoder{
+	cpe := &ComputePassEncoder{
 		encoder: e,
 	}
+
+	if e.isRecording && desc != nil && desc.TimestampWrites != nil {
+		tw := computeTSW{desc.TimestampWrites}
+		cpe.endOfPassTimerHeap, cpe.endOfPassTimerIndex = e.writeBeginTimestamp(tw.querySet(), tw)
+	}
+
+	return cpe
 }
 
 // RenderPassEncoder implements hal.RenderPassEncoder for DirectX 12.
@@ -550,14 +619,28 @@ type RenderPassEncoder struct {
 	pipeline           *RenderPipeline
 	indexFormat        gputypes.IndexFormat
 	descriptorHeapsSet bool // Tracks whether descriptor heaps have been bound
+
+	// endOfPassTimerQuery stores the query heap and index for the end-of-pass
+	// timestamp write. Set during BeginRenderPass, consumed in End().
+	// Rust wgpu-hal reference: dx12/mod.rs end_of_pass_timer_query field.
+	endOfPassTimerHeap  *d3d12.ID3D12QueryHeap
+	endOfPassTimerIndex uint32
 }
 
 // End finishes the render pass.
-// Handles MSAA resolve (if ResolveTarget is set) and transitions surface
-// textures back to PRESENT state for presentation.
+// Handles MSAA resolve (if ResolveTarget is set), writes end-of-pass
+// timestamp, and transitions surface textures back to PRESENT state.
 func (e *RenderPassEncoder) End() {
 	if e.desc == nil || e.encoder == nil || !e.encoder.isRecording {
 		return
+	}
+
+	// Write end-of-pass timestamp before state transitions.
+	// Rust wgpu-hal reference: dx12/command.rs end_render_pass calls
+	// write_pass_end_timestamp_if_requested after resolves but before end_pass.
+	if e.endOfPassTimerHeap != nil {
+		e.encoder.cmdList.EndQuery(e.endOfPassTimerHeap, d3d12.D3D12_QUERY_TYPE_TIMESTAMP, e.endOfPassTimerIndex)
+		e.endOfPassTimerHeap = nil
 	}
 
 	for _, ca := range e.desc.ColorAttachments {
@@ -860,11 +943,24 @@ type ComputePassEncoder struct {
 	// dispatch via BufferUsageScope, then drains barriers on state transitions
 	// (wgpu-core/src/command/compute.rs:326-377).
 	boundStorageBuffers []*Buffer
+
+	// endOfPassTimerQuery stores the query heap and index for the end-of-pass
+	// timestamp write. Set during BeginComputePass, consumed in End().
+	endOfPassTimerHeap  *d3d12.ID3D12QueryHeap
+	endOfPassTimerIndex uint32
 }
 
 // End finishes the compute pass.
+// Writes end-of-pass timestamp if requested.
+// Rust wgpu-hal reference: dx12/command.rs end_compute_pass.
 func (e *ComputePassEncoder) End() {
-	// No explicit end needed for D3D12 compute passes
+	if e.encoder == nil || !e.encoder.isRecording {
+		return
+	}
+	if e.endOfPassTimerHeap != nil {
+		e.encoder.cmdList.EndQuery(e.endOfPassTimerHeap, d3d12.D3D12_QUERY_TYPE_TIMESTAMP, e.endOfPassTimerIndex)
+		e.endOfPassTimerHeap = nil
+	}
 }
 
 // SetPipeline sets the compute pipeline.

--- a/hal/dx12/d3d12/device.go
+++ b/hal/dx12/d3d12/device.go
@@ -1077,6 +1077,45 @@ func (c *ID3D12GraphicsCommandList) ExecuteIndirect(
 	)
 }
 
+// EndQuery ends a query (also used for timestamp writes).
+// DX12 uses EndQuery for timestamps — there is no begin/end pair for timestamp queries.
+// Rust wgpu-hal: command.rs write_timestamp uses EndQuery with D3D12_QUERY_TYPE_TIMESTAMP.
+func (c *ID3D12GraphicsCommandList) EndQuery(queryHeap *ID3D12QueryHeap, queryType D3D12_QUERY_TYPE, index uint32) {
+	_, _, _ = syscall.Syscall6(
+		c.vtbl.EndQuery,
+		4,
+		uintptr(unsafe.Pointer(c)),
+		uintptr(unsafe.Pointer(queryHeap)),
+		uintptr(queryType),
+		uintptr(index),
+		0, 0,
+	)
+}
+
+// ResolveQueryData copies query results from a query heap into a destination buffer.
+// The destination buffer must be in D3D12_RESOURCE_STATE_COPY_DEST state.
+// Each timestamp result is a uint64 (8 bytes).
+func (c *ID3D12GraphicsCommandList) ResolveQueryData(
+	queryHeap *ID3D12QueryHeap,
+	queryType D3D12_QUERY_TYPE,
+	startIndex, numQueries uint32,
+	destinationBuffer *ID3D12Resource,
+	alignedDestinationBufferOffset uint64,
+) {
+	_, _, _ = syscall.Syscall9(
+		c.vtbl.ResolveQueryData,
+		7,
+		uintptr(unsafe.Pointer(c)),
+		uintptr(unsafe.Pointer(queryHeap)),
+		uintptr(queryType),
+		uintptr(startIndex),
+		uintptr(numQueries),
+		uintptr(unsafe.Pointer(destinationBuffer)),
+		uintptr(alignedDestinationBufferOffset),
+		0, 0,
+	)
+}
+
 // -----------------------------------------------------------------------------
 // ID3D12Fence methods
 // -----------------------------------------------------------------------------

--- a/hal/dx12/device.go
+++ b/hal/dx12/device.go
@@ -2532,16 +2532,7 @@ func (d *Device) DestroyComputePipeline(pipeline hal.ComputePipeline) {
 	}
 }
 
-// CreateQuerySet creates a query set.
-// TODO: implement using ID3D12Device::CreateQueryHeap for full timestamp support.
-func (d *Device) CreateQuerySet(_ *hal.QuerySetDescriptor) (hal.QuerySet, error) {
-	return nil, hal.ErrTimestampsNotSupported
-}
-
-// DestroyQuerySet destroys a query set.
-func (d *Device) DestroyQuerySet(_ hal.QuerySet) {
-	// Stub: DX12 query set implementation pending.
-}
+// CreateQuerySet and DestroyQuerySet are in query.go.
 
 // CreateCommandEncoder creates a command encoder.
 // The encoder is a lightweight shell — command allocator and list are created

--- a/hal/dx12/query.go
+++ b/hal/dx12/query.go
@@ -1,0 +1,79 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build windows && !(js && wasm)
+
+package dx12
+
+import (
+	"fmt"
+
+	"github.com/gogpu/wgpu/hal"
+	"github.com/gogpu/wgpu/hal/dx12/d3d12"
+)
+
+// QuerySet implements hal.QuerySet for DirectX 12.
+// Maps to ID3D12QueryHeap + D3D12_QUERY_TYPE.
+// Rust wgpu-hal reference: dx12/mod.rs QuerySet struct.
+type QuerySet struct {
+	raw   *d3d12.ID3D12QueryHeap
+	rawTy d3d12.D3D12_QUERY_TYPE
+	count uint32
+}
+
+// Destroy releases the DX12 query heap.
+func (q *QuerySet) Destroy() {
+	if q.raw != nil {
+		q.raw.Release()
+		q.raw = nil
+	}
+}
+
+// CreateQuerySet creates a DX12 query heap.
+// Maps hal.QueryType to the corresponding D3D12 heap and query types.
+// Rust wgpu-hal reference: dx12/device.rs create_query_set.
+func (d *Device) CreateQuerySet(desc *hal.QuerySetDescriptor) (hal.QuerySet, error) {
+	if desc == nil {
+		return nil, fmt.Errorf("dx12: query set descriptor is nil")
+	}
+	if desc.Count == 0 {
+		return nil, fmt.Errorf("dx12: query set count is 0")
+	}
+
+	var heapTy d3d12.D3D12_QUERY_HEAP_TYPE
+	var rawTy d3d12.D3D12_QUERY_TYPE
+	switch desc.Type {
+	case hal.QueryTypeTimestamp:
+		heapTy = d3d12.D3D12_QUERY_HEAP_TYPE_TIMESTAMP
+		rawTy = d3d12.D3D12_QUERY_TYPE_TIMESTAMP
+	case hal.QueryTypeOcclusion:
+		heapTy = d3d12.D3D12_QUERY_HEAP_TYPE_OCCLUSION
+		rawTy = d3d12.D3D12_QUERY_TYPE_BINARY_OCCLUSION
+	default:
+		return nil, fmt.Errorf("dx12: unsupported query type: %d", desc.Type)
+	}
+
+	heapDesc := &d3d12.D3D12_QUERY_HEAP_DESC{
+		Type:     heapTy,
+		Count:    desc.Count,
+		NodeMask: 0,
+	}
+
+	heap, err := d.raw.CreateQueryHeap(heapDesc)
+	if err != nil {
+		return nil, fmt.Errorf("dx12: CreateQueryHeap failed: %w", err)
+	}
+
+	return &QuerySet{
+		raw:   heap,
+		rawTy: rawTy,
+		count: desc.Count,
+	}, nil
+}
+
+// DestroyQuerySet destroys a DX12 query set.
+func (d *Device) DestroyQuerySet(querySet hal.QuerySet) {
+	if qs, ok := querySet.(*QuerySet); ok && qs != nil {
+		qs.Destroy()
+	}
+}

--- a/hal/gles/command.go
+++ b/hal/gles/command.go
@@ -69,14 +69,40 @@ func (e *CommandEncoder) ResetAll(_ []hal.CommandBuffer) {
 // Destroy is a no-op for OpenGL (no persistent GPU resources owned by encoder).
 func (e *CommandEncoder) Destroy() {}
 
-// TransitionBuffers transitions buffer states.
-func (e *CommandEncoder) TransitionBuffers(_ []hal.BufferBarrier) {
-	// No-op for OpenGL - no explicit barriers needed
+// TransitionBuffers emits memory barriers for buffer state transitions.
+// GLES only needs explicit barriers when transitioning FROM storage write
+// (compute shader output) to any other usage (vertex, uniform, draw).
+// Matches Rust wgpu-hal/gles command.rs:279-298.
+func (e *CommandEncoder) TransitionBuffers(barriers []hal.BufferBarrier) {
+	var bits uint32
+	for _, bar := range barriers {
+		if bar.Usage.OldUsage&gputypes.BufferUsageStorage != 0 {
+			bits |= gl.SHADER_STORAGE_BARRIER_BIT | gl.BUFFER_UPDATE_BARRIER_BIT |
+				gl.VERTEX_ATTRIB_ARRAY_BARRIER_BIT | gl.ELEMENT_ARRAY_BARRIER_BIT |
+				gl.UNIFORM_BARRIER_BIT | gl.COMMAND_BARRIER_BIT
+		}
+	}
+	if bits != 0 {
+		e.commands = append(e.commands, &MemoryBarrierCommand{barriers: bits})
+	}
 }
 
-// TransitionTextures transitions texture states.
-func (e *CommandEncoder) TransitionTextures(_ []hal.TextureBarrier) {
-	// No-op for OpenGL - no explicit barriers needed
+// TransitionTextures emits memory barriers for texture state transitions.
+// GLES only needs explicit barriers when transitioning FROM storage write
+// to any other usage (texture fetch, framebuffer attachment).
+// Matches Rust wgpu-hal/gles command.rs:300-327.
+func (e *CommandEncoder) TransitionTextures(barriers []hal.TextureBarrier) {
+	var bits uint32
+	for _, bar := range barriers {
+		if bar.Usage.OldUsage&gputypes.TextureUsageStorageBinding != 0 {
+			bits |= gl.TEXTURE_FETCH_BARRIER_BIT | gl.SHADER_IMAGE_ACCESS_BARRIER_BIT |
+				gl.FRAMEBUFFER_BARRIER_BIT | gl.TEXTURE_UPDATE_BARRIER_BIT |
+				gl.PIXEL_BUFFER_BARRIER_BIT
+		}
+	}
+	if bits != 0 {
+		e.commands = append(e.commands, &MemoryBarrierCommand{barriers: bits})
+	}
 }
 
 // ClearBuffer clears a buffer region to zero.
@@ -614,6 +640,16 @@ func (e *ComputePassEncoder) DispatchIndirect(buffer hal.Buffer, offset uint64) 
 }
 
 // --- GL Command implementations ---
+
+// MemoryBarrierCommand inserts a glMemoryBarrier call.
+// Ensures compute shader writes are visible to subsequent draw/dispatch commands.
+type MemoryBarrierCommand struct {
+	barriers uint32
+}
+
+func (c *MemoryBarrierCommand) Execute(ctx *gl.Context) {
+	ctx.MemoryBarrier(c.barriers)
+}
 
 // ClearBufferCommand clears a buffer region.
 type ClearBufferCommand struct {

--- a/hal/vulkan/device.go
+++ b/hal/vulkan/device.go
@@ -91,6 +91,11 @@ type Device struct {
 	// Queried during initAllocator. (BUG-VK-009 Fix 2)
 	nonCoherentAtomSize uint64
 
+	// timestampPeriod is the number of nanoseconds per timestamp query tick
+	// (from VkPhysicalDeviceLimits.TimestampPeriod). Intel typically 1.0,
+	// AMD/NVIDIA vary. Queried during initAllocator.
+	timestampPeriod float32
+
 	// mappedMemory tracks persistently mapped VkDeviceMemory objects.
 	// Vulkan only allows one active vkMapMemory per VkDeviceMemory;
 	// with suballocation multiple buffers share the same VkDeviceMemory,
@@ -211,8 +216,14 @@ func (d *Device) queryNonCoherentAtomSize() {
 	}
 	d.nonCoherentAtomSize = atomSize
 
-	hal.Logger().Debug("vulkan: nonCoherentAtomSize queried",
-		"atomSize", atomSize,
+	d.timestampPeriod = props.Limits.TimestampPeriod
+	if d.timestampPeriod <= 0 {
+		d.timestampPeriod = 1.0
+	}
+
+	hal.Logger().Debug("vulkan: device limits queried",
+		"nonCoherentAtomSize", atomSize,
+		"timestampPeriod", d.timestampPeriod,
 	)
 }
 

--- a/hal/vulkan/queue.go
+++ b/hal/vulkan/queue.go
@@ -704,10 +704,11 @@ func (q *Queue) Present(surface hal.Surface, _ hal.SurfaceTexture, damageRects [
 	return err
 }
 
-// GetTimestampPeriod returns the timestamp period in nanoseconds.
+// GetTimestampPeriod returns the timestamp period in nanoseconds per tick.
+// Queried from VkPhysicalDeviceLimits.TimestampPeriod at device init.
+// Intel typically 1.0, AMD/NVIDIA vary.
 func (q *Queue) GetTimestampPeriod() float32 {
-	// Note: Should query VkPhysicalDeviceLimits.timestampPeriod.
-	return 1.0
+	return q.device.timestampPeriod
 }
 
 // SupportsCommandBufferCopies returns true for Vulkan.

--- a/queue_native.go
+++ b/queue_native.go
@@ -4,13 +4,21 @@ package wgpu
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/gogpu/wgpu/core"
 	"github.com/gogpu/wgpu/hal"
 )
 
 // Queue handles command submission and data transfers.
+//
+// Queue is safe for concurrent use from multiple goroutines. All mutating
+// operations (Submit, WriteBuffer, WriteTexture) are serialized via an
+// internal mutex, matching Rust wgpu-core which uses RwLock::write() on
+// device.fence + device.command_indices during submit (queue.rs:1171-1173).
 type Queue struct {
+	mu sync.Mutex // serializes Submit, WriteBuffer, WriteTexture (Rust wgpu parity)
+
 	hal       hal.Queue
 	halDevice hal.Device
 	device    *Device
@@ -19,6 +27,7 @@ type Queue struct {
 	// lastSubmissionIndex is the most recent submission index returned by
 	// hal.Queue.Submit(). Used by DestroyQueue to conservatively defer
 	// resource destruction until after the latest known submission completes.
+	// Protected by mu.
 	lastSubmissionIndex uint64
 }
 
@@ -29,6 +38,9 @@ type Queue struct {
 // If there are pending WriteBuffer/WriteTexture operations, they are flushed
 // and prepended before the user command buffers in a single HAL submit.
 func (q *Queue) Submit(commandBuffers ...*CommandBuffer) (uint64, error) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
 	if q.hal == nil {
 		return 0, fmt.Errorf("wgpu: queue not available")
 	}
@@ -210,6 +222,9 @@ func (q *Queue) Poll() uint64 {
 //
 // Matches Rust wgpu-core queue.rs:647-672 (validate_write_buffer_impl).
 func (q *Queue) WriteBuffer(buffer *Buffer, offset uint64, data []byte) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
 	if q.hal == nil || buffer == nil {
 		return fmt.Errorf("wgpu: WriteBuffer: queue or buffer is nil")
 	}
@@ -274,6 +289,9 @@ func (q *Queue) WriteBuffer(buffer *Buffer, offset uint64, data []byte) error {
 // Resource barriers are computed from the texture's tracked CurrentUsage().
 // For GLES/Software backends, the write is performed immediately via HAL.
 func (q *Queue) WriteTexture(dst *ImageCopyTexture, data []byte, layout *ImageDataLayout, size *Extent3D) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
 	if q.hal == nil || dst == nil {
 		return fmt.Errorf("wgpu: WriteTexture: queue or destination is nil")
 	}
@@ -323,8 +341,12 @@ func (q *Queue) SetSwapchainSuppressed(suppressed bool) {
 
 // LastSubmissionIndex returns the most recent submission index.
 // Used by resource Release() methods to schedule deferred destruction.
+// Safe for concurrent use — reads under the queue mutex.
 func (q *Queue) LastSubmissionIndex() uint64 {
-	return q.lastSubmissionIndex
+	q.mu.Lock()
+	idx := q.lastSubmissionIndex
+	q.mu.Unlock()
+	return idx
 }
 
 // destroyQueue returns the device's DestroyQueue, or nil if unavailable.


### PR DESCRIPTION
## Summary

- **DX12 timestamp queries** — CreateQuerySet, ResolveQuerySet, begin/end-of-pass timestamps via EndQuery. FFI wrappers added.
- **Queue thread safety** — Submit/WriteBuffer/WriteTexture serialized via sync.Mutex (Rust wgpu parity: RwLock::write on device.fence)
- **GLES compute barriers** — TransitionBuffers/TransitionTextures emit glMemoryBarrier (was no-op, correctness bug)
- **Vulkan GetTimestampPeriod** — reads VkPhysicalDeviceLimits instead of hardcoded 1.0 (wrong on AMD/NVIDIA)

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] `gofmt -l .` — clean
- [ ] CI