### PR TITLE
v0.27.5: defensive NULL handle guard in TransitionTextures/Buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.27.5] - 2026-05-14
+
+### Fixed
+
+- **Vulkan: crash on destroyed texture barrier** — `TransitionTextures` passed NULL VkImage
+  to `vkCmdPipelineBarrier` when a destroyed texture (handle=0) was in the barrier array,
+  causing access violation (Exception 0xc0000005 at address 0x23e). Now skips invalid
+  barriers with a warning log. Same fix applied to `TransitionBuffers`.
+  Rust wgpu prevents this at the core layer via `Snatchable<TextureInner>` + `SnatchGuard`.
+  Our fix adds defense-in-depth at three levels:
+  1. **Public API** (`encoder_native.go`) — filters nil/destroyed textures before HAL
+  2. **Vulkan HAL** (`hal/vulkan/command.go`) — skips barriers with handle=0
+  3. **DX12 HAL** (`hal/dx12/command.go`) — skips barriers with nil raw resource
+
 ## [0.27.4] - 2026-05-13
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.27.4
+## Current State: v0.27.5
 
 ✅ **All 5 HAL backends complete** (~127K LOC)
 ✅ **Three-layer WebGPU stack** — wgpu API → wgpu/core → wgpu/hal
@@ -149,6 +149,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.27.5** | 2026-05 | Defensive NULL handle guard in TransitionTextures/Buffers (Vulkan, DX12, public API). Prevents crash on destroyed resource barriers. |
 | **v0.27.4** | 2026-05 | goffi v0.5.1 (struct ABI, XMM return, CGO_ENABLED=1), x/sys v0.44.0, flaky TestThread_CallAsync fix |
 | **v0.27.3** | 2026-05 | Software render pass instrumentation (slog + RenderPassStats), Metal MsgSend docs |
 | **v0.27.2** | 2026-05 | DX12 timestamp queries, Queue mutex, GLES compute barriers, Vulkan timestampPeriod fix |

--- a/encoder_native.go
+++ b/encoder_native.go
@@ -246,11 +246,16 @@ func (e *CommandEncoder) TransitionTextures(barriers []TextureBarrier) {
 	if raw == nil {
 		return
 	}
-	halBarriers := make([]hal.TextureBarrier, len(barriers))
-	for i, b := range barriers {
-		halBarriers[i] = b.toHAL()
+	halBarriers := make([]hal.TextureBarrier, 0, len(barriers))
+	for _, b := range barriers {
+		if b.Texture == nil || b.Texture.hal == nil {
+			continue
+		}
+		halBarriers = append(halBarriers, b.toHAL())
 	}
-	raw.TransitionTextures(halBarriers)
+	if len(halBarriers) > 0 {
+		raw.TransitionTextures(halBarriers)
+	}
 }
 
 // DiscardEncoding discards the encoder without producing a command buffer.

--- a/hal/dx12/command.go
+++ b/hal/dx12/command.go
@@ -158,14 +158,14 @@ func (e *CommandEncoder) TransitionBuffers(barriers []hal.BufferBarrier) {
 	d3dBarriers := make([]d3d12.D3D12_RESOURCE_BARRIER, 0, len(barriers))
 	for _, b := range barriers {
 		buf, ok := b.Buffer.(*Buffer)
-		if !ok {
+		if !ok || buf.raw == nil {
+			hal.Logger().Warn("TransitionBuffers: skipping invalid buffer (nil or destroyed)")
 			continue
 		}
 
 		beforeState := bufferUsageToD3D12State(b.Usage.OldUsage)
 		afterState := bufferUsageToD3D12State(b.Usage.NewUsage)
 
-		// Skip if no transition needed
 		if beforeState == afterState {
 			continue
 		}
@@ -188,7 +188,8 @@ func (e *CommandEncoder) TransitionTextures(barriers []hal.TextureBarrier) {
 	d3dBarriers := make([]d3d12.D3D12_RESOURCE_BARRIER, 0, len(barriers))
 	for _, b := range barriers {
 		tex, ok := b.Texture.(*Texture)
-		if !ok {
+		if !ok || tex.raw == nil {
+			hal.Logger().Warn("TransitionTextures: skipping invalid texture (nil or destroyed)")
 			continue
 		}
 

--- a/hal/vulkan/command.go
+++ b/hal/vulkan/command.go
@@ -275,18 +275,18 @@ func (e *CommandEncoder) TransitionBuffers(barriers []hal.BufferBarrier) {
 		return
 	}
 
-	// Convert to Vulkan buffer memory barriers
-	bufferBarriers := make([]vk.BufferMemoryBarrier, len(barriers))
-	for i, b := range barriers {
+	bufferBarriers := make([]vk.BufferMemoryBarrier, 0, len(barriers))
+	for _, b := range barriers {
 		buf, ok := b.Buffer.(*Buffer)
-		if !ok {
+		if !ok || buf.handle == 0 {
+			hal.Logger().Warn("TransitionBuffers: skipping invalid buffer (nil or destroyed)")
 			continue
 		}
 
 		srcAccess, srcStage := bufferUsageToAccessAndStage(b.Usage.OldUsage)
 		dstAccess, dstStage := bufferUsageToAccessAndStage(b.Usage.NewUsage)
 
-		bufferBarriers[i] = vk.BufferMemoryBarrier{
+		bufferBarriers = append(bufferBarriers, vk.BufferMemoryBarrier{
 			SType:               vk.StructureTypeBufferMemoryBarrier,
 			SrcAccessMask:       srcAccess,
 			DstAccessMask:       dstAccess,
@@ -295,14 +295,16 @@ func (e *CommandEncoder) TransitionBuffers(barriers []hal.BufferBarrier) {
 			Buffer:              buf.handle,
 			Offset:              0,
 			Size:                vk.DeviceSize(vk.WholeSize),
-		}
+		})
 
-		// Track pipeline stages for the barrier command
 		_ = srcStage
 		_ = dstStage
 	}
 
-	// Use vkCmdPipelineBarrier with buffer memory barriers
+	if len(bufferBarriers) == 0 {
+		return
+	}
+
 	vkCmdPipelineBarrier(
 		e.device.cmds,
 		e.active,
@@ -321,18 +323,18 @@ func (e *CommandEncoder) TransitionTextures(barriers []hal.TextureBarrier) {
 		return
 	}
 
-	// Convert to Vulkan image memory barriers
-	imageBarriers := make([]vk.ImageMemoryBarrier, len(barriers))
-	for i, b := range barriers {
+	imageBarriers := make([]vk.ImageMemoryBarrier, 0, len(barriers))
+	for _, b := range barriers {
 		tex, ok := b.Texture.(*Texture)
-		if !ok {
+		if !ok || tex.handle == 0 {
+			hal.Logger().Warn("TransitionTextures: skipping invalid texture (nil or destroyed)")
 			continue
 		}
 
 		srcAccess, srcStage, oldLayout := textureUsageToAccessStageLayout(b.Usage.OldUsage)
 		dstAccess, dstStage, newLayout := textureUsageToAccessStageLayout(b.Usage.NewUsage)
 
-		imageBarriers[i] = vk.ImageMemoryBarrier{
+		imageBarriers = append(imageBarriers, vk.ImageMemoryBarrier{
 			SType:               vk.StructureTypeImageMemoryBarrier,
 			SrcAccessMask:       srcAccess,
 			DstAccessMask:       dstAccess,
@@ -348,10 +350,14 @@ func (e *CommandEncoder) TransitionTextures(barriers []hal.TextureBarrier) {
 				BaseArrayLayer: b.Range.BaseArrayLayer,
 				LayerCount:     arrayLayerCountOrRemaining(b.Range.ArrayLayerCount),
 			},
-		}
+		})
 
 		_ = srcStage
 		_ = dstStage
+	}
+
+	if len(imageBarriers) == 0 {
+		return
 	}
 
 	vkCmdPipelineBarrier(

--- a/hal/vulkan/command_nullguard_test.go
+++ b/hal/vulkan/command_nullguard_test.go
@@ -282,6 +282,63 @@ func TestResetAllRecyclesCBs(t *testing.T) {
 	}
 }
 
+// TestTransitionTexturesDestroyedHandle verifies that TransitionTextures
+// skips barriers with a destroyed texture (handle == 0) instead of crashing.
+// Regression test for vkCmdPipelineBarrier access violation (0xc0000005).
+func TestTransitionTexturesDestroyedHandle(t *testing.T) {
+	enc := &CommandEncoder{
+		device: &Device{},
+		active: 42,
+	}
+
+	// Should not panic — destroyed texture (handle=0) is skipped.
+	enc.TransitionTextures([]hal.TextureBarrier{
+		{Texture: &Texture{handle: 0}},
+	})
+}
+
+// TestTransitionTexturesNilTexture verifies that TransitionTextures
+// skips barriers with a nil texture interface.
+func TestTransitionTexturesNilTexture(t *testing.T) {
+	enc := &CommandEncoder{
+		device: &Device{},
+		active: 42,
+	}
+
+	// Should not panic — nil texture is skipped.
+	enc.TransitionTextures([]hal.TextureBarrier{
+		{Texture: nil},
+	})
+}
+
+// TestTransitionBuffersDestroyedHandle verifies that TransitionBuffers
+// skips barriers with a destroyed buffer (handle == 0) instead of crashing.
+func TestTransitionBuffersDestroyedHandle(t *testing.T) {
+	enc := &CommandEncoder{
+		device: &Device{},
+		active: 42,
+	}
+
+	// Should not panic — destroyed buffer (handle=0) is skipped.
+	enc.TransitionBuffers([]hal.BufferBarrier{
+		{Buffer: &Buffer{handle: 0}},
+	})
+}
+
+// TestTransitionBuffersNilBuffer verifies that TransitionBuffers
+// skips barriers with a nil buffer interface.
+func TestTransitionBuffersNilBuffer(t *testing.T) {
+	enc := &CommandEncoder{
+		device: &Device{},
+		active: 42,
+	}
+
+	// Should not panic — nil buffer is skipped.
+	enc.TransitionBuffers([]hal.BufferBarrier{
+		{Buffer: nil},
+	})
+}
+
 // TestAllocationGranularity verifies the batch allocation constant.
 func TestAllocationGranularity(t *testing.T) {
 	if allocationGranularity != 16 {


### PR DESCRIPTION
## Summary

- **Fix Vulkan crash on destroyed texture barrier** — `vkCmdPipelineBarrier` access violation (0xc0000005) when a destroyed texture (VkImage=0) reached the driver. Three-level defense-in-depth:
  1. Public API (`encoder_native.go`) — filters nil/destroyed textures before HAL
  2. Vulkan HAL — skips barriers with handle=0, logs warning
  3. DX12 HAL — skips barriers with nil raw resource, logs warning
- Both `TransitionTextures` and `TransitionBuffers` fixed (same pattern)
- Rust wgpu prevents this via `Snatchable<TextureInner>` + `SnatchGuard` at core layer

## Test plan

- [x] 4 new tests: destroyed handle + nil texture/buffer (Vulkan HAL)
- [x] `go test ./...` — all pass
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] Cross-platform build: Windows, Linux, macOS
