### PR TITLE
v0.28.0: Browser WebGPU backend — Pure Go WASM support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -174,6 +174,13 @@ linters:
           - gocyclo
           - cyclop
 
+      # Browser backend enum-to-string conversions: repeated string literals
+      # in switch/default are intentional for readability (each function is
+      # a self-contained WebGPU spec mapping).
+      - path: internal/browser/convert_enums\.go
+        linters:
+          - goconst
+
       # DX12 COM bindings - Windows API naming conventions preserved
       # D3D12_* types match the Windows SDK headers exactly for documentation cross-reference
       - path: hal/dx12/d3d12/.*\.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.0] - 2026-05-14
+
+### Added
+
+- **Browser WebGPU backend** (WASM-001) — complete browser WebGPU support via `syscall/js` →
+  `navigator.gpu`. Same public API, same user code — `GOOS=js GOARCH=wasm go build` produces
+  a working WASM binary. ~6500 LOC across 5 phases:
+  - **Phase 1:** Instance, Adapter, Device — `navigator.gpu` access, pre-bound JS methods (Ebiten pattern)
+  - **Phase 2:** Resources + Pipelines — Buffer, Texture, ShaderModule (WGSL passthrough), BindGroup,
+    RenderPipeline, ComputePipeline. 97 TextureFormats + 31 VertexFormats + all WebGPU enum conversions
+  - **Phase 3:** Command Recording + Submit — CommandEncoder, RenderPassEncoder (13 methods),
+    ComputePassEncoder, Queue.Submit/WriteBuffer/WriteTexture with `js.CopyBytesToJS` data transfer
+  - **Phase 4:** Surface/Canvas — HTMLCanvasElement + GPUCanvasContext, Configure, GetCurrentTexture,
+    Present (no-op — browser auto-presents), preferred format detection
+  - **Phase 5:** Buffer Mapping — MapAsync (Promise→goroutine), MappedRange with lazy copy
+    (Rust OnceCell pattern), dirty write-back on Release (Rust Drop pattern)
+  - Architecture: bypasses core/hal (browser validates internally), matches Rust wgpu `backend/webgpu.rs`
+  - Zero external dependencies — only `syscall/js` from Go stdlib
+  - 29+ enum conversion tests running on native (no WASM required)
+
 ## [0.27.5] - 2026-05-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@
 
 | Category | Capabilities |
 |----------|--------------|
-| **Backends** | Vulkan, Metal, DirectX 12, OpenGL ES, Software |
-| **Platforms** | Windows, Linux, macOS, iOS, Browser (WASM — in progress) |
+| **Backends** | Vulkan, Metal, DirectX 12, OpenGL ES, Software, **Browser WebGPU** |
+| **Platforms** | Windows, Linux, macOS, iOS, **Browser (WASM)** |
 | **API** | WebGPU-compliant (W3C specification) |
 | **Shaders** | WGSL via gogpu/naga compiler (SPIR-V, HLSL, MSL, GLSL, DXIL) |
 | **Compute** | Full compute shader support, GPU→CPU readback |
@@ -55,6 +55,13 @@ CGO_ENABLED=0 go build
 ```
 
 > **Note:** wgpu uses Pure Go FFI via [goffi](https://github.com/go-webgpu/goffi). Both `CGO_ENABLED=0` (default, zero C compiler dependency) and `CGO_ENABLED=1` (for race detector or coexistence with CGO libraries) are supported.
+
+**Browser (WASM):**
+```bash
+GOOS=js GOARCH=wasm go build -o app.wasm .
+```
+
+> Browser backend uses `syscall/js` → `navigator.gpu` directly, bypassing core/hal. Same public API, same user code — just a different build target. Zero external dependencies.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ import _ "github.com/gogpu/wgpu/hal/software"
 - [WebGPU Specification](https://www.w3.org/TR/webgpu/) — W3C standard
 - [wgpu (Rust)](https://github.com/gfx-rs/wgpu) — Reference implementation
 - [Dawn (C++)](https://dawn.googlesource.com/dawn) — Google's implementation
+- [Architecture Deep-Dive (Chinese)](https://chenxutan.com/d/1987.html) — Performance benchmarks, Snatchable pattern analysis, zero-alloc hot paths
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.27.5
+## Current State: v0.28.0
 
 ✅ **All 5 HAL backends complete** (~127K LOC)
 ✅ **Three-layer WebGPU stack** — wgpu API → wgpu/core → wgpu/hal
@@ -63,6 +63,7 @@
 ✅ **Queue thread safety** — Submit/WriteBuffer/WriteTexture serialized via sync.Mutex (Rust wgpu-core parity)
 ✅ **GLES compute memory barriers** — glMemoryBarrier for storage→draw/dispatch transitions (Rust parity)
 ✅ **Software render pass instrumentation** — slog debug events + RenderPassStats for CI e2e assertions
+✅ **Browser WebGPU backend** — complete `syscall/js` → `navigator.gpu` implementation (~6500 LOC). Instance, Adapter, Device, Resources, Pipelines, Command Recording, Queue Submit, Surface/Canvas, Buffer Mapping. Bypasses core/hal (Rust wgpu pattern). 97 TextureFormats, 31 VertexFormats, 29+ tests. Zero external dependencies.
 
 ### Remaining validation (planned)
 - **Phase C** (P2): Spec compliance edge cases, feature gates
@@ -109,10 +110,9 @@
 
 ### Future — Platform Expansion
 
-- [ ] **WebAssembly (browser WebGPU)** — ADR approved, research complete. Top-level
-  `backend/browser/` via `syscall/js` → `navigator.gpu` (bypasses core/hal, like Rust
-  wgpu `ContextWebGpu`). WebGL2 fallback via GLES backend + `_js.go`.
-  See `docs/dev/research/ADR-WASM-WEBGPU-ARCHITECTURE.md`
+- [x] **WebAssembly (browser WebGPU)** — DONE (v0.28.0). `internal/browser/` via `syscall/js` →
+  `navigator.gpu` (bypasses core/hal, Rust wgpu `ContextWebGpu` pattern). ~6500 LOC, zero deps.
+- [ ] **WebGL2 fallback** — GLES backend `_js.go` files for browsers without WebGPU.
 - [ ] **Android** — Vulkan surface via `vkCreateAndroidSurfaceKHR` (S estimate).
   Depends on gogpu platform layer
 - [ ] **iOS** — Metal backend ready (naga MSL 91/91), needs platform integration
@@ -149,6 +149,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.28.0** | 2026-05 | **Browser WebGPU backend** (WASM-001). Complete `syscall/js` → `navigator.gpu`. 6500 LOC, 5 phases, zero deps. First Pure Go WebGPU in the browser. |
 | **v0.27.5** | 2026-05 | Defensive NULL handle guard in TransitionTextures/Buffers (Vulkan, DX12, public API). Prevents crash on destroyed resource barriers. |
 | **v0.27.4** | 2026-05 | goffi v0.5.1 (struct ABI, XMM return, CGO_ENABLED=1), x/sys v0.44.0, flaky TestThread_CallAsync fix |
 | **v0.27.3** | 2026-05 | Software render pass instrumentation (slog + RenderPassStats), Metal MsgSend docs |

--- a/adapter_browser.go
+++ b/adapter_browser.go
@@ -2,6 +2,12 @@
 
 package wgpu
 
+import (
+	"syscall/js"
+
+	"github.com/gogpu/wgpu/internal/browser"
+)
+
 // DeviceDescriptor configures device creation.
 type DeviceDescriptor struct {
 	Label            string
@@ -10,7 +16,9 @@ type DeviceDescriptor struct {
 }
 
 // Adapter represents a physical GPU.
+// On browser, this wraps a GPUAdapter via internal/browser.Adapter.
 type Adapter struct {
+	browser  *browser.Adapter
 	info     AdapterInfo
 	features Features
 	limits   Limits
@@ -27,8 +35,39 @@ func (a *Adapter) Features() Features { return a.features }
 func (a *Adapter) Limits() Limits { return a.limits }
 
 // RequestDevice creates a logical device from this adapter.
+// If desc is nil, default features and limits are used.
 func (a *Adapter) RequestDevice(desc *DeviceDescriptor) (*Device, error) {
-	panic("wgpu: browser backend not yet implemented")
+	if a.released {
+		return nil, ErrReleased
+	}
+
+	// Build JS descriptor from Go types.
+	var jsDesc js.Value
+	if desc != nil {
+		jsDesc = browser.BuildDeviceDescriptor(desc.Label, desc.RequiredFeatures, desc.RequiredLimits)
+	} else {
+		jsDesc = js.Undefined()
+	}
+
+	bd, err := a.browser.RequestDevice(jsDesc)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the device's features and limits.
+	deviceFeatures := browser.ExtractFeatures(bd.Features())
+	deviceLimits := browser.ExtractLimits(bd.Limits())
+
+	queue := &Queue{
+		browser: bd.Queue(),
+	}
+
+	return &Device{
+		browser:  bd,
+		queue:    queue,
+		features: deviceFeatures,
+		limits:   deviceLimits,
+	}, nil
 }
 
 // SurfaceCapabilities describes what a surface supports on this adapter.
@@ -39,8 +78,9 @@ type SurfaceCapabilities struct {
 }
 
 // GetSurfaceCapabilities returns the capabilities of a surface for this adapter.
+// Phase 4 — not yet implemented for browser.
 func (a *Adapter) GetSurfaceCapabilities(surface *Surface) *SurfaceCapabilities {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser GetSurfaceCapabilities not yet implemented (Phase 4)")
 }
 
 // Release releases the adapter.

--- a/adapter_browser.go
+++ b/adapter_browser.go
@@ -5,6 +5,7 @@ package wgpu
 import (
 	"syscall/js"
 
+	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/internal/browser"
 )
 
@@ -78,9 +79,42 @@ type SurfaceCapabilities struct {
 }
 
 // GetSurfaceCapabilities returns the capabilities of a surface for this adapter.
-// Phase 4 — not yet implemented for browser.
+//
+// On browser, capabilities are statically defined per the WebGPU spec:
+//   - Formats: rgba8unorm, bgra8unorm, rgba16float (preferred format first)
+//   - PresentModes: Fifo only (browser controls VSync)
+//   - AlphaModes: Opaque only (browser default)
+//
+// The preferred format is obtained from navigator.gpu.getPreferredCanvasFormat()
+// and placed first in the formats list.
+//
+// Matches Rust wgpu SurfaceInterface::get_capabilities for WebSurface.
 func (a *Adapter) GetSurfaceCapabilities(surface *Surface) *SurfaceCapabilities {
-	panic("wgpu: browser GetSurfaceCapabilities not yet implemented (Phase 4)")
+	// Browser WebGPU supports these three formats per spec:
+	// https://gpuweb.github.io/gpuweb/#supported-context-formats
+	formats := []TextureFormat{
+		TextureFormatRGBA8Unorm,
+		TextureFormatBGRA8Unorm,
+		gputypes.TextureFormatRGBA16Float,
+	}
+
+	// Put the preferred format first (Rust wgpu does the same swap).
+	if surface != nil && surface.browser != nil {
+		preferredStr := surface.browser.GetPreferredCanvasFormat()
+		preferredFmt := browser.TextureFormatFromJS(preferredStr)
+		for i, f := range formats {
+			if f == preferredFmt {
+				formats[0], formats[i] = formats[i], formats[0]
+				break
+			}
+		}
+	}
+
+	return &SurfaceCapabilities{
+		Formats:      formats,
+		PresentModes: []PresentMode{PresentModeFifo},
+		AlphaModes:   []CompositeAlphaMode{gputypes.CompositeAlphaModeOpaque},
+	}
 }
 
 // Release releases the adapter.

--- a/bind_browser.go
+++ b/bind_browser.go
@@ -2,8 +2,11 @@
 
 package wgpu
 
+import "github.com/gogpu/wgpu/internal/browser"
+
 // BindGroupLayout defines the structure of resource bindings for shaders.
 type BindGroupLayout struct {
+	browser  *browser.BindGroupLayout
 	released bool
 }
 
@@ -17,6 +20,7 @@ func (l *BindGroupLayout) Release() {
 
 // PipelineLayout defines the bind group layout arrangement for a pipeline.
 type PipelineLayout struct {
+	browser  *browser.PipelineLayout
 	released bool
 }
 
@@ -37,6 +41,7 @@ type LateBufferBindingInfo struct {
 
 // BindGroup represents bound GPU resources for shader access.
 type BindGroup struct {
+	browser  *browser.BindGroup
 	released bool
 }
 

--- a/buffer_browser.go
+++ b/buffer_browser.go
@@ -4,6 +4,7 @@ package wgpu
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gogpu/wgpu/internal/browser"
 )
@@ -14,6 +15,9 @@ type Buffer struct {
 	size     uint64
 	usage    BufferUsage
 	released bool
+
+	// mapState tracks the current mapping state. Updated by MapAsync/Unmap.
+	mapState MapState
 }
 
 // Size returns the buffer size in bytes.
@@ -38,37 +42,200 @@ func (b *Buffer) Release() {
 		return
 	}
 	b.released = true
+	b.mapState = MapStateDestroyed
 	if b.browser != nil {
 		b.browser.Destroy()
 	}
 }
 
 // MapState returns the current mapping state of the buffer.
-// Phase 5 — full mapping support not yet implemented for browser.
 func (b *Buffer) MapState() MapState {
-	return MapStateUnmapped
+	if b == nil || b.released {
+		return MapStateUnmapped
+	}
+	return b.mapState
 }
 
-// Map blocks until a CPU-visible mapping is established.
-// Phase 5 — not yet implemented for browser.
+// mapModeToJS converts a MapMode to the WebGPU GPUMapMode flags.
+// Our MapMode values already match WebGPU spec: MapModeRead=1, MapModeWrite=2.
+// This function validates and converts explicitly for clarity.
+func mapModeToJS(mode MapMode) uint32 {
+	var jsMode uint32
+	if mode&MapModeRead != 0 {
+		jsMode |= 1 // GPUMapMode.READ
+	}
+	if mode&MapModeWrite != 0 {
+		jsMode |= 2 // GPUMapMode.WRITE
+	}
+	return jsMode
+}
+
+// Map blocks until a CPU-visible mapping is established for the given
+// byte range, or until ctx is canceled.
+//
+// The buffer must have been created with BufferUsageMapRead or
+// BufferUsageMapWrite matching mode. offset must be a multiple of 8 and
+// size must be a multiple of 4 (WebGPU MAP_ALIGNMENT).
+//
+// After Map succeeds, call MappedRange to obtain a byte view and Unmap
+// when finished:
+//
+//	if err := buf.Map(ctx, wgpu.MapModeRead, 0, size); err != nil {
+//	    return err
+//	}
+//	defer buf.Unmap()
+//	rng, _ := buf.MappedRange(0, size)
+//	data := rng.Bytes()
+//
+// On the browser, Map spawns a goroutine that calls GPUBuffer.mapAsync
+// (a JS Promise) via AwaitPromise. The ctx parameter allows cancellation.
 func (b *Buffer) Map(ctx context.Context, mode MapMode, offset, size uint64) error {
-	panic("wgpu: browser Buffer.Map not yet implemented (Phase 5)")
+	if b == nil || b.browser == nil {
+		return ErrReleased
+	}
+	if b.released {
+		return ErrBufferDestroyed
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := validateMapArgs(b, mode, offset, size); err != nil {
+		return err
+	}
+
+	// MapAsync sets the state to pending, then blocks on the JS Promise.
+	// We use a channel + goroutine to support context cancellation.
+	pending, err := b.MapAsync(mode, offset, size)
+	if err != nil {
+		return err
+	}
+	return pending.Wait(ctx)
 }
 
 // MapAsync initiates a buffer map without blocking the caller.
-// Phase 5 — not yet implemented for browser.
+//
+// Returns a *MapPending handle that resolves once the browser's
+// GPUBuffer.mapAsync Promise settles. The caller can poll with
+// Status() or block with Wait(ctx).
+//
+// Validation errors (alignment, usage mismatch, range overflow,
+// already-mapped state) surface synchronously.
 func (b *Buffer) MapAsync(mode MapMode, offset, size uint64) (*MapPending, error) {
-	panic("wgpu: browser Buffer.MapAsync not yet implemented (Phase 5)")
+	if b == nil || b.browser == nil {
+		return nil, ErrReleased
+	}
+	if b.released {
+		return nil, ErrBufferDestroyed
+	}
+	if err := validateMapArgs(b, mode, offset, size); err != nil {
+		return nil, err
+	}
+
+	b.mapState = MapStatePending
+	jsMode := mapModeToJS(mode)
+
+	// Create a MapPending that will resolve asynchronously.
+	p := &MapPending{
+		buf:  b,
+		done: make(chan error, 1),
+	}
+
+	// Launch a goroutine to await the JS Promise. AwaitPromise blocks the
+	// goroutine (not the main thread) until the Promise settles.
+	go func() {
+		err := b.browser.MapAsync(jsMode, offset, size)
+		if err != nil {
+			b.mapState = MapStateUnmapped
+			p.done <- fmt.Errorf("mapAsync: %w", err)
+		} else {
+			b.mapState = MapStateMapped
+			p.done <- nil
+		}
+	}()
+
+	return p, nil
 }
 
-// MappedRange returns a safe view over the mapped region.
-// Phase 5 — not yet implemented for browser.
+// MappedRange returns a safe view over the mapped region [offset, offset+size).
+//
+// The buffer must be in the Mapped state (Map or MapAsync resolved, or the
+// buffer was created with MappedAtCreation: true). The returned MappedRange
+// is invalidated by Unmap.
 func (b *Buffer) MappedRange(offset, size uint64) (*MappedRange, error) {
-	panic("wgpu: browser Buffer.MappedRange not yet implemented (Phase 5)")
+	if b == nil || b.browser == nil {
+		return nil, ErrReleased
+	}
+	if b.released {
+		return nil, ErrBufferDestroyed
+	}
+	if b.mapState != MapStateMapped {
+		return nil, ErrMapNotMapped
+	}
+	if offset%8 != 0 || size%4 != 0 {
+		return nil, ErrMapAlignment
+	}
+	if offset+size > b.size {
+		return nil, ErrMapRangeOverflow
+	}
+
+	return &MappedRange{
+		buf:    b,
+		offset: offset,
+		size:   size,
+		valid:  true,
+	}, nil
 }
 
-// Unmap releases the current mapping.
-// Phase 5 — not yet implemented for browser.
+// Unmap releases the current mapping and invalidates all outstanding
+// MappedRange handles. Safe to call multiple times; a second call returns
+// ErrMapNotMapped.
 func (b *Buffer) Unmap() error {
-	panic("wgpu: browser Buffer.Unmap not yet implemented (Phase 5)")
+	if b == nil || b.browser == nil {
+		return ErrReleased
+	}
+	if b.released {
+		return ErrBufferDestroyed
+	}
+	if b.mapState != MapStateMapped && b.mapState != MapStatePending {
+		return ErrMapNotMapped
+	}
+	b.browser.Unmap()
+	b.mapState = MapStateUnmapped
+	return nil
+}
+
+// validateMapArgs performs synchronous validation of mapping parameters.
+func validateMapArgs(b *Buffer, mode MapMode, offset, size uint64) error {
+	if b.mapState == MapStatePending {
+		return ErrMapAlreadyPending
+	}
+	if b.mapState == MapStateMapped {
+		return ErrMapAlreadyMapped
+	}
+	if b.mapState == MapStateDestroyed {
+		return ErrBufferDestroyed
+	}
+
+	// Check usage flags.
+	if mode&MapModeRead != 0 && b.usage&BufferUsageMapRead == 0 {
+		return ErrMapInvalidMode
+	}
+	if mode&MapModeWrite != 0 && b.usage&BufferUsageMapWrite == 0 {
+		return ErrMapInvalidMode
+	}
+
+	// Alignment: offset must be multiple of 8, size must be multiple of 4.
+	if offset%8 != 0 || size%4 != 0 {
+		return ErrMapAlignment
+	}
+
+	// Range overflow.
+	if offset+size > b.size {
+		return ErrMapRangeOverflow
+	}
+
+	return nil
 }

--- a/buffer_browser.go
+++ b/buffer_browser.go
@@ -2,26 +2,34 @@
 
 package wgpu
 
-import "context"
+import (
+	"context"
+
+	"github.com/gogpu/wgpu/internal/browser"
+)
 
 // Buffer represents a GPU buffer.
 type Buffer struct {
+	browser  *browser.Buffer
+	size     uint64
+	usage    BufferUsage
 	released bool
 }
 
 // Size returns the buffer size in bytes.
 func (b *Buffer) Size() uint64 {
-	panic("wgpu: browser backend not yet implemented")
+	return b.size
 }
 
 // Usage returns the buffer's usage flags.
 func (b *Buffer) Usage() BufferUsage {
-	panic("wgpu: browser backend not yet implemented")
+	return b.usage
 }
 
 // Label returns the buffer's debug label.
+// Browser WebGPU does not expose label on the object; returns empty string.
 func (b *Buffer) Label() string {
-	panic("wgpu: browser backend not yet implemented")
+	return ""
 }
 
 // Release destroys the buffer.
@@ -30,29 +38,37 @@ func (b *Buffer) Release() {
 		return
 	}
 	b.released = true
+	if b.browser != nil {
+		b.browser.Destroy()
+	}
 }
 
 // MapState returns the current mapping state of the buffer.
+// Phase 5 — full mapping support not yet implemented for browser.
 func (b *Buffer) MapState() MapState {
-	panic("wgpu: browser backend not yet implemented")
+	return MapStateUnmapped
 }
 
 // Map blocks until a CPU-visible mapping is established.
+// Phase 5 — not yet implemented for browser.
 func (b *Buffer) Map(ctx context.Context, mode MapMode, offset, size uint64) error {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser Buffer.Map not yet implemented (Phase 5)")
 }
 
 // MapAsync initiates a buffer map without blocking the caller.
+// Phase 5 — not yet implemented for browser.
 func (b *Buffer) MapAsync(mode MapMode, offset, size uint64) (*MapPending, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser Buffer.MapAsync not yet implemented (Phase 5)")
 }
 
 // MappedRange returns a safe view over the mapped region.
+// Phase 5 — not yet implemented for browser.
 func (b *Buffer) MappedRange(offset, size uint64) (*MappedRange, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser Buffer.MappedRange not yet implemented (Phase 5)")
 }
 
 // Unmap releases the current mapping.
+// Phase 5 — not yet implemented for browser.
 func (b *Buffer) Unmap() error {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser Buffer.Unmap not yet implemented (Phase 5)")
 }

--- a/computepass_browser.go
+++ b/computepass_browser.go
@@ -2,32 +2,50 @@
 
 package wgpu
 
+import "github.com/gogpu/wgpu/internal/browser"
+
 // ComputePassEncoder records compute dispatch commands.
+// On browser, this wraps a GPUComputePassEncoder via internal/browser.ComputePassEncoder.
 type ComputePassEncoder struct {
+	browser  *browser.ComputePassEncoder
 	released bool
 }
 
 // SetPipeline sets the active compute pipeline.
 func (p *ComputePassEncoder) SetPipeline(pipeline *ComputePipeline) {
-	panic("wgpu: browser backend not yet implemented")
+	if pipeline == nil || pipeline.browser == nil {
+		return
+	}
+	p.browser.SetPipeline(pipeline.browser.Ref())
 }
 
 // SetBindGroup sets a bind group for the given index.
 func (p *ComputePassEncoder) SetBindGroup(index uint32, group *BindGroup, offsets []uint32) {
-	panic("wgpu: browser backend not yet implemented")
+	if group == nil || group.browser == nil {
+		return
+	}
+	p.browser.SetBindGroup(index, group.browser.Ref(), offsets)
 }
 
 // Dispatch dispatches compute work.
 func (p *ComputePassEncoder) Dispatch(x, y, z uint32) {
-	panic("wgpu: browser backend not yet implemented")
+	p.browser.DispatchWorkgroups(x, y, z)
 }
 
 // DispatchIndirect dispatches compute work with GPU-generated parameters.
 func (p *ComputePassEncoder) DispatchIndirect(buffer *Buffer, offset uint64) {
-	panic("wgpu: browser backend not yet implemented")
+	if buffer == nil || buffer.browser == nil {
+		return
+	}
+	p.browser.DispatchIndirect(buffer.browser.Ref(), offset)
 }
 
 // End ends the compute pass.
 func (p *ComputePassEncoder) End() error {
-	panic("wgpu: browser backend not yet implemented")
+	if p.released {
+		return ErrReleased
+	}
+	p.released = true
+	p.browser.End()
+	return nil
 }

--- a/device_browser.go
+++ b/device_browser.go
@@ -224,9 +224,21 @@ func (d *Device) CreateComputePipeline(desc *ComputePipelineDescriptor) (*Comput
 }
 
 // CreateCommandEncoder creates a command encoder for recording GPU commands.
-// Phase 3 — not yet implemented for browser.
 func (d *Device) CreateCommandEncoder(desc *CommandEncoderDescriptor) (*CommandEncoder, error) {
-	panic("wgpu: browser CreateCommandEncoder not yet implemented (Phase 3)")
+	if d.released {
+		return nil, ErrReleased
+	}
+	label := ""
+	if desc != nil {
+		label = desc.Label
+	}
+	jsDesc := browser.BuildCommandEncoderDescriptor(label)
+	jsEncoder := d.browser.CreateCommandEncoder().Invoke(jsDesc)
+	be := browser.NewCommandEncoder(jsEncoder)
+	return &CommandEncoder{
+		browser:  be,
+		released: false,
+	}, nil
 }
 
 // CreateFence creates a GPU synchronization fence.

--- a/device_browser.go
+++ b/device_browser.go
@@ -45,11 +45,22 @@ func (d *Device) CreateBuffer(desc *BufferDescriptor) (*Buffer, error) {
 		desc.MappedAtCreation,
 	)
 	bb := d.browser.CreateBufferFromDesc(jsDesc)
+
+	state := MapStateUnmapped
+	if desc.MappedAtCreation {
+		// When mappedAtCreation is true the buffer starts in the Mapped state
+		// with the entire range [0, size) mapped. Record this so that
+		// MappedRange / Unmap work without calling MapAsync first.
+		bb.SetMappedAtCreation()
+		state = MapStateMapped
+	}
+
 	return &Buffer{
 		browser:  bb,
 		size:     desc.Size,
 		usage:    desc.Usage,
 		released: false,
+		mapState: state,
 	}, nil
 }
 

--- a/device_browser.go
+++ b/device_browser.go
@@ -3,6 +3,8 @@
 package wgpu
 
 import (
+	"syscall/js"
+
 	"github.com/gogpu/wgpu/internal/browser"
 )
 
@@ -31,64 +33,194 @@ func (d *Device) Limits() Limits {
 	return d.limits
 }
 
-// CreateBuffer creates a GPU buffer.
-// Phase 2 — not yet implemented for browser.
+// CreateBuffer creates a GPU buffer from the given descriptor.
 func (d *Device) CreateBuffer(desc *BufferDescriptor) (*Buffer, error) {
-	panic("wgpu: browser CreateBuffer not yet implemented (Phase 2)")
+	if d.released {
+		return nil, ErrReleased
+	}
+	jsDesc := browser.BuildBufferDescriptor(
+		desc.Label,
+		desc.Size,
+		uint64(desc.Usage),
+		desc.MappedAtCreation,
+	)
+	bb := d.browser.CreateBufferFromDesc(jsDesc)
+	return &Buffer{
+		browser:  bb,
+		size:     desc.Size,
+		usage:    desc.Usage,
+		released: false,
+	}, nil
 }
 
-// CreateTexture creates a GPU texture.
-// Phase 2 — not yet implemented for browser.
+// CreateTexture creates a GPU texture from the given descriptor.
 func (d *Device) CreateTexture(desc *TextureDescriptor) (*Texture, error) {
-	panic("wgpu: browser CreateTexture not yet implemented (Phase 2)")
+	if d.released {
+		return nil, ErrReleased
+	}
+	jsDesc := browser.BuildTextureDescriptor(
+		desc.Label,
+		desc.Size.Width, desc.Size.Height, desc.Size.DepthOrArrayLayers,
+		desc.MipLevelCount, desc.SampleCount,
+		desc.Dimension, desc.Format, desc.Usage,
+		desc.ViewFormats,
+	)
+	bt := d.browser.CreateTextureFromDesc(jsDesc)
+	return &Texture{
+		browser:  bt,
+		format:   desc.Format,
+		released: false,
+	}, nil
 }
 
 // CreateTextureView creates a view into a texture.
-// Phase 2 — not yet implemented for browser.
 func (d *Device) CreateTextureView(texture *Texture, desc *TextureViewDescriptor) (*TextureView, error) {
-	panic("wgpu: browser CreateTextureView not yet implemented (Phase 2)")
+	if d.released {
+		return nil, ErrReleased
+	}
+	if texture == nil || texture.browser == nil {
+		return nil, ErrReleased
+	}
+	jsDesc := browser.BuildTextureViewDescriptor(
+		desc.Label,
+		desc.Format, desc.Dimension, desc.Aspect,
+		desc.BaseMipLevel, desc.MipLevelCount,
+		desc.BaseArrayLayer, desc.ArrayLayerCount,
+	)
+	bv := texture.browser.CreateView(jsDesc)
+	return &TextureView{
+		browser:  bv,
+		released: false,
+	}, nil
 }
 
-// CreateSampler creates a texture sampler.
-// Phase 2 — not yet implemented for browser.
+// CreateSampler creates a texture sampler from the given descriptor.
 func (d *Device) CreateSampler(desc *SamplerDescriptor) (*Sampler, error) {
-	panic("wgpu: browser CreateSampler not yet implemented (Phase 2)")
+	if d.released {
+		return nil, ErrReleased
+	}
+	jsDesc := browser.BuildSamplerDescriptor(
+		desc.Label,
+		desc.AddressModeU, desc.AddressModeV, desc.AddressModeW,
+		desc.MagFilter, desc.MinFilter, desc.MipmapFilter,
+		desc.LodMinClamp, desc.LodMaxClamp,
+		desc.Compare, desc.Anisotropy,
+	)
+	bs := d.browser.CreateSamplerFromDesc(jsDesc)
+	return &Sampler{
+		browser:  bs,
+		released: false,
+	}, nil
 }
 
-// CreateShaderModule creates a shader module.
-// Phase 2 — not yet implemented for browser.
+// CreateShaderModule creates a shader module from the given descriptor.
+// On browser, WGSL code goes directly to the browser's createShaderModule.
+// SPIR-V bytecode is not supported in the browser (browser only accepts WGSL).
 func (d *Device) CreateShaderModule(desc *ShaderModuleDescriptor) (*ShaderModule, error) {
-	panic("wgpu: browser CreateShaderModule not yet implemented (Phase 2)")
+	if d.released {
+		return nil, ErrReleased
+	}
+	jsDesc := browser.BuildShaderModuleDescriptor(desc.Label, desc.WGSL)
+	bm := d.browser.CreateShaderModuleFromDesc(jsDesc)
+	return &ShaderModule{
+		browser:  bm,
+		released: false,
+	}, nil
 }
 
-// CreateBindGroupLayout creates a bind group layout.
-// Phase 2 — not yet implemented for browser.
+// CreateBindGroupLayout creates a bind group layout from the given descriptor.
 func (d *Device) CreateBindGroupLayout(desc *BindGroupLayoutDescriptor) (*BindGroupLayout, error) {
-	panic("wgpu: browser CreateBindGroupLayout not yet implemented (Phase 2)")
+	if d.released {
+		return nil, ErrReleased
+	}
+	entries := convertBindGroupLayoutEntries(desc.Entries)
+	jsDesc := browser.BuildBindGroupLayoutDescriptor(desc.Label, entries)
+	bl := d.browser.CreateBindGroupLayoutFromDesc(jsDesc)
+	return &BindGroupLayout{
+		browser:  bl,
+		released: false,
+	}, nil
 }
 
-// CreatePipelineLayout creates a pipeline layout.
-// Phase 2 — not yet implemented for browser.
+// CreatePipelineLayout creates a pipeline layout from the given descriptor.
 func (d *Device) CreatePipelineLayout(desc *PipelineLayoutDescriptor) (*PipelineLayout, error) {
-	panic("wgpu: browser CreatePipelineLayout not yet implemented (Phase 2)")
+	if d.released {
+		return nil, ErrReleased
+	}
+	refs := make([]js.Value, len(desc.BindGroupLayouts))
+	for i, bgl := range desc.BindGroupLayouts {
+		if bgl != nil && bgl.browser != nil {
+			refs[i] = bgl.browser.Ref()
+		} else {
+			refs[i] = js.Undefined()
+		}
+	}
+	jsDesc := browser.BuildPipelineLayoutDescriptor(desc.Label, refs)
+	bp := d.browser.CreatePipelineLayoutFromDesc(jsDesc)
+	return &PipelineLayout{
+		browser:  bp,
+		released: false,
+	}, nil
 }
 
-// CreateBindGroup creates a bind group.
-// Phase 2 — not yet implemented for browser.
+// CreateBindGroup creates a bind group from the given descriptor.
 func (d *Device) CreateBindGroup(desc *BindGroupDescriptor) (*BindGroup, error) {
-	panic("wgpu: browser CreateBindGroup not yet implemented (Phase 2)")
+	if d.released {
+		return nil, ErrReleased
+	}
+	var layoutRef js.Value
+	if desc.Layout != nil && desc.Layout.browser != nil {
+		layoutRef = desc.Layout.browser.Ref()
+	} else {
+		layoutRef = js.Undefined()
+	}
+	entries := convertBindGroupEntries(desc.Entries)
+	jsDesc := browser.BuildBindGroupDescriptor(desc.Label, layoutRef, entries)
+	bg := d.browser.CreateBindGroupFromDesc(jsDesc)
+	return &BindGroup{
+		browser:  bg,
+		released: false,
+	}, nil
 }
 
-// CreateRenderPipeline creates a render pipeline.
-// Phase 2 — not yet implemented for browser.
+// CreateRenderPipeline creates a render pipeline from the given descriptor.
 func (d *Device) CreateRenderPipeline(desc *RenderPipelineDescriptor) (*RenderPipeline, error) {
-	panic("wgpu: browser CreateRenderPipeline not yet implemented (Phase 2)")
+	if d.released {
+		return nil, ErrReleased
+	}
+	jsDesc := convertRenderPipelineDescriptor(desc)
+	bp := d.browser.CreateRenderPipelineFromDesc(jsDesc)
+	return &RenderPipeline{
+		browser:  bp,
+		released: false,
+	}, nil
 }
 
-// CreateComputePipeline creates a compute pipeline.
-// Phase 2 — not yet implemented for browser.
+// CreateComputePipeline creates a compute pipeline from the given descriptor.
 func (d *Device) CreateComputePipeline(desc *ComputePipelineDescriptor) (*ComputePipeline, error) {
-	panic("wgpu: browser CreateComputePipeline not yet implemented (Phase 2)")
+	if d.released {
+		return nil, ErrReleased
+	}
+	var layoutRef js.Value
+	if desc.Layout != nil && desc.Layout.browser != nil {
+		layoutRef = desc.Layout.browser.Ref()
+	} else {
+		layoutRef = js.Undefined()
+	}
+	var moduleRef js.Value
+	if desc.Module != nil && desc.Module.browser != nil {
+		moduleRef = desc.Module.browser.Ref()
+	} else {
+		moduleRef = js.Undefined()
+	}
+	jsDesc := browser.BuildComputePipelineDescriptor(
+		desc.Label, layoutRef, moduleRef, desc.EntryPoint,
+	)
+	bp := d.browser.CreateComputePipelineFromDesc(jsDesc)
+	return &ComputePipeline{
+		browser:  bp,
+		released: false,
+	}, nil
 }
 
 // CreateCommandEncoder creates a command encoder for recording GPU commands.
@@ -141,4 +273,241 @@ func (d *Device) Release() {
 	if d.browser != nil {
 		d.browser.Destroy()
 	}
+}
+
+// --- Descriptor conversion helpers ---
+
+// convertBindGroupLayoutEntries converts Go BindGroupLayoutEntry slice to
+// browser.BindGroupLayoutEntryJS slice for JS object construction.
+func convertBindGroupLayoutEntries(entries []BindGroupLayoutEntry) []browser.BindGroupLayoutEntryJS {
+	result := make([]browser.BindGroupLayoutEntryJS, len(entries))
+	for i, e := range entries {
+		entry := browser.BindGroupLayoutEntryJS{
+			Binding:    e.Binding,
+			Visibility: uint32(e.Visibility),
+		}
+		if e.Buffer != nil {
+			entry.Buffer = &browser.BufferBindingLayoutJS{
+				Type:             browser.BufferBindingTypeToJS(e.Buffer.Type),
+				HasDynamicOffset: e.Buffer.HasDynamicOffset,
+				MinBindingSize:   e.Buffer.MinBindingSize,
+			}
+		}
+		if e.Sampler != nil {
+			entry.Sampler = &browser.SamplerBindingLayoutJS{
+				Type: browser.SamplerBindingTypeToJS(e.Sampler.Type),
+			}
+		}
+		if e.Texture != nil {
+			entry.Texture = &browser.TextureBindingLayoutJS{
+				SampleType:    browser.TextureSampleTypeToJS(e.Texture.SampleType),
+				ViewDimension: browser.TextureViewDimensionToJS(e.Texture.ViewDimension),
+				Multisampled:  e.Texture.Multisampled,
+			}
+		}
+		if e.StorageTexture != nil {
+			entry.StorageTexture = &browser.StorageTextureBindingLayoutJS{
+				Access:        browser.StorageTextureAccessToJS(e.StorageTexture.Access),
+				Format:        browser.TextureFormatToJS(e.StorageTexture.Format),
+				ViewDimension: browser.TextureViewDimensionToJS(e.StorageTexture.ViewDimension),
+			}
+		}
+		result[i] = entry
+	}
+	return result
+}
+
+// convertBindGroupEntries converts Go BindGroupEntry slice to
+// browser.BindGroupEntryJS slice for JS object construction.
+func convertBindGroupEntries(entries []BindGroupEntry) []browser.BindGroupEntryJS {
+	result := make([]browser.BindGroupEntryJS, len(entries))
+	for i, e := range entries {
+		entry := browser.BindGroupEntryJS{
+			Binding:        e.Binding,
+			BufferRef:      js.Undefined(),
+			SamplerRef:     js.Undefined(),
+			TextureViewRef: js.Undefined(),
+		}
+		if e.Buffer != nil && e.Buffer.browser != nil {
+			entry.BufferRef = e.Buffer.browser.Ref()
+			entry.BufferOffset = e.Offset
+			entry.BufferSize = e.Size
+		}
+		if e.Sampler != nil && e.Sampler.browser != nil {
+			entry.SamplerRef = e.Sampler.browser.Ref()
+		}
+		if e.TextureView != nil && e.TextureView.browser != nil {
+			entry.TextureViewRef = e.TextureView.browser.Ref()
+		}
+		result[i] = entry
+	}
+	return result
+}
+
+// convertRenderPipelineDescriptor converts a Go RenderPipelineDescriptor to
+// a JS descriptor object via browser.BuildRenderPipelineDescriptor.
+func convertRenderPipelineDescriptor(desc *RenderPipelineDescriptor) js.Value {
+	rpd := &browser.RenderPipelineDescriptorJS{
+		Label: desc.Label,
+	}
+
+	// Layout
+	if desc.Layout != nil && desc.Layout.browser != nil {
+		rpd.LayoutRef = desc.Layout.browser.Ref()
+	} else {
+		rpd.LayoutRef = js.Undefined()
+	}
+
+	// Vertex state
+	rpd.Vertex = browser.VertexStateJS{
+		EntryPoint: desc.Vertex.EntryPoint,
+	}
+	if desc.Vertex.Module != nil && desc.Vertex.Module.browser != nil {
+		rpd.Vertex.ModuleRef = desc.Vertex.Module.browser.Ref()
+	} else {
+		rpd.Vertex.ModuleRef = js.Undefined()
+	}
+	rpd.Vertex.Buffers = convertVertexBufferLayouts(desc.Vertex.Buffers)
+
+	// Primitive state
+	rpd.Primitive = &browser.PrimitiveStateJS{
+		Topology:  browser.PrimitiveTopologyToJS(desc.Primitive.Topology),
+		FrontFace: browser.FrontFaceToJS(desc.Primitive.FrontFace),
+		CullMode:  browser.CullModeToJS(desc.Primitive.CullMode),
+	}
+	if desc.Primitive.StripIndexFormat != nil {
+		rpd.Primitive.StripIndexFormat = browser.IndexFormatToJS(*desc.Primitive.StripIndexFormat)
+	}
+	if desc.Primitive.UnclippedDepth {
+		rpd.Primitive.UnclippedDepth = true
+	}
+
+	// Depth-stencil state
+	if desc.DepthStencil != nil {
+		rpd.DepthStencil = convertDepthStencilState(desc.DepthStencil)
+	}
+
+	// Multisample state
+	rpd.Multisample = &browser.MultisampleStateJS{
+		Count:                  desc.Multisample.Count,
+		Mask:                   desc.Multisample.Mask,
+		AlphaToCoverageEnabled: desc.Multisample.AlphaToCoverageEnabled,
+	}
+
+	// Fragment state
+	if desc.Fragment != nil {
+		rpd.Fragment = convertFragmentState(desc.Fragment)
+	}
+
+	return browser.BuildRenderPipelineDescriptor(rpd)
+}
+
+// convertVertexBufferLayouts converts Go VertexBufferLayout slice to JS types.
+func convertVertexBufferLayouts(layouts []VertexBufferLayout) []browser.VertexBufferLayoutJS {
+	result := make([]browser.VertexBufferLayoutJS, len(layouts))
+	for i, l := range layouts {
+		jsLayout := browser.VertexBufferLayoutJS{
+			ArrayStride: l.ArrayStride,
+			StepMode:    browser.VertexStepModeToJS(l.StepMode),
+		}
+		jsLayout.Attributes = make([]browser.VertexAttributeJS, len(l.Attributes))
+		for j, a := range l.Attributes {
+			jsLayout.Attributes[j] = browser.VertexAttributeJS{
+				Format:         browser.VertexFormatToJS(a.Format),
+				Offset:         a.Offset,
+				ShaderLocation: a.ShaderLocation,
+			}
+		}
+		result[i] = jsLayout
+	}
+	return result
+}
+
+// convertDepthStencilState converts a Go DepthStencilState to JS types.
+func convertDepthStencilState(ds *DepthStencilState) *browser.DepthStencilStateJS {
+	result := &browser.DepthStencilStateJS{
+		Format:              browser.TextureFormatToJS(ds.Format),
+		DepthWriteEnabled:   ds.DepthWriteEnabled,
+		DepthCompare:        browser.CompareFunctionToJS(ds.DepthCompare),
+		StencilReadMask:     ds.StencilReadMask,
+		StencilWriteMask:    ds.StencilWriteMask,
+		DepthBias:           ds.DepthBias,
+		DepthBiasSlopeScale: ds.DepthBiasSlopeScale,
+		DepthBiasClamp:      ds.DepthBiasClamp,
+	}
+	result.StencilFront = convertStencilFaceState(&ds.StencilFront)
+	result.StencilBack = convertStencilFaceState(&ds.StencilBack)
+	return result
+}
+
+// convertStencilFaceState converts a Go StencilFaceState to JS types.
+func convertStencilFaceState(s *StencilFaceState) *browser.StencilFaceStateJS {
+	return &browser.StencilFaceStateJS{
+		Compare:     browser.CompareFunctionToJS(s.Compare),
+		FailOp:      stencilOpToJS(s.FailOp),
+		DepthFailOp: stencilOpToJS(s.DepthFailOp),
+		PassOp:      stencilOpToJS(s.PassOp),
+	}
+}
+
+// stencilOpToJS converts the local StencilOperation enum to a WebGPU JS string.
+// The local enum (descriptor_browser.go) uses 0-based values while gputypes uses
+// 1-based (with Undefined=0), so we map explicitly to be correct.
+func stencilOpToJS(op StencilOperation) string {
+	switch op {
+	case StencilOperationKeep:
+		return "keep"
+	case StencilOperationZero:
+		return "zero"
+	case StencilOperationReplace:
+		return "replace"
+	case StencilOperationInvert:
+		return "invert"
+	case StencilOperationIncrementClamp:
+		return "increment-clamp"
+	case StencilOperationDecrementClamp:
+		return "decrement-clamp"
+	case StencilOperationIncrementWrap:
+		return "increment-wrap"
+	case StencilOperationDecrementWrap:
+		return "decrement-wrap"
+	default:
+		return "keep"
+	}
+}
+
+// convertFragmentState converts a Go FragmentState to JS types.
+func convertFragmentState(fs *FragmentState) *browser.FragmentStateJS {
+	result := &browser.FragmentStateJS{
+		EntryPoint: fs.EntryPoint,
+	}
+	if fs.Module != nil && fs.Module.browser != nil {
+		result.ModuleRef = fs.Module.browser.Ref()
+	} else {
+		result.ModuleRef = js.Undefined()
+	}
+
+	result.Targets = make([]browser.ColorTargetStateJS, len(fs.Targets))
+	for i, t := range fs.Targets {
+		ct := browser.ColorTargetStateJS{
+			Format:    browser.TextureFormatToJS(t.Format),
+			WriteMask: uint32(t.WriteMask),
+		}
+		if t.Blend != nil {
+			ct.Blend = &browser.BlendStateJS{
+				Color: browser.BlendComponentJS{
+					SrcFactor: browser.BlendFactorToJS(t.Blend.Color.SrcFactor),
+					DstFactor: browser.BlendFactorToJS(t.Blend.Color.DstFactor),
+					Operation: browser.BlendOperationToJS(t.Blend.Color.Operation),
+				},
+				Alpha: browser.BlendComponentJS{
+					SrcFactor: browser.BlendFactorToJS(t.Blend.Alpha.SrcFactor),
+					DstFactor: browser.BlendFactorToJS(t.Blend.Alpha.DstFactor),
+					Operation: browser.BlendOperationToJS(t.Blend.Alpha.Operation),
+				},
+			}
+		}
+		result.Targets[i] = ct
+	}
+	return result
 }

--- a/device_browser.go
+++ b/device_browser.go
@@ -2,105 +2,134 @@
 
 package wgpu
 
+import (
+	"github.com/gogpu/wgpu/internal/browser"
+)
+
 // Device represents a logical GPU device.
-// On browser, this wraps a JavaScript GPUDevice via syscall/js.
+// On browser, this wraps a GPUDevice via internal/browser.Device.
 type Device struct {
+	browser  *browser.Device
+	queue    *Queue
+	features Features
+	limits   Limits
 	released bool
 }
 
 // Queue returns the device's command queue.
 func (d *Device) Queue() *Queue {
-	panic("wgpu: browser backend not yet implemented")
+	return d.queue
 }
 
 // Features returns the device's enabled features.
 func (d *Device) Features() Features {
-	panic("wgpu: browser backend not yet implemented")
+	return d.features
 }
 
 // Limits returns the device's resource limits.
 func (d *Device) Limits() Limits {
-	panic("wgpu: browser backend not yet implemented")
+	return d.limits
 }
 
 // CreateBuffer creates a GPU buffer.
+// Phase 2 — not yet implemented for browser.
 func (d *Device) CreateBuffer(desc *BufferDescriptor) (*Buffer, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser CreateBuffer not yet implemented (Phase 2)")
 }
 
 // CreateTexture creates a GPU texture.
+// Phase 2 — not yet implemented for browser.
 func (d *Device) CreateTexture(desc *TextureDescriptor) (*Texture, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser CreateTexture not yet implemented (Phase 2)")
 }
 
 // CreateTextureView creates a view into a texture.
+// Phase 2 — not yet implemented for browser.
 func (d *Device) CreateTextureView(texture *Texture, desc *TextureViewDescriptor) (*TextureView, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser CreateTextureView not yet implemented (Phase 2)")
 }
 
 // CreateSampler creates a texture sampler.
+// Phase 2 — not yet implemented for browser.
 func (d *Device) CreateSampler(desc *SamplerDescriptor) (*Sampler, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser CreateSampler not yet implemented (Phase 2)")
 }
 
 // CreateShaderModule creates a shader module.
+// Phase 2 — not yet implemented for browser.
 func (d *Device) CreateShaderModule(desc *ShaderModuleDescriptor) (*ShaderModule, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser CreateShaderModule not yet implemented (Phase 2)")
 }
 
 // CreateBindGroupLayout creates a bind group layout.
+// Phase 2 — not yet implemented for browser.
 func (d *Device) CreateBindGroupLayout(desc *BindGroupLayoutDescriptor) (*BindGroupLayout, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser CreateBindGroupLayout not yet implemented (Phase 2)")
 }
 
 // CreatePipelineLayout creates a pipeline layout.
+// Phase 2 — not yet implemented for browser.
 func (d *Device) CreatePipelineLayout(desc *PipelineLayoutDescriptor) (*PipelineLayout, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser CreatePipelineLayout not yet implemented (Phase 2)")
 }
 
 // CreateBindGroup creates a bind group.
+// Phase 2 — not yet implemented for browser.
 func (d *Device) CreateBindGroup(desc *BindGroupDescriptor) (*BindGroup, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser CreateBindGroup not yet implemented (Phase 2)")
 }
 
 // CreateRenderPipeline creates a render pipeline.
+// Phase 2 — not yet implemented for browser.
 func (d *Device) CreateRenderPipeline(desc *RenderPipelineDescriptor) (*RenderPipeline, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser CreateRenderPipeline not yet implemented (Phase 2)")
 }
 
 // CreateComputePipeline creates a compute pipeline.
+// Phase 2 — not yet implemented for browser.
 func (d *Device) CreateComputePipeline(desc *ComputePipelineDescriptor) (*ComputePipeline, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser CreateComputePipeline not yet implemented (Phase 2)")
 }
 
 // CreateCommandEncoder creates a command encoder for recording GPU commands.
+// Phase 3 — not yet implemented for browser.
 func (d *Device) CreateCommandEncoder(desc *CommandEncoderDescriptor) (*CommandEncoder, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser CreateCommandEncoder not yet implemented (Phase 3)")
 }
 
 // CreateFence creates a GPU synchronization fence.
+// On browser, fences are not needed (browser auto-polls).
+// Returns a no-op fence for API compatibility.
 func (d *Device) CreateFence() (*Fence, error) {
-	panic("wgpu: browser backend not yet implemented")
+	if d.released {
+		return nil, ErrReleased
+	}
+	return &Fence{}, nil
 }
 
 // PushErrorScope pushes a new error scope onto the device's error scope stack.
+// Phase 2 — not yet implemented for browser.
 func (d *Device) PushErrorScope(filter ErrorFilter) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser PushErrorScope not yet implemented (Phase 2)")
 }
 
 // PopErrorScope pops the most recently pushed error scope.
+// Phase 2 — not yet implemented for browser.
 func (d *Device) PopErrorScope() *GPUError {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser PopErrorScope not yet implemented (Phase 2)")
 }
 
 // WaitIdle waits for all GPU work to complete.
+// On browser, the GPU is polled automatically. This is a no-op.
 func (d *Device) WaitIdle() error {
-	panic("wgpu: browser backend not yet implemented")
+	return nil
 }
 
 // Poll drives the per-device pending-map triage loop.
+// On browser, the GPU is polled automatically by the browser event loop.
+// Returns true (devices are always considered polled in browser).
 func (d *Device) Poll(pollType PollType) bool {
-	panic("wgpu: browser backend not yet implemented")
+	return true
 }
 
 // Release releases the device and all associated resources.
@@ -109,4 +138,7 @@ func (d *Device) Release() {
 		return
 	}
 	d.released = true
+	if d.browser != nil {
+		d.browser.Destroy()
+	}
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -12,23 +12,22 @@ This document describes the architecture of `wgpu` — a Pure Go WebGPU implemen
 └──────────────────────┬──────────────────────────┘
                        │
 ┌──────────────────────▼──────────────────────────┐
-│              Root Package (wgpu/)                │
+│              Root Package (wgpu/)               │
 │  Safe, ergonomic public API (WebGPU-aligned)    │
 │  Instance · Adapter · Device · Queue · Buffer   │
-│  Texture · Pipeline · CommandEncoder · Surface   │
-└──────────────────────┬──────────────────────────┘
-                       │ wraps
-┌──────────────────────▼──────────────────────────┐
-│                  core/                          │
-│      Validation, state tracking, error scopes   │
-│   (Instance, Adapter, Device, Queue, Pipeline)  │
-└──────────────────────┬──────────────────────────┘
-                       │
-┌──────────────────────▼──────────────────────────┐
+│  Texture · Pipeline · CommandEncoder · Surface  │
+└──────────┬──────────────────────────┬───────────┘
+           │ native                   │ browser (WASM)
+           │ *_native.go              │ *_browser.go
+┌──────────▼──────────┐   ┌──────────▼───────────┐
+│       core/         │   │  internal/browser/   │
+│  Validation, state  │   │  syscall/js →        │
+│  tracking, scopes   │   │  navigator.gpu       │
+└──────────┬──────────┘   │  (bypasses core/hal) │
+           │              └──────────────────────┘
+┌──────────▼──────────────────────────────────────┐
 │                  hal/                           │
 │     Hardware Abstraction Layer (interfaces)     │
-│  Backend · Instance · Adapter · Device · Queue  │
-│  CommandEncoder · RenderPass · ComputePass      │
 └──────┬────────┬────────┬────────┬────────┬──────┘
        │        │        │        │        │
 ┌──────▼──┐┌───▼────┐┌──▼───┐┌────▼───┐┌───▼──────┐
@@ -154,6 +153,27 @@ Use cases: **shader debugging** (step through every SPIR-V instruction), **CI/CD
 
 Stub implementation for testing. All operations succeed without GPU interaction.
 
+### `internal/browser/` — Browser WebGPU Backend
+
+Browser WebGPU via `syscall/js` → `navigator.gpu`. Bypasses `core/` and `hal/` entirely — browser validates internally (same W3C spec as our public API). Matches Rust wgpu's `backend/webgpu.rs` top-level bypass architecture.
+
+```
+wgpu public API
+  ├── [native]  core/ → hal/ → Vulkan/Metal/DX12/GLES/Software
+  └── [browser] internal/browser/ → syscall/js → navigator.gpu
+```
+
+- Build tags: `//go:build js && wasm` on all browser files
+- Root `*_browser.go` files are thin wrappers delegating to `internal/browser/`
+- Pre-bound JS methods (Ebiten pattern): `method.Call("bind", obj)` at construction, avoiding `.Get()` on hot paths
+- Promise→goroutine: `AwaitPromise()` blocks via `Promise.then/catch` + channel
+- Data transfer: `js.CopyBytesToGo`/`js.CopyBytesToJS` for GPU↔CPU
+- Shaders: WGSL string passthrough to browser `createShaderModule()` — no naga on browser path
+- Surface: HTML Canvas + `GPUCanvasContext`, present is no-op (browser auto-presents)
+- ~6500 LOC total (4000 internal/browser + 2500 root wrappers), zero external dependencies
+
+Key files: `promise.go` (async→sync), `convert_enums.go` (97 TextureFormats, 31 VertexFormats + all WebGPU enums), `convert_resources.go` (JS descriptor builders), `surface.go` (Canvas + GPUCanvasContext).
+
 ## Backend Registration
 
 Backends register via `init()` functions. Import `hal/allbackends` to auto-register platform-appropriate backends:
@@ -261,5 +281,6 @@ gogpu (app framework) / gg (2D graphics)
 
 External dependencies:
 - `github.com/gogpu/naga` — shader compiler (WGSL → SPIR-V / MSL / GLSL / HLSL / DXIL), Pure Go
-- `github.com/gogpu/gputypes` v0.4.0 — shared WebGPU type definitions
-- `github.com/go-webgpu/goffi` v0.5.0 — Pure Go FFI for Vulkan/Metal symbol loading
+- `github.com/gogpu/gputypes` v0.5.0 — shared WebGPU type definitions
+- `github.com/go-webgpu/goffi` v0.5.1 — Pure Go FFI for Vulkan/Metal symbol loading
+- `golang.org/x/sys` v0.44.0 — platform syscall definitions

--- a/docs/COMPUTE-BACKENDS.md
+++ b/docs/COMPUTE-BACKENDS.md
@@ -4,15 +4,15 @@ This document describes compute shader support across wgpu's HAL backends.
 
 ## Support Matrix
 
-| Feature | Vulkan | DX12 | Metal | GLES | Software | Noop |
-|---------|:------:|:----:|:-----:|:----:|:--------:|:----:|
-| Compute shaders | Yes | Yes | Yes | Partial | Yes (interpreted) | No |
-| Storage buffers | Yes | Yes | Yes | Yes | Yes (interpreted) | No |
-| Timestamp queries | Yes | Yes | Stub | Stub | No | No |
-| Indirect dispatch | Yes | Yes | Yes | Yes | No | No |
-| Buffer mapping (GPU->CPU) | Yes | Yes | Yes | Yes | Yes | No |
-| Max workgroup size X | 1024+ | 1024 | 1024 | 1024 | 1024 | N/A |
-| Max workgroup invocations | 1024+ | 1024 | 1024 | 1024 | 1024 | N/A |
+| Feature | Vulkan | DX12 | Metal | GLES | Software | Browser | Noop |
+|---------|:------:|:----:|:-----:|:----:|:--------:|:-------:|:----:|
+| Compute shaders | Yes | Yes | Yes | Partial | Yes (interpreted) | Yes | No |
+| Storage buffers | Yes | Yes | Yes | Yes | Yes (interpreted) | Yes | No |
+| Timestamp queries | Yes | Yes | Stub | Stub | No | No | No |
+| Indirect dispatch | Yes | Yes | Yes | Yes | No | Yes | No |
+| Buffer mapping (GPU->CPU) | Yes | Yes | Yes | Yes | Yes | Yes | No |
+| Max workgroup size X | 1024+ | 1024 | 1024 | 1024 | 1024 | Browser | N/A |
+| Max workgroup invocations | 1024+ | 1024 | 1024 | 1024 | 1024 | Browser | N/A |
 
 ## Vulkan
 
@@ -98,6 +98,25 @@ The software backend executes compute shaders on CPU through a built-in SPIR-V i
 
 `wgpu/examples/software-test/` — 256-element scaled-copy compute shader, all values match.
 `gogpu/examples/particles/` — 4096-particle orbital simulation (compute + instanced render).
+
+## Browser WebGPU Backend
+
+**Status:** Full compute support via browser WebGPU API.
+
+The browser backend delegates compute operations directly to the browser's WebGPU implementation via `syscall/js`. No shader compilation in Go — WGSL is passed as a string to `createShaderModule()`.
+
+- **Shader compilation:** Browser handles WGSL compilation internally.
+- **Storage buffers:** Full support via browser `GPUBuffer`.
+- **Timestamp queries:** Not yet wired (browser support varies).
+- **Indirect dispatch:** `dispatchWorkgroupsIndirect` via `syscall/js`.
+- **Buffer mapping:** `mapAsync` + `getMappedRange` → `js.CopyBytesToGo`.
+- **Workgroup limits:** Determined by browser/GPU combination.
+
+### Browser-Specific Notes
+
+- All compute passes are recorded and submitted like native — `beginComputePass`, `setPipeline`, `setBindGroup`, `dispatchWorkgroups`, `end`, `queue.submit`.
+- Data transfer uses `js.CopyBytesToJS`/`js.CopyBytesToGo` for crossing the JS/WASM boundary.
+- Build: `GOOS=js GOARCH=wasm go build`.
 
 ## Noop Backend
 

--- a/encoder_browser.go
+++ b/encoder_browser.go
@@ -2,39 +2,108 @@
 
 package wgpu
 
+import (
+	"syscall/js"
+
+	"github.com/gogpu/wgpu/internal/browser"
+)
+
 // CommandEncoder records GPU commands for later submission.
+// On browser, this wraps a GPUCommandEncoder via internal/browser.CommandEncoder.
 type CommandEncoder struct {
+	browser  *browser.CommandEncoder
 	released bool
 }
 
 // BeginRenderPass begins a render pass.
 func (e *CommandEncoder) BeginRenderPass(desc *RenderPassDescriptor) (*RenderPassEncoder, error) {
-	panic("wgpu: browser backend not yet implemented")
+	if e.released {
+		return nil, ErrReleased
+	}
+	jsDesc := buildRenderPassDescriptorJS(desc)
+	bp := e.browser.BeginRenderPass(jsDesc)
+	return &RenderPassEncoder{
+		browser:  bp,
+		released: false,
+	}, nil
 }
 
 // BeginComputePass begins a compute pass.
 func (e *CommandEncoder) BeginComputePass(desc *ComputePassDescriptor) (*ComputePassEncoder, error) {
-	panic("wgpu: browser backend not yet implemented")
+	if e.released {
+		return nil, ErrReleased
+	}
+	label := ""
+	if desc != nil {
+		label = desc.Label
+	}
+	jsDesc := browser.BuildComputePassDescriptor(label)
+	bp := e.browser.BeginComputePass(jsDesc)
+	return &ComputePassEncoder{
+		browser:  bp,
+		released: false,
+	}, nil
 }
 
 // CopyBufferToBuffer copies data between buffers.
 func (e *CommandEncoder) CopyBufferToBuffer(src *Buffer, srcOffset uint64, dst *Buffer, dstOffset uint64, size uint64) {
-	panic("wgpu: browser backend not yet implemented")
+	if e.released || src == nil || dst == nil {
+		return
+	}
+	e.browser.CopyBufferToBuffer(
+		src.browser.Ref(), srcOffset,
+		dst.browser.Ref(), dstOffset,
+		size,
+	)
 }
 
 // CopyTextureToBuffer copies data from a texture to a buffer.
 func (e *CommandEncoder) CopyTextureToBuffer(src *Texture, dst *Buffer, regions []BufferTextureCopy) {
-	panic("wgpu: browser backend not yet implemented")
+	if e.released || src == nil || dst == nil {
+		return
+	}
+	for _, r := range regions {
+		srcObj := browser.BuildImageCopyTexture(
+			src.browser.Ref(),
+			r.TextureBase.MipLevel,
+			r.TextureBase.Origin.X, r.TextureBase.Origin.Y, r.TextureBase.Origin.Z,
+		)
+		dstObj := browser.BuildImageCopyBuffer(
+			dst.browser.Ref(),
+			r.BufferLayout.Offset,
+			r.BufferLayout.BytesPerRow,
+			r.BufferLayout.RowsPerImage,
+		)
+		sizeObj := browser.BuildExtent3D(r.Size.Width, r.Size.Height, r.Size.DepthOrArrayLayers)
+		e.browser.CopyTextureToBuffer(srcObj, dstObj, sizeObj)
+	}
 }
 
 // CopyTextureToTexture copies data between textures.
 func (e *CommandEncoder) CopyTextureToTexture(src, dst *Texture, regions []TextureCopy) {
-	panic("wgpu: browser backend not yet implemented")
+	if e.released || src == nil || dst == nil {
+		return
+	}
+	for _, r := range regions {
+		srcObj := browser.BuildImageCopyTexture(
+			src.browser.Ref(),
+			r.Source.MipLevel,
+			r.Source.Origin.X, r.Source.Origin.Y, r.Source.Origin.Z,
+		)
+		dstObj := browser.BuildImageCopyTexture(
+			dst.browser.Ref(),
+			r.Destination.MipLevel,
+			r.Destination.Origin.X, r.Destination.Origin.Y, r.Destination.Origin.Z,
+		)
+		sizeObj := browser.BuildExtent3D(r.Size.Width, r.Size.Height, r.Size.DepthOrArrayLayers)
+		e.browser.CopyTextureToTexture(srcObj, dstObj, sizeObj)
+	}
 }
 
 // TransitionTextures transitions texture states for synchronization.
+// On browser, this is a no-op — the browser WebGPU API handles barriers internally.
 func (e *CommandEncoder) TransitionTextures(barriers []TextureBarrier) {
-	panic("wgpu: browser backend not yet implemented")
+	// No-op: browser WebGPU manages resource state transitions automatically.
 }
 
 // DiscardEncoding discards the encoder without producing a command buffer.
@@ -43,18 +112,86 @@ func (e *CommandEncoder) DiscardEncoding() {
 		return
 	}
 	e.released = true
+	// Browser GC handles cleanup of the underlying GPUCommandEncoder.
 }
 
 // Finish completes command recording and returns a CommandBuffer.
 func (e *CommandEncoder) Finish() (*CommandBuffer, error) {
-	panic("wgpu: browser backend not yet implemented")
+	if e.released {
+		return nil, ErrReleased
+	}
+	e.released = true
+	bcb := e.browser.Finish(js.Undefined())
+	return &CommandBuffer{
+		browser:  bcb,
+		released: false,
+	}, nil
 }
 
 // CommandBuffer holds recorded GPU commands ready for submission.
+// On browser, this wraps a GPUCommandBuffer via internal/browser.CommandBuffer.
 type CommandBuffer struct {
+	browser  *browser.CommandBuffer
 	released bool
 }
 
 // Release releases a CommandBuffer that will NOT be submitted to the GPU.
 func (cb *CommandBuffer) Release() {
+	if cb.released {
+		return
+	}
+	cb.released = true
+	// Browser GC handles cleanup.
+}
+
+// --- Render pass descriptor conversion ---
+
+// buildRenderPassDescriptorJS converts a Go RenderPassDescriptor to a JS object
+// via the internal/browser conversion helpers.
+func buildRenderPassDescriptorJS(desc *RenderPassDescriptor) js.Value {
+	colorAttachments := make([]browser.RenderPassColorAttachmentJS, len(desc.ColorAttachments))
+	for i, ca := range desc.ColorAttachments {
+		att := browser.RenderPassColorAttachmentJS{
+			LoadOp:  browser.LoadOpToJS(ca.LoadOp),
+			StoreOp: browser.StoreOpToJS(ca.StoreOp),
+			ClearR:  ca.ClearValue.R,
+			ClearG:  ca.ClearValue.G,
+			ClearB:  ca.ClearValue.B,
+			ClearA:  ca.ClearValue.A,
+		}
+		if ca.View != nil && ca.View.browser != nil {
+			att.View = ca.View.browser.Ref()
+		} else {
+			att.View = js.Undefined()
+		}
+		if ca.ResolveTarget != nil && ca.ResolveTarget.browser != nil {
+			att.ResolveTarget = ca.ResolveTarget.browser.Ref()
+		} else {
+			att.ResolveTarget = js.Undefined()
+		}
+		colorAttachments[i] = att
+	}
+
+	var depthStencil *browser.RenderPassDepthStencilAttachmentJS
+	if desc.DepthStencilAttachment != nil {
+		dsa := desc.DepthStencilAttachment
+		ds := &browser.RenderPassDepthStencilAttachmentJS{
+			DepthLoadOp:       browser.LoadOpToJS(dsa.DepthLoadOp),
+			DepthStoreOp:      browser.StoreOpToJS(dsa.DepthStoreOp),
+			DepthClearValue:   dsa.DepthClearValue,
+			DepthReadOnly:     dsa.DepthReadOnly,
+			StencilLoadOp:     browser.LoadOpToJS(dsa.StencilLoadOp),
+			StencilStoreOp:    browser.StoreOpToJS(dsa.StencilStoreOp),
+			StencilClearValue: dsa.StencilClearValue,
+			StencilReadOnly:   dsa.StencilReadOnly,
+		}
+		if dsa.View != nil && dsa.View.browser != nil {
+			ds.View = dsa.View.browser.Ref()
+		} else {
+			ds.View = js.Undefined()
+		}
+		depthStencil = ds
+	}
+
+	return browser.BuildRenderPassDescriptor(desc.Label, colorAttachments, depthStencil)
 }

--- a/encoder_browser.go
+++ b/encoder_browser.go
@@ -57,6 +57,36 @@ func (e *CommandEncoder) CopyBufferToBuffer(src *Buffer, srcOffset uint64, dst *
 	)
 }
 
+// CopyBufferToTexture copies data from a buffer to a texture.
+func (e *CommandEncoder) CopyBufferToTexture(src *Buffer, dst *Texture, regions []BufferTextureCopy) {
+	if e.released || src == nil || dst == nil {
+		return
+	}
+	for _, r := range regions {
+		srcObj := browser.BuildImageCopyBuffer(
+			src.browser.Ref(),
+			r.BufferLayout.Offset,
+			r.BufferLayout.BytesPerRow,
+			r.BufferLayout.RowsPerImage,
+		)
+		dstObj := browser.BuildImageCopyTexture(
+			dst.browser.Ref(),
+			r.TextureBase.MipLevel,
+			r.TextureBase.Origin.X, r.TextureBase.Origin.Y, r.TextureBase.Origin.Z,
+		)
+		sizeObj := browser.BuildExtent3D(r.Size.Width, r.Size.Height, r.Size.DepthOrArrayLayers)
+		e.browser.CopyBufferToTexture(srcObj, dstObj, sizeObj)
+	}
+}
+
+// ClearBuffer clears a buffer region to zero.
+func (e *CommandEncoder) ClearBuffer(buffer *Buffer, offset, size uint64) {
+	if e.released || buffer == nil {
+		return
+	}
+	e.browser.ClearBuffer(buffer.browser.Ref(), offset, size)
+}
+
 // CopyTextureToBuffer copies data from a texture to a buffer.
 func (e *CommandEncoder) CopyTextureToBuffer(src *Texture, dst *Buffer, regions []BufferTextureCopy) {
 	if e.released || src == nil || dst == nil {

--- a/fence_browser.go
+++ b/fence_browser.go
@@ -3,7 +3,8 @@
 package wgpu
 
 // Fence is a GPU synchronization primitive.
-// On browser, fences are not needed (browser auto-polls).
+// On browser, fences are no-ops — the browser auto-polls GPU completion
+// via its internal event loop. This type exists for API compatibility.
 type Fence struct {
 	released bool
 }

--- a/instance_browser.go
+++ b/instance_browser.go
@@ -70,11 +70,7 @@ func (i *Instance) RequestAdapter(opts *RequestAdapterOptions) (*Adapter, error)
 	}, nil
 }
 
-// CreateSurface creates a rendering surface from platform-specific handles.
-// Phase 4 — not yet implemented for browser.
-func (i *Instance) CreateSurface(displayHandle, windowHandle uintptr) (*Surface, error) {
-	panic("wgpu: browser CreateSurface not yet implemented (Phase 4)")
-}
+// CreateSurface and CreateSurfaceFromCanvas are defined in surface_browser.go.
 
 // Release releases the instance and all associated resources.
 func (i *Instance) Release() {

--- a/instance_browser.go
+++ b/instance_browser.go
@@ -2,6 +2,12 @@
 
 package wgpu
 
+import (
+	"syscall/js"
+
+	"github.com/gogpu/wgpu/internal/browser"
+)
+
 // InstanceDescriptor configures instance creation.
 type InstanceDescriptor struct {
 	Backends Backends
@@ -9,23 +15,65 @@ type InstanceDescriptor struct {
 }
 
 // Instance is the entry point for GPU operations.
+// On browser, this wraps navigator.gpu via internal/browser.Instance.
 type Instance struct {
+	browser  *browser.Instance
 	released bool
 }
 
 // CreateInstance creates a new GPU instance.
+// On browser, this accesses navigator.gpu. The desc parameter is accepted
+// for API compatibility but Backends/Flags are ignored (browser has one backend).
 func CreateInstance(desc *InstanceDescriptor) (*Instance, error) {
-	panic("wgpu: browser backend not yet implemented")
+	bi, err := browser.NewInstance()
+	if err != nil {
+		return nil, err
+	}
+	return &Instance{browser: bi}, nil
 }
 
 // RequestAdapter requests a GPU adapter matching the options.
+// If opts is nil, the best available adapter is returned.
 func (i *Instance) RequestAdapter(opts *RequestAdapterOptions) (*Adapter, error) {
-	panic("wgpu: browser backend not yet implemented")
+	if i.released {
+		return nil, ErrReleased
+	}
+
+	// Build JS options object from Go types.
+	var jsOpts js.Value
+	if opts != nil {
+		jsOpts = browser.BuildRequestAdapterOptions(opts.PowerPreference, opts.ForceFallbackAdapter)
+	} else {
+		jsOpts = js.Undefined()
+	}
+
+	ba, err := i.browser.RequestAdapter(jsOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract features and limits from the JS adapter.
+	features := browser.ExtractFeatures(ba.Features())
+	limits := browser.ExtractLimits(ba.Limits())
+
+	// WebGPU browser API does not expose detailed adapter info.
+	// Return minimal info matching Rust wgpu's WebAdapter::get_info().
+	info := AdapterInfo{
+		Name: "WebGPU Adapter",
+	}
+
+	return &Adapter{
+		browser:  ba,
+		info:     info,
+		features: features,
+		limits:   limits,
+	}, nil
 }
 
 // CreateSurface creates a rendering surface from platform-specific handles.
+// Phase 4 — not yet implemented for browser.
 func (i *Instance) CreateSurface(displayHandle, windowHandle uintptr) (*Surface, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser CreateSurface not yet implemented (Phase 4)")
 }
 
 // Release releases the instance and all associated resources.

--- a/internal/browser/adapter.go
+++ b/internal/browser/adapter.go
@@ -1,0 +1,77 @@
+//go:build js && wasm
+
+package browser
+
+import (
+	"fmt"
+	"syscall/js"
+)
+
+// Adapter wraps a browser GPUAdapter.
+//
+// Matches Rust wgpu WebAdapter which holds the webgpu_sys::GpuAdapter inner value
+// and pre-caches features/limits at construction time.
+type Adapter struct {
+	// ref_ is the GPUAdapter JavaScript object.
+	ref_ js.Value
+
+	// features is the cached GPUSupportedFeatures set.
+	features js.Value
+
+	// limits is the cached GPUSupportedLimits object.
+	limits js.Value
+}
+
+// newAdapter constructs an Adapter from a GPUAdapter js.Value.
+// Pre-caches features and limits to avoid repeated property lookups.
+func newAdapter(ref js.Value) *Adapter {
+	return &Adapter{
+		ref_:     ref,
+		features: ref.Get("features"),
+		limits:   ref.Get("limits"),
+	}
+}
+
+// RequestDevice requests a logical device from this adapter.
+//
+// The descriptor parameter is a JS object matching GPUDeviceDescriptor
+// (built by convert.go helpers). Pass js.Undefined() for default device.
+//
+// Matches Rust wgpu WebAdapter::request_device which calls
+// inner.request_device_with_descriptor and awaits the promise.
+func (a *Adapter) RequestDevice(descriptor js.Value) (*Device, error) {
+	var promise js.Value
+	if descriptor.IsUndefined() || descriptor.IsNull() {
+		promise = a.ref_.Call("requestDevice")
+	} else {
+		promise = a.ref_.Call("requestDevice", descriptor)
+	}
+
+	result, err := AwaitPromise(promise)
+	if err != nil {
+		return nil, fmt.Errorf("requestDevice: %w", err)
+	}
+
+	if result.IsNull() || result.IsUndefined() {
+		return nil, ErrDeviceCreationFailed
+	}
+
+	return NewDevice(result), nil
+}
+
+// Features returns the cached GPUSupportedFeatures js.Value.
+// Use convert.ExtractFeatures to convert to gputypes.Features.
+func (a *Adapter) Features() js.Value {
+	return a.features
+}
+
+// Limits returns the cached GPUSupportedLimits js.Value.
+// Use convert.ExtractLimits to convert to gputypes.Limits.
+func (a *Adapter) Limits() js.Value {
+	return a.limits
+}
+
+// Ref returns the underlying GPUAdapter js.Value.
+func (a *Adapter) Ref() js.Value {
+	return a.ref_
+}

--- a/internal/browser/bind.go
+++ b/internal/browser/bind.go
@@ -1,0 +1,47 @@
+//go:build js && wasm
+
+package browser
+
+import "syscall/js"
+
+// BindGroupLayout wraps a browser GPUBindGroupLayout.
+type BindGroupLayout struct {
+	// ref_ is the GPUBindGroupLayout JavaScript object.
+	ref_ js.Value
+}
+
+// NewBindGroupLayout constructs a BindGroupLayout from a GPUBindGroupLayout js.Value.
+func NewBindGroupLayout(ref js.Value) *BindGroupLayout {
+	return &BindGroupLayout{ref_: ref}
+}
+
+// Ref returns the underlying GPUBindGroupLayout js.Value.
+func (l *BindGroupLayout) Ref() js.Value { return l.ref_ }
+
+// BindGroup wraps a browser GPUBindGroup.
+type BindGroup struct {
+	// ref_ is the GPUBindGroup JavaScript object.
+	ref_ js.Value
+}
+
+// NewBindGroup constructs a BindGroup from a GPUBindGroup js.Value.
+func NewBindGroup(ref js.Value) *BindGroup {
+	return &BindGroup{ref_: ref}
+}
+
+// Ref returns the underlying GPUBindGroup js.Value.
+func (g *BindGroup) Ref() js.Value { return g.ref_ }
+
+// PipelineLayout wraps a browser GPUPipelineLayout.
+type PipelineLayout struct {
+	// ref_ is the GPUPipelineLayout JavaScript object.
+	ref_ js.Value
+}
+
+// NewPipelineLayout constructs a PipelineLayout from a GPUPipelineLayout js.Value.
+func NewPipelineLayout(ref js.Value) *PipelineLayout {
+	return &PipelineLayout{ref_: ref}
+}
+
+// Ref returns the underlying GPUPipelineLayout js.Value.
+func (l *PipelineLayout) Ref() js.Value { return l.ref_ }

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1,0 +1,27 @@
+//go:build js && wasm
+
+// Package browser implements the WebGPU backend for browsers using syscall/js.
+//
+// This package delegates all GPU operations to the browser's native WebGPU API
+// (navigator.gpu) via JavaScript interop. It is only compiled on GOOS=js GOARCH=wasm.
+//
+// Architecture: each Go type (Instance, Adapter, Device, Queue) wraps a js.Value
+// reference to the corresponding GPUInstance / GPUAdapter / GPUDevice / GPUQueue
+// JavaScript object. Methods are pre-bound at construction time to avoid repeated
+// property lookups on the hot path (Ebiten pattern).
+//
+// No core/ or hal/ packages are used — the browser validates GPU operations itself.
+package browser
+
+import "syscall/js"
+
+// GPUAvailable reports whether the browser supports WebGPU.
+// It checks for the existence of navigator.gpu.
+func GPUAvailable() bool {
+	navigator := js.Global().Get("navigator")
+	if navigator.IsUndefined() || navigator.IsNull() {
+		return false
+	}
+	gpu := navigator.Get("gpu")
+	return !gpu.IsUndefined() && !gpu.IsNull()
+}

--- a/internal/browser/buffer.go
+++ b/internal/browser/buffer.go
@@ -2,12 +2,19 @@
 
 package browser
 
-import "syscall/js"
+import (
+	"fmt"
+	"syscall/js"
+)
 
-// Buffer wraps a browser GPUBuffer.
+// Buffer wraps a browser GPUBuffer with mapping state tracking.
 //
 // Holds a reference to the JavaScript GPUBuffer object and caches the size
-// to avoid repeated JS property lookups.
+// to avoid repeated JS property lookups. Tracks the mapped ArrayBuffer
+// so that multiple Go-side GetMappedRange calls reuse a single JS mapping,
+// matching the Rust wgpu WebBuffer/WebBufferMapState pattern -- the WebGPU
+// spec forbids calling GPUBuffer.getMappedRange more than once for the same
+// mapped region.
 type Buffer struct {
 	// ref_ is the GPUBuffer JavaScript object.
 	ref_ js.Value
@@ -17,6 +24,19 @@ type Buffer struct {
 
 	// usage is the buffer's usage flags, cached at creation time.
 	usage uint32
+
+	// mappedBuffer is the cached JS ArrayBuffer from getMappedRange.
+	// Nil (zero Value) when the buffer is not mapped. The WebGPU spec
+	// forbids calling getMappedRange on a GPUBuffer more than once, so
+	// we cache the result and create sub-range Uint8Array views into it.
+	// Matches Rust wgpu WebBufferMapState.mapped_buffer.
+	mappedBuffer js.Value
+
+	// mappedOffset is the start of the overall mapped range.
+	mappedOffset uint64
+
+	// mappedSize is the length of the overall mapped range.
+	mappedSize uint64
 }
 
 // NewBuffer constructs a Buffer from a GPUBuffer js.Value.
@@ -39,19 +59,98 @@ func (b *Buffer) Usage() uint32 { return b.usage }
 
 // Destroy calls GPUBuffer.destroy() to release GPU memory.
 func (b *Buffer) Destroy() {
+	b.mappedBuffer = js.Value{}
 	destroy := b.ref_.Get("destroy")
 	if !destroy.IsUndefined() && !destroy.IsNull() {
 		b.ref_.Call("destroy")
 	}
 }
 
-// GetMappedRange returns a JS ArrayBuffer covering [offset, offset+size)
-// of the mapped buffer. Must be called while the buffer is mapped.
-func (b *Buffer) GetMappedRange(offset, size uint64) js.Value {
-	return b.ref_.Call("getMappedRange", float64(offset), float64(size))
+// MapAsync maps the buffer for CPU access by calling GPUBuffer.mapAsync(mode, offset, size).
+// Blocks the calling goroutine until the JS Promise resolves or rejects.
+//
+// mode uses WebGPU GPUMapMode flags: 1 = MAP_READ, 2 = MAP_WRITE.
+// The caller MUST be on a goroutine (not the main goroutine) or the program
+// will deadlock, because AwaitPromise yields via a channel.
+//
+// On success the mapped range is recorded so that subsequent GetMappedRangeBytes
+// calls can cache the JS ArrayBuffer (matching Rust wgpu WebBuffer.set_mapped_range).
+func (b *Buffer) MapAsync(mode uint32, offset, size uint64) error {
+	promise := b.ref_.Call("mapAsync", mode, float64(offset), float64(size))
+	_, err := AwaitPromise(promise)
+	if err != nil {
+		return fmt.Errorf("GPUBuffer.mapAsync: %w", err)
+	}
+	// Record the mapped range so GetMappedRangeBytes can lazily fetch
+	// the ArrayBuffer on the first call (Rust wgpu set_mapped_range).
+	b.mappedOffset = offset
+	b.mappedSize = size
+	return nil
 }
 
-// Unmap unmaps the buffer, making its mapped ranges invalid.
+// ensureMappedBuffer lazily calls GPUBuffer.getMappedRange once for the
+// entire mapped region and caches the result. Subsequent calls to
+// GetMappedRangeBytes create Uint8Array views into this cached ArrayBuffer
+// without additional JS interop. Matches Rust wgpu WebBuffer.get_mapped_range
+// which calls get_mapped_range_with_f64_and_f64 once and then creates
+// Uint8Array views with byte_offset + length.
+func (b *Buffer) ensureMappedBuffer() js.Value {
+	if b.mappedBuffer.IsUndefined() || b.mappedBuffer.IsNull() || b.mappedBuffer.Equal(js.Value{}) {
+		b.mappedBuffer = b.ref_.Call("getMappedRange", float64(b.mappedOffset), float64(b.mappedSize))
+	}
+	return b.mappedBuffer
+}
+
+// GetMappedRangeBytes copies bytes from the mapped region [offset, offset+size) into
+// a new Go byte slice. The buffer must be in the mapped state (MapAsync resolved or
+// the buffer was created with mappedAtCreation: true).
+//
+// Internally this obtains a Uint8Array view into the cached ArrayBuffer at the
+// correct sub-range offset, then uses js.CopyBytesToGo to transfer data.
+// Matches Rust wgpu WebBufferMappedRange which copies from JS to Rust/WASM heap.
+func (b *Buffer) GetMappedRangeBytes(offset, size uint64) ([]byte, error) {
+	ab := b.ensureMappedBuffer()
+
+	// Create a Uint8Array view at the sub-range offset within the cached
+	// ArrayBuffer. The sub-range offset is relative to mappedOffset.
+	byteOffset := offset - b.mappedOffset
+	view := js.Global().Get("Uint8Array").New(ab, int(byteOffset), int(size)) //nolint:gosec // validated by caller
+	data := make([]byte, size)
+	js.CopyBytesToGo(data, view)
+	return data, nil
+}
+
+// WriteMappedRange writes data into the mapped buffer at [offset, offset+len(data)).
+// The buffer must be mapped with MAP_WRITE mode (or created with mappedAtCreation).
+//
+// Internally creates a Uint8Array view into the cached ArrayBuffer and uses
+// js.CopyBytesToJS to transfer data from Go to JS. On Unmap the browser flushes
+// the written data to the GPU.
+// Matches Rust wgpu WebBufferMappedRange.slice_mut + Drop write-back pattern.
+func (b *Buffer) WriteMappedRange(offset uint64, data []byte) error {
+	ab := b.ensureMappedBuffer()
+
+	byteOffset := offset - b.mappedOffset
+	view := js.Global().Get("Uint8Array").New(ab, int(byteOffset), len(data)) //nolint:gosec // validated by caller
+	js.CopyBytesToJS(view, data)
+	return nil
+}
+
+// SetMappedAtCreation records the mapped range for a buffer created with
+// mappedAtCreation: true. The entire buffer [0, size) is mapped. This must
+// be called immediately after NewBuffer for mappedAtCreation buffers so that
+// GetMappedRangeBytes / WriteMappedRange work correctly.
+func (b *Buffer) SetMappedAtCreation() {
+	b.mappedOffset = 0
+	b.mappedSize = b.size
+}
+
+// Unmap unmaps the buffer, making its mapped ranges invalid, and clears the
+// cached ArrayBuffer. Matches Rust wgpu WebBuffer.unmap which calls
+// inner.unmap() and sets mapped_buffer = None.
 func (b *Buffer) Unmap() {
 	b.ref_.Call("unmap")
+	b.mappedBuffer = js.Value{}
+	b.mappedOffset = 0
+	b.mappedSize = 0
 }

--- a/internal/browser/buffer.go
+++ b/internal/browser/buffer.go
@@ -1,0 +1,57 @@
+//go:build js && wasm
+
+package browser
+
+import "syscall/js"
+
+// Buffer wraps a browser GPUBuffer.
+//
+// Holds a reference to the JavaScript GPUBuffer object and caches the size
+// to avoid repeated JS property lookups.
+type Buffer struct {
+	// ref_ is the GPUBuffer JavaScript object.
+	ref_ js.Value
+
+	// size is the buffer's byte size, cached at creation time.
+	size uint64
+
+	// usage is the buffer's usage flags, cached at creation time.
+	usage uint32
+}
+
+// NewBuffer constructs a Buffer from a GPUBuffer js.Value.
+func NewBuffer(ref js.Value) *Buffer {
+	return &Buffer{
+		ref_:  ref,
+		size:  uint64(ref.Get("size").Float()), //nolint:gosec // JS API returns safe integers
+		usage: uint32(ref.Get("usage").Int()),  //nolint:gosec // JS API returns safe integers
+	}
+}
+
+// Ref returns the underlying GPUBuffer js.Value.
+func (b *Buffer) Ref() js.Value { return b.ref_ }
+
+// Size returns the buffer size in bytes.
+func (b *Buffer) Size() uint64 { return b.size }
+
+// Usage returns the buffer usage flags.
+func (b *Buffer) Usage() uint32 { return b.usage }
+
+// Destroy calls GPUBuffer.destroy() to release GPU memory.
+func (b *Buffer) Destroy() {
+	destroy := b.ref_.Get("destroy")
+	if !destroy.IsUndefined() && !destroy.IsNull() {
+		b.ref_.Call("destroy")
+	}
+}
+
+// GetMappedRange returns a JS ArrayBuffer covering [offset, offset+size)
+// of the mapped buffer. Must be called while the buffer is mapped.
+func (b *Buffer) GetMappedRange(offset, size uint64) js.Value {
+	return b.ref_.Call("getMappedRange", float64(offset), float64(size))
+}
+
+// Unmap unmaps the buffer, making its mapped ranges invalid.
+func (b *Buffer) Unmap() {
+	b.ref_.Call("unmap")
+}

--- a/internal/browser/computepass.go
+++ b/internal/browser/computepass.go
@@ -1,0 +1,78 @@
+//go:build js && wasm
+
+package browser
+
+import "syscall/js"
+
+// ComputePassEncoder wraps a browser GPUComputePassEncoder with pre-bound methods.
+//
+// Pre-binding JS methods at construction time avoids repeated property lookups
+// during compute dispatch. Matches Rust wgpu WebComputePassEncoder which holds
+// webgpu_sys::GpuComputePassEncoder.
+type ComputePassEncoder struct {
+	// ref_ is the GPUComputePassEncoder JavaScript object.
+	ref_ js.Value
+
+	// Pre-bound methods for compute dispatch.
+	fnSetPipeline        js.Value
+	fnSetBindGroup       js.Value
+	fnDispatchWorkgroups js.Value
+	fnDispatchIndirect   js.Value
+	fnEnd                js.Value
+}
+
+// NewComputePassEncoder constructs a ComputePassEncoder from a
+// GPUComputePassEncoder js.Value. Pre-binds all dispatch and state methods.
+func NewComputePassEncoder(ref js.Value) *ComputePassEncoder {
+	return &ComputePassEncoder{
+		ref_:                 ref,
+		fnSetPipeline:        bindMethod(ref, "setPipeline"),
+		fnSetBindGroup:       bindMethod(ref, "setBindGroup"),
+		fnDispatchWorkgroups: bindMethod(ref, "dispatchWorkgroups"),
+		fnDispatchIndirect:   bindMethod(ref, "dispatchWorkgroupsIndirect"),
+		fnEnd:                bindMethod(ref, "end"),
+	}
+}
+
+// SetPipeline sets the active compute pipeline.
+func (p *ComputePassEncoder) SetPipeline(pipeline js.Value) {
+	p.fnSetPipeline.Invoke(pipeline)
+}
+
+// SetBindGroup sets a bind group at the given index.
+//
+// When dynamicOffsets is non-empty, the offsets are passed as a Uint32Array,
+// matching Rust wgpu's set_bind_group_with_u32_slice_and_f64_and_dynamic_offsets_data_length.
+func (p *ComputePassEncoder) SetBindGroup(index uint32, group js.Value, dynamicOffsets []uint32) {
+	if len(dynamicOffsets) == 0 {
+		p.fnSetBindGroup.Invoke(index, group)
+		return
+	}
+	jsArray := js.Global().Get("Uint32Array").New(len(dynamicOffsets))
+	for i, offset := range dynamicOffsets {
+		jsArray.SetIndex(i, js.ValueOf(offset))
+	}
+	p.fnSetBindGroup.Invoke(index, group, jsArray, 0, len(dynamicOffsets))
+}
+
+// DispatchWorkgroups dispatches compute work.
+// Matches Rust: dispatch_workgroups_with_workgroup_count_y_and_workgroup_count_z.
+func (p *ComputePassEncoder) DispatchWorkgroups(x, y, z uint32) {
+	p.fnDispatchWorkgroups.Invoke(x, y, z)
+}
+
+// DispatchIndirect dispatches compute work with GPU-generated parameters
+// from an indirect buffer.
+func (p *ComputePassEncoder) DispatchIndirect(buffer js.Value, offset uint64) {
+	p.fnDispatchIndirect.Invoke(buffer, float64(offset))
+}
+
+// End ends the compute pass.
+func (p *ComputePassEncoder) End() {
+	p.fnEnd.Invoke()
+}
+
+// Ref returns the underlying GPUComputePassEncoder js.Value.
+func (p *ComputePassEncoder) Ref() js.Value {
+	return p.ref_
+}

--- a/internal/browser/convert.go
+++ b/internal/browser/convert.go
@@ -1,0 +1,242 @@
+//go:build js && wasm
+
+package browser
+
+import (
+	"math"
+	"syscall/js"
+
+	"github.com/gogpu/gputypes"
+)
+
+// PowerPreferenceToJS converts a gputypes.PowerPreference to the JS string
+// expected by GPURequestAdapterOptions.powerPreference.
+//
+// Matches Rust wgpu's map of PowerPreference to GpuPowerPreference.
+func PowerPreferenceToJS(pref gputypes.PowerPreference) string {
+	switch pref {
+	case gputypes.PowerPreferenceLowPower:
+		return "low-power"
+	case gputypes.PowerPreferenceHighPerformance:
+		return "high-performance"
+	default:
+		// PowerPreferenceNone => omit the field (browser uses its default).
+		return ""
+	}
+}
+
+// BuildRequestAdapterOptions constructs a JS GPURequestAdapterOptions object.
+func BuildRequestAdapterOptions(
+	powerPreference gputypes.PowerPreference,
+	forceFallback bool,
+) js.Value {
+	opts := js.Global().Get("Object").New()
+
+	pref := PowerPreferenceToJS(powerPreference)
+	if pref != "" {
+		opts.Set("powerPreference", pref)
+	}
+
+	if forceFallback {
+		opts.Set("forceFallbackAdapter", true)
+	}
+
+	return opts
+}
+
+// BuildDeviceDescriptor constructs a JS GPUDeviceDescriptor object.
+//
+// Matches Rust wgpu WebAdapter::request_device which builds the JS descriptor
+// with requiredFeatures array and requiredLimits object.
+func BuildDeviceDescriptor(
+	label string,
+	requiredFeatures gputypes.Features,
+	requiredLimits gputypes.Limits,
+) js.Value {
+	desc := js.Global().Get("Object").New()
+
+	if label != "" {
+		desc.Set("label", label)
+	}
+
+	// Build requiredFeatures array.
+	features := featuresToJSArray(requiredFeatures)
+	if features.Length() > 0 {
+		desc.Set("requiredFeatures", features)
+	}
+
+	// Build requiredLimits object. Only set non-zero limits to avoid
+	// requesting values the adapter cannot provide.
+	limits := limitsToJSObject(requiredLimits)
+	desc.Set("requiredLimits", limits)
+
+	return desc
+}
+
+// ExtractFeatures reads a GPUSupportedFeatures set and returns gputypes.Features.
+//
+// GPUSupportedFeatures is a Set-like object. We check each known WebGPU feature
+// string using .has(). Matches Rust wgpu's map_wgt_features.
+func ExtractFeatures(supported js.Value) gputypes.Features {
+	if supported.IsUndefined() || supported.IsNull() {
+		return 0
+	}
+
+	var features gputypes.Features
+	for _, mapping := range featuresMappingTable {
+		hasMethod := supported.Get("has")
+		if !hasMethod.IsUndefined() && supported.Call("has", mapping.jsName).Bool() {
+			features.Insert(mapping.feature)
+		}
+	}
+	return features
+}
+
+// ExtractLimits reads a GPUSupportedLimits object and returns gputypes.Limits.
+//
+// GPUSupportedLimits has getter properties for each limit. We read them
+// as float64 (JS numbers) and convert to the appropriate Go integer type.
+// Matches Rust wgpu's map_wgt_limits.
+func ExtractLimits(jsLimits js.Value) gputypes.Limits {
+	if jsLimits.IsUndefined() || jsLimits.IsNull() {
+		return gputypes.DefaultLimits()
+	}
+
+	return gputypes.Limits{
+		MaxTextureDimension1D:                     getUint32(jsLimits, "maxTextureDimension1D"),
+		MaxTextureDimension2D:                     getUint32(jsLimits, "maxTextureDimension2D"),
+		MaxTextureDimension3D:                     getUint32(jsLimits, "maxTextureDimension3D"),
+		MaxTextureArrayLayers:                     getUint32(jsLimits, "maxTextureArrayLayers"),
+		MaxBindGroups:                             getUint32(jsLimits, "maxBindGroups"),
+		MaxBindingsPerBindGroup:                   getUint32(jsLimits, "maxBindingsPerBindGroup"),
+		MaxDynamicUniformBuffersPerPipelineLayout: getUint32(jsLimits, "maxDynamicUniformBuffersPerPipelineLayout"),
+		MaxDynamicStorageBuffersPerPipelineLayout: getUint32(jsLimits, "maxDynamicStorageBuffersPerPipelineLayout"),
+		MaxSampledTexturesPerShaderStage:          getUint32(jsLimits, "maxSampledTexturesPerShaderStage"),
+		MaxSamplersPerShaderStage:                 getUint32(jsLimits, "maxSamplersPerShaderStage"),
+		MaxStorageBuffersPerShaderStage:           getUint32(jsLimits, "maxStorageBuffersPerShaderStage"),
+		MaxStorageTexturesPerShaderStage:          getUint32(jsLimits, "maxStorageTexturesPerShaderStage"),
+		MaxUniformBuffersPerShaderStage:           getUint32(jsLimits, "maxUniformBuffersPerShaderStage"),
+		MaxUniformBufferBindingSize:               getUint64(jsLimits, "maxUniformBufferBindingSize"),
+		MaxStorageBufferBindingSize:               getUint64(jsLimits, "maxStorageBufferBindingSize"),
+		MinUniformBufferOffsetAlignment:           getUint32(jsLimits, "minUniformBufferOffsetAlignment"),
+		MinStorageBufferOffsetAlignment:           getUint32(jsLimits, "minStorageBufferOffsetAlignment"),
+		MaxVertexBuffers:                          getUint32(jsLimits, "maxVertexBuffers"),
+		MaxBufferSize:                             getUint64(jsLimits, "maxBufferSize"),
+		MaxVertexAttributes:                       getUint32(jsLimits, "maxVertexAttributes"),
+		MaxVertexBufferArrayStride:                getUint32(jsLimits, "maxVertexBufferArrayStride"),
+		MaxColorAttachments:                       getUint32(jsLimits, "maxColorAttachments"),
+		MaxColorAttachmentBytesPerSample:          getUint32(jsLimits, "maxColorAttachmentBytesPerSample"),
+		MaxComputeWorkgroupStorageSize:            getUint32(jsLimits, "maxComputeWorkgroupStorageSize"),
+		MaxComputeInvocationsPerWorkgroup:         getUint32(jsLimits, "maxComputeInvocationsPerWorkgroup"),
+		MaxComputeWorkgroupSizeX:                  getUint32(jsLimits, "maxComputeWorkgroupSizeX"),
+		MaxComputeWorkgroupSizeY:                  getUint32(jsLimits, "maxComputeWorkgroupSizeY"),
+		MaxComputeWorkgroupSizeZ:                  getUint32(jsLimits, "maxComputeWorkgroupSizeZ"),
+		MaxComputeWorkgroupsPerDimension:          getUint32(jsLimits, "maxComputeWorkgroupsPerDimension"),
+	}
+}
+
+// featureMapping maps a gputypes.Feature to its WebGPU JS string name.
+type featureMapping struct {
+	feature gputypes.Feature
+	jsName  string
+}
+
+// featuresMappingTable maps Go feature flags to WebGPU JS feature name strings.
+// Matches Rust wgpu's FEATURES_MAPPING constant.
+var featuresMappingTable = []featureMapping{
+	{gputypes.FeatureDepthClipControl, "depth-clip-control"},
+	{gputypes.FeatureDepth32FloatStencil8, "depth32float-stencil8"},
+	{gputypes.FeatureTextureCompressionBC, "texture-compression-bc"},
+	{gputypes.FeatureTextureCompressionETC2, "texture-compression-etc2"},
+	{gputypes.FeatureTextureCompressionASTC, "texture-compression-astc"},
+	{gputypes.FeatureTimestampQuery, "timestamp-query"},
+	{gputypes.FeatureIndirectFirstInstance, "indirect-first-instance"},
+	{gputypes.FeatureShaderF16, "shader-f16"},
+	{gputypes.FeatureRG11B10UfloatRenderable, "rg11b10ufloat-renderable"},
+	{gputypes.FeatureBGRA8UnormStorage, "bgra8unorm-storage"},
+	{gputypes.FeatureFloat32Filterable, "float32-filterable"},
+}
+
+// featuresToJSArray builds a JS Array of feature name strings from Go flags.
+func featuresToJSArray(features gputypes.Features) js.Value {
+	array := js.Global().Get("Array").New()
+	for _, mapping := range featuresMappingTable {
+		if features.Contains(mapping.feature) {
+			array.Call("push", mapping.jsName)
+		}
+	}
+	return array
+}
+
+// limitsToJSObject converts gputypes.Limits to a JS object for GPUDeviceDescriptor.
+// Only non-zero fields are set, matching Rust wgpu's map_js_sys_limits.
+// JS numbers are f64, so uint64 values are sent as f64 per the WebGPU convention.
+func limitsToJSObject(limits gputypes.Limits) js.Value {
+	obj := js.Global().Get("Object").New()
+
+	setNonZeroU32 := func(name string, val uint32) {
+		if val != 0 {
+			obj.Set(name, val)
+		}
+	}
+	setNonZeroU64 := func(name string, val uint64) {
+		if val != 0 {
+			obj.Set(name, float64(val))
+		}
+	}
+
+	setNonZeroU32("maxTextureDimension1D", limits.MaxTextureDimension1D)
+	setNonZeroU32("maxTextureDimension2D", limits.MaxTextureDimension2D)
+	setNonZeroU32("maxTextureDimension3D", limits.MaxTextureDimension3D)
+	setNonZeroU32("maxTextureArrayLayers", limits.MaxTextureArrayLayers)
+	setNonZeroU32("maxBindGroups", limits.MaxBindGroups)
+	setNonZeroU32("maxBindingsPerBindGroup", limits.MaxBindingsPerBindGroup)
+	setNonZeroU32("maxDynamicUniformBuffersPerPipelineLayout", limits.MaxDynamicUniformBuffersPerPipelineLayout)
+	setNonZeroU32("maxDynamicStorageBuffersPerPipelineLayout", limits.MaxDynamicStorageBuffersPerPipelineLayout)
+	setNonZeroU32("maxSampledTexturesPerShaderStage", limits.MaxSampledTexturesPerShaderStage)
+	setNonZeroU32("maxSamplersPerShaderStage", limits.MaxSamplersPerShaderStage)
+	setNonZeroU32("maxStorageBuffersPerShaderStage", limits.MaxStorageBuffersPerShaderStage)
+	setNonZeroU32("maxStorageTexturesPerShaderStage", limits.MaxStorageTexturesPerShaderStage)
+	setNonZeroU32("maxUniformBuffersPerShaderStage", limits.MaxUniformBuffersPerShaderStage)
+	setNonZeroU64("maxUniformBufferBindingSize", limits.MaxUniformBufferBindingSize)
+	setNonZeroU64("maxStorageBufferBindingSize", limits.MaxStorageBufferBindingSize)
+	setNonZeroU32("minUniformBufferOffsetAlignment", limits.MinUniformBufferOffsetAlignment)
+	setNonZeroU32("minStorageBufferOffsetAlignment", limits.MinStorageBufferOffsetAlignment)
+	setNonZeroU32("maxVertexBuffers", limits.MaxVertexBuffers)
+	setNonZeroU64("maxBufferSize", limits.MaxBufferSize)
+	setNonZeroU32("maxVertexAttributes", limits.MaxVertexAttributes)
+	setNonZeroU32("maxVertexBufferArrayStride", limits.MaxVertexBufferArrayStride)
+	setNonZeroU32("maxColorAttachments", limits.MaxColorAttachments)
+	setNonZeroU32("maxColorAttachmentBytesPerSample", limits.MaxColorAttachmentBytesPerSample)
+	setNonZeroU32("maxComputeWorkgroupStorageSize", limits.MaxComputeWorkgroupStorageSize)
+	setNonZeroU32("maxComputeInvocationsPerWorkgroup", limits.MaxComputeInvocationsPerWorkgroup)
+	setNonZeroU32("maxComputeWorkgroupSizeX", limits.MaxComputeWorkgroupSizeX)
+	setNonZeroU32("maxComputeWorkgroupSizeY", limits.MaxComputeWorkgroupSizeY)
+	setNonZeroU32("maxComputeWorkgroupSizeZ", limits.MaxComputeWorkgroupSizeZ)
+	setNonZeroU32("maxComputeWorkgroupsPerDimension", limits.MaxComputeWorkgroupsPerDimension)
+
+	return obj
+}
+
+// getUint32 reads a JS number property as uint32. Returns 0 if missing.
+func getUint32(obj js.Value, name string) uint32 {
+	v := obj.Get(name)
+	if v.IsUndefined() || v.IsNull() {
+		return 0
+	}
+	return uint32(v.Int()) //nolint:gosec // JS API returns safe integers
+}
+
+// getUint64 reads a JS number property as uint64.
+// JS numbers are f64, so values up to 2^53 are exact. Returns 0 if missing.
+func getUint64(obj js.Value, name string) uint64 {
+	v := obj.Get(name)
+	if v.IsUndefined() || v.IsNull() {
+		return 0
+	}
+	f := v.Float()
+	if f < 0 || math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0
+	}
+	return uint64(f) //nolint:gosec // JS API returns safe integers within f64 precision
+}

--- a/internal/browser/convert_command_test.go
+++ b/internal/browser/convert_command_test.go
@@ -1,0 +1,63 @@
+package browser
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+)
+
+// TestLoadOpToJS verifies all load operation mappings.
+func TestLoadOpToJS(t *testing.T) {
+	tests := []struct {
+		op   gputypes.LoadOp
+		want string
+	}{
+		{gputypes.LoadOpClear, "clear"},
+		{gputypes.LoadOpLoad, "load"},
+		{gputypes.LoadOpUndefined, "load"}, // default fallback
+	}
+	for _, tc := range tests {
+		got := LoadOpToJS(tc.op)
+		if got != tc.want {
+			t.Errorf("LoadOpToJS(%v) = %q, want %q", tc.op, got, tc.want)
+		}
+	}
+}
+
+// TestStoreOpToJS verifies all store operation mappings.
+func TestStoreOpToJS(t *testing.T) {
+	tests := []struct {
+		op   gputypes.StoreOp
+		want string
+	}{
+		{gputypes.StoreOpStore, "store"},
+		{gputypes.StoreOpDiscard, "discard"},
+		{gputypes.StoreOpUndefined, "store"}, // default fallback
+	}
+	for _, tc := range tests {
+		got := StoreOpToJS(tc.op)
+		if got != tc.want {
+			t.Errorf("StoreOpToJS(%v) = %q, want %q", tc.op, got, tc.want)
+		}
+	}
+}
+
+// TestLoadOpStoreOpRoundTrip verifies that every non-undefined load/store op
+// produces a non-empty string, preventing silent empty-string bugs at runtime.
+func TestLoadOpStoreOpRoundTrip(t *testing.T) {
+	loadOps := []gputypes.LoadOp{gputypes.LoadOpLoad, gputypes.LoadOpClear}
+	for _, op := range loadOps {
+		s := LoadOpToJS(op)
+		if s == "" {
+			t.Errorf("LoadOpToJS(%v) returned empty string — missing mapping", op)
+		}
+	}
+
+	storeOps := []gputypes.StoreOp{gputypes.StoreOpStore, gputypes.StoreOpDiscard}
+	for _, op := range storeOps {
+		s := StoreOpToJS(op)
+		if s == "" {
+			t.Errorf("StoreOpToJS(%v) returned empty string — missing mapping", op)
+		}
+	}
+}

--- a/internal/browser/convert_enums.go
+++ b/internal/browser/convert_enums.go
@@ -1,0 +1,471 @@
+package browser
+
+import "github.com/gogpu/gputypes"
+
+// TextureFormatToJS converts a gputypes.TextureFormat to the WebGPU JS string.
+// Returns "" for TextureFormatUndefined.
+func TextureFormatToJS(f gputypes.TextureFormat) string {
+	s, ok := textureFormatMap[f]
+	if ok {
+		return s
+	}
+	return ""
+}
+
+// textureFormatMap maps gputypes texture format constants to WebGPU JS string names.
+// Covers all formats defined in the WebGPU specification.
+var textureFormatMap = map[gputypes.TextureFormat]string{
+	// 8-bit
+	gputypes.TextureFormatR8Unorm: "r8unorm",
+	gputypes.TextureFormatR8Snorm: "r8snorm",
+	gputypes.TextureFormatR8Uint:  "r8uint",
+	gputypes.TextureFormatR8Sint:  "r8sint",
+
+	// 16-bit
+	gputypes.TextureFormatR16Uint:  "r16uint",
+	gputypes.TextureFormatR16Sint:  "r16sint",
+	gputypes.TextureFormatR16Float: "r16float",
+	gputypes.TextureFormatRG8Unorm: "rg8unorm",
+	gputypes.TextureFormatRG8Snorm: "rg8snorm",
+	gputypes.TextureFormatRG8Uint:  "rg8uint",
+	gputypes.TextureFormatRG8Sint:  "rg8sint",
+
+	// 32-bit
+	gputypes.TextureFormatR32Float:       "r32float",
+	gputypes.TextureFormatR32Uint:        "r32uint",
+	gputypes.TextureFormatR32Sint:        "r32sint",
+	gputypes.TextureFormatRG16Uint:       "rg16uint",
+	gputypes.TextureFormatRG16Sint:       "rg16sint",
+	gputypes.TextureFormatRG16Float:      "rg16float",
+	gputypes.TextureFormatRGBA8Unorm:     "rgba8unorm",
+	gputypes.TextureFormatRGBA8UnormSrgb: "rgba8unorm-srgb",
+	gputypes.TextureFormatRGBA8Snorm:     "rgba8snorm",
+	gputypes.TextureFormatRGBA8Uint:      "rgba8uint",
+	gputypes.TextureFormatRGBA8Sint:      "rgba8sint",
+	gputypes.TextureFormatBGRA8Unorm:     "bgra8unorm",
+	gputypes.TextureFormatBGRA8UnormSrgb: "bgra8unorm-srgb",
+
+	// Packed 32-bit
+	gputypes.TextureFormatRGB10A2Uint:   "rgb10a2uint",
+	gputypes.TextureFormatRGB10A2Unorm:  "rgb10a2unorm",
+	gputypes.TextureFormatRG11B10Ufloat: "rg11b10ufloat",
+	gputypes.TextureFormatRGB9E5Ufloat:  "rgb9e5ufloat",
+
+	// 64-bit
+	gputypes.TextureFormatRG32Float:   "rg32float",
+	gputypes.TextureFormatRG32Uint:    "rg32uint",
+	gputypes.TextureFormatRG32Sint:    "rg32sint",
+	gputypes.TextureFormatRGBA16Uint:  "rgba16uint",
+	gputypes.TextureFormatRGBA16Sint:  "rgba16sint",
+	gputypes.TextureFormatRGBA16Float: "rgba16float",
+
+	// 128-bit
+	gputypes.TextureFormatRGBA32Float: "rgba32float",
+	gputypes.TextureFormatRGBA32Uint:  "rgba32uint",
+	gputypes.TextureFormatRGBA32Sint:  "rgba32sint",
+
+	// Depth/stencil
+	gputypes.TextureFormatStencil8:             "stencil8",
+	gputypes.TextureFormatDepth16Unorm:         "depth16unorm",
+	gputypes.TextureFormatDepth24Plus:          "depth24plus",
+	gputypes.TextureFormatDepth24PlusStencil8:  "depth24plus-stencil8",
+	gputypes.TextureFormatDepth32Float:         "depth32float",
+	gputypes.TextureFormatDepth32FloatStencil8: "depth32float-stencil8",
+
+	// BC compressed
+	gputypes.TextureFormatBC1RGBAUnorm:     "bc1-rgba-unorm",
+	gputypes.TextureFormatBC1RGBAUnormSrgb: "bc1-rgba-unorm-srgb",
+	gputypes.TextureFormatBC2RGBAUnorm:     "bc2-rgba-unorm",
+	gputypes.TextureFormatBC2RGBAUnormSrgb: "bc2-rgba-unorm-srgb",
+	gputypes.TextureFormatBC3RGBAUnorm:     "bc3-rgba-unorm",
+	gputypes.TextureFormatBC3RGBAUnormSrgb: "bc3-rgba-unorm-srgb",
+	gputypes.TextureFormatBC4RUnorm:        "bc4-r-unorm",
+	gputypes.TextureFormatBC4RSnorm:        "bc4-r-snorm",
+	gputypes.TextureFormatBC5RGUnorm:       "bc5-rg-unorm",
+	gputypes.TextureFormatBC5RGSnorm:       "bc5-rg-snorm",
+	gputypes.TextureFormatBC6HRGBUfloat:    "bc6h-rgb-ufloat",
+	gputypes.TextureFormatBC6HRGBFloat:     "bc6h-rgb-float",
+	gputypes.TextureFormatBC7RGBAUnorm:     "bc7-rgba-unorm",
+	gputypes.TextureFormatBC7RGBAUnormSrgb: "bc7-rgba-unorm-srgb",
+
+	// ETC2 compressed
+	gputypes.TextureFormatETC2RGB8Unorm:       "etc2-rgb8unorm",
+	gputypes.TextureFormatETC2RGB8UnormSrgb:   "etc2-rgb8unorm-srgb",
+	gputypes.TextureFormatETC2RGB8A1Unorm:     "etc2-rgb8a1unorm",
+	gputypes.TextureFormatETC2RGB8A1UnormSrgb: "etc2-rgb8a1unorm-srgb",
+	gputypes.TextureFormatETC2RGBA8Unorm:      "etc2-rgba8unorm",
+	gputypes.TextureFormatETC2RGBA8UnormSrgb:  "etc2-rgba8unorm-srgb",
+	gputypes.TextureFormatEACR11Unorm:         "eac-r11unorm",
+	gputypes.TextureFormatEACR11Snorm:         "eac-r11snorm",
+	gputypes.TextureFormatEACRG11Unorm:        "eac-rg11unorm",
+	gputypes.TextureFormatEACRG11Snorm:        "eac-rg11snorm",
+
+	// ASTC compressed
+	gputypes.TextureFormatASTC4x4Unorm:       "astc-4x4-unorm",
+	gputypes.TextureFormatASTC4x4UnormSrgb:   "astc-4x4-unorm-srgb",
+	gputypes.TextureFormatASTC5x4Unorm:       "astc-5x4-unorm",
+	gputypes.TextureFormatASTC5x4UnormSrgb:   "astc-5x4-unorm-srgb",
+	gputypes.TextureFormatASTC5x5Unorm:       "astc-5x5-unorm",
+	gputypes.TextureFormatASTC5x5UnormSrgb:   "astc-5x5-unorm-srgb",
+	gputypes.TextureFormatASTC6x5Unorm:       "astc-6x5-unorm",
+	gputypes.TextureFormatASTC6x5UnormSrgb:   "astc-6x5-unorm-srgb",
+	gputypes.TextureFormatASTC6x6Unorm:       "astc-6x6-unorm",
+	gputypes.TextureFormatASTC6x6UnormSrgb:   "astc-6x6-unorm-srgb",
+	gputypes.TextureFormatASTC8x5Unorm:       "astc-8x5-unorm",
+	gputypes.TextureFormatASTC8x5UnormSrgb:   "astc-8x5-unorm-srgb",
+	gputypes.TextureFormatASTC8x6Unorm:       "astc-8x6-unorm",
+	gputypes.TextureFormatASTC8x6UnormSrgb:   "astc-8x6-unorm-srgb",
+	gputypes.TextureFormatASTC8x8Unorm:       "astc-8x8-unorm",
+	gputypes.TextureFormatASTC8x8UnormSrgb:   "astc-8x8-unorm-srgb",
+	gputypes.TextureFormatASTC10x5Unorm:      "astc-10x5-unorm",
+	gputypes.TextureFormatASTC10x5UnormSrgb:  "astc-10x5-unorm-srgb",
+	gputypes.TextureFormatASTC10x6Unorm:      "astc-10x6-unorm",
+	gputypes.TextureFormatASTC10x6UnormSrgb:  "astc-10x6-unorm-srgb",
+	gputypes.TextureFormatASTC10x8Unorm:      "astc-10x8-unorm",
+	gputypes.TextureFormatASTC10x8UnormSrgb:  "astc-10x8-unorm-srgb",
+	gputypes.TextureFormatASTC10x10Unorm:     "astc-10x10-unorm",
+	gputypes.TextureFormatASTC10x10UnormSrgb: "astc-10x10-unorm-srgb",
+	gputypes.TextureFormatASTC12x10Unorm:     "astc-12x10-unorm",
+	gputypes.TextureFormatASTC12x10UnormSrgb: "astc-12x10-unorm-srgb",
+	gputypes.TextureFormatASTC12x12Unorm:     "astc-12x12-unorm",
+	gputypes.TextureFormatASTC12x12UnormSrgb: "astc-12x12-unorm-srgb",
+}
+
+// TextureDimensionToJS converts a gputypes.TextureDimension to the WebGPU JS string.
+func TextureDimensionToJS(d gputypes.TextureDimension) string {
+	switch d {
+	case gputypes.TextureDimension1D:
+		return "1d"
+	case gputypes.TextureDimension2D:
+		return "2d"
+	case gputypes.TextureDimension3D:
+		return "3d"
+	default:
+		return ""
+	}
+}
+
+// TextureViewDimensionToJS converts a gputypes.TextureViewDimension to JS string.
+func TextureViewDimensionToJS(d gputypes.TextureViewDimension) string {
+	switch d {
+	case gputypes.TextureViewDimension1D:
+		return "1d"
+	case gputypes.TextureViewDimension2D:
+		return "2d"
+	case gputypes.TextureViewDimension2DArray:
+		return "2d-array"
+	case gputypes.TextureViewDimensionCube:
+		return "cube"
+	case gputypes.TextureViewDimensionCubeArray:
+		return "cube-array"
+	case gputypes.TextureViewDimension3D:
+		return "3d"
+	default:
+		return ""
+	}
+}
+
+// TextureAspectToJS converts a gputypes.TextureAspect to JS string.
+func TextureAspectToJS(a gputypes.TextureAspect) string {
+	switch a {
+	case gputypes.TextureAspectAll:
+		return "all"
+	case gputypes.TextureAspectStencilOnly:
+		return "stencil-only"
+	case gputypes.TextureAspectDepthOnly:
+		return "depth-only"
+	default:
+		return ""
+	}
+}
+
+// AddressModeToJS converts a gputypes.AddressMode to JS string.
+func AddressModeToJS(m gputypes.AddressMode) string {
+	switch m {
+	case gputypes.AddressModeClampToEdge:
+		return "clamp-to-edge"
+	case gputypes.AddressModeRepeat:
+		return "repeat"
+	case gputypes.AddressModeMirrorRepeat:
+		return "mirror-repeat"
+	default:
+		return "clamp-to-edge"
+	}
+}
+
+// FilterModeToJS converts a gputypes.FilterMode to JS string.
+func FilterModeToJS(m gputypes.FilterMode) string {
+	switch m {
+	case gputypes.FilterModeNearest:
+		return "nearest"
+	case gputypes.FilterModeLinear:
+		return "linear"
+	default:
+		return "nearest"
+	}
+}
+
+// CompareFunctionToJS converts a gputypes.CompareFunction to JS string.
+func CompareFunctionToJS(f gputypes.CompareFunction) string {
+	switch f {
+	case gputypes.CompareFunctionNever:
+		return "never"
+	case gputypes.CompareFunctionLess:
+		return "less"
+	case gputypes.CompareFunctionEqual:
+		return "equal"
+	case gputypes.CompareFunctionLessEqual:
+		return "less-equal"
+	case gputypes.CompareFunctionGreater:
+		return "greater"
+	case gputypes.CompareFunctionNotEqual:
+		return "not-equal"
+	case gputypes.CompareFunctionGreaterEqual:
+		return "greater-equal"
+	case gputypes.CompareFunctionAlways:
+		return "always"
+	default:
+		return ""
+	}
+}
+
+// PrimitiveTopologyToJS converts a gputypes.PrimitiveTopology to JS string.
+func PrimitiveTopologyToJS(t gputypes.PrimitiveTopology) string {
+	switch t {
+	case gputypes.PrimitiveTopologyPointList:
+		return "point-list"
+	case gputypes.PrimitiveTopologyLineList:
+		return "line-list"
+	case gputypes.PrimitiveTopologyLineStrip:
+		return "line-strip"
+	case gputypes.PrimitiveTopologyTriangleList:
+		return "triangle-list"
+	case gputypes.PrimitiveTopologyTriangleStrip:
+		return "triangle-strip"
+	default:
+		return "triangle-list"
+	}
+}
+
+// FrontFaceToJS converts a gputypes.FrontFace to JS string.
+func FrontFaceToJS(f gputypes.FrontFace) string {
+	switch f {
+	case gputypes.FrontFaceCW:
+		return "cw"
+	default:
+		return "ccw"
+	}
+}
+
+// CullModeToJS converts a gputypes.CullMode to JS string.
+func CullModeToJS(m gputypes.CullMode) string {
+	switch m {
+	case gputypes.CullModeFront:
+		return "front"
+	case gputypes.CullModeBack:
+		return "back"
+	default:
+		return "none"
+	}
+}
+
+// IndexFormatToJS converts a gputypes.IndexFormat to JS string.
+func IndexFormatToJS(f gputypes.IndexFormat) string {
+	switch f {
+	case gputypes.IndexFormatUint16:
+		return "uint16"
+	case gputypes.IndexFormatUint32:
+		return "uint32"
+	default:
+		return ""
+	}
+}
+
+// VertexFormatToJS converts a gputypes.VertexFormat to JS string.
+func VertexFormatToJS(f gputypes.VertexFormat) string {
+	s, ok := vertexFormatMap[f]
+	if ok {
+		return s
+	}
+	return ""
+}
+
+var vertexFormatMap = map[gputypes.VertexFormat]string{
+	gputypes.VertexFormatUint8x2:      "uint8x2",
+	gputypes.VertexFormatUint8x4:      "uint8x4",
+	gputypes.VertexFormatSint8x2:      "sint8x2",
+	gputypes.VertexFormatSint8x4:      "sint8x4",
+	gputypes.VertexFormatUnorm8x2:     "unorm8x2",
+	gputypes.VertexFormatUnorm8x4:     "unorm8x4",
+	gputypes.VertexFormatSnorm8x2:     "snorm8x2",
+	gputypes.VertexFormatSnorm8x4:     "snorm8x4",
+	gputypes.VertexFormatUint16x2:     "uint16x2",
+	gputypes.VertexFormatUint16x4:     "uint16x4",
+	gputypes.VertexFormatSint16x2:     "sint16x2",
+	gputypes.VertexFormatSint16x4:     "sint16x4",
+	gputypes.VertexFormatUnorm16x2:    "unorm16x2",
+	gputypes.VertexFormatUnorm16x4:    "unorm16x4",
+	gputypes.VertexFormatSnorm16x2:    "snorm16x2",
+	gputypes.VertexFormatSnorm16x4:    "snorm16x4",
+	gputypes.VertexFormatFloat16x2:    "float16x2",
+	gputypes.VertexFormatFloat16x4:    "float16x4",
+	gputypes.VertexFormatFloat32:      "float32",
+	gputypes.VertexFormatFloat32x2:    "float32x2",
+	gputypes.VertexFormatFloat32x3:    "float32x3",
+	gputypes.VertexFormatFloat32x4:    "float32x4",
+	gputypes.VertexFormatUint32:       "uint32",
+	gputypes.VertexFormatUint32x2:     "uint32x2",
+	gputypes.VertexFormatUint32x3:     "uint32x3",
+	gputypes.VertexFormatUint32x4:     "uint32x4",
+	gputypes.VertexFormatSint32:       "sint32",
+	gputypes.VertexFormatSint32x2:     "sint32x2",
+	gputypes.VertexFormatSint32x3:     "sint32x3",
+	gputypes.VertexFormatSint32x4:     "sint32x4",
+	gputypes.VertexFormatUnorm1010102: "unorm10-10-10-2",
+}
+
+// VertexStepModeToJS converts a gputypes.VertexStepMode to JS string.
+func VertexStepModeToJS(m gputypes.VertexStepMode) string {
+	switch m {
+	case gputypes.VertexStepModeInstance:
+		return "instance"
+	default:
+		return "vertex"
+	}
+}
+
+// BlendFactorToJS converts a gputypes.BlendFactor to JS string.
+func BlendFactorToJS(f gputypes.BlendFactor) string {
+	switch f {
+	case gputypes.BlendFactorZero:
+		return "zero"
+	case gputypes.BlendFactorOne:
+		return "one"
+	case gputypes.BlendFactorSrc:
+		return "src"
+	case gputypes.BlendFactorOneMinusSrc:
+		return "one-minus-src"
+	case gputypes.BlendFactorSrcAlpha:
+		return "src-alpha"
+	case gputypes.BlendFactorOneMinusSrcAlpha:
+		return "one-minus-src-alpha"
+	case gputypes.BlendFactorDst:
+		return "dst"
+	case gputypes.BlendFactorOneMinusDst:
+		return "one-minus-dst"
+	case gputypes.BlendFactorDstAlpha:
+		return "dst-alpha"
+	case gputypes.BlendFactorOneMinusDstAlpha:
+		return "one-minus-dst-alpha"
+	case gputypes.BlendFactorSrcAlphaSaturated:
+		return "src-alpha-saturated"
+	case gputypes.BlendFactorConstant:
+		return "constant"
+	case gputypes.BlendFactorOneMinusConstant:
+		return "one-minus-constant"
+	default:
+		return "one"
+	}
+}
+
+// BlendOperationToJS converts a gputypes.BlendOperation to JS string.
+func BlendOperationToJS(op gputypes.BlendOperation) string {
+	switch op {
+	case gputypes.BlendOperationAdd:
+		return "add"
+	case gputypes.BlendOperationSubtract:
+		return "subtract"
+	case gputypes.BlendOperationReverseSubtract:
+		return "reverse-subtract"
+	case gputypes.BlendOperationMin:
+		return "min"
+	case gputypes.BlendOperationMax:
+		return "max"
+	default:
+		return "add"
+	}
+}
+
+// StencilOperationToJS converts a gputypes.StencilOperation to JS string.
+func StencilOperationToJS(op gputypes.StencilOperation) string {
+	switch op {
+	case gputypes.StencilOperationKeep:
+		return "keep"
+	case gputypes.StencilOperationZero:
+		return "zero"
+	case gputypes.StencilOperationReplace:
+		return "replace"
+	case gputypes.StencilOperationInvert:
+		return "invert"
+	case gputypes.StencilOperationIncrementClamp:
+		return "increment-clamp"
+	case gputypes.StencilOperationDecrementClamp:
+		return "decrement-clamp"
+	case gputypes.StencilOperationIncrementWrap:
+		return "increment-wrap"
+	case gputypes.StencilOperationDecrementWrap:
+		return "decrement-wrap"
+	default:
+		return "keep"
+	}
+}
+
+// BufferBindingTypeToJS converts a gputypes.BufferBindingType to JS string.
+func BufferBindingTypeToJS(t gputypes.BufferBindingType) string {
+	switch t {
+	case gputypes.BufferBindingTypeUniform:
+		return "uniform"
+	case gputypes.BufferBindingTypeStorage:
+		return "storage"
+	case gputypes.BufferBindingTypeReadOnlyStorage:
+		return "read-only-storage"
+	default:
+		return "uniform"
+	}
+}
+
+// SamplerBindingTypeToJS converts a gputypes.SamplerBindingType to JS string.
+func SamplerBindingTypeToJS(t gputypes.SamplerBindingType) string {
+	switch t {
+	case gputypes.SamplerBindingTypeFiltering:
+		return "filtering"
+	case gputypes.SamplerBindingTypeNonFiltering:
+		return "non-filtering"
+	case gputypes.SamplerBindingTypeComparison:
+		return "comparison"
+	default:
+		return "filtering"
+	}
+}
+
+// TextureSampleTypeToJS converts a gputypes.TextureSampleType to JS string.
+func TextureSampleTypeToJS(t gputypes.TextureSampleType) string {
+	switch t {
+	case gputypes.TextureSampleTypeFloat:
+		return "float"
+	case gputypes.TextureSampleTypeUnfilterableFloat:
+		return "unfilterable-float"
+	case gputypes.TextureSampleTypeDepth:
+		return "depth"
+	case gputypes.TextureSampleTypeSint:
+		return "sint"
+	case gputypes.TextureSampleTypeUint:
+		return "uint"
+	default:
+		return "float"
+	}
+}
+
+// StorageTextureAccessToJS converts a gputypes.StorageTextureAccess to JS string.
+func StorageTextureAccessToJS(a gputypes.StorageTextureAccess) string {
+	switch a {
+	case gputypes.StorageTextureAccessWriteOnly:
+		return "write-only"
+	case gputypes.StorageTextureAccessReadOnly:
+		return "read-only"
+	case gputypes.StorageTextureAccessReadWrite:
+		return "read-write"
+	default:
+		return "write-only"
+	}
+}

--- a/internal/browser/convert_enums.go
+++ b/internal/browser/convert_enums.go
@@ -469,3 +469,29 @@ func StorageTextureAccessToJS(a gputypes.StorageTextureAccess) string {
 		return "write-only"
 	}
 }
+
+// LoadOpToJS converts a gputypes.LoadOp to the WebGPU JS string.
+// Returns "load" for LoadOpLoad, "clear" for LoadOpClear, and "load" as default.
+func LoadOpToJS(op gputypes.LoadOp) string {
+	switch op {
+	case gputypes.LoadOpClear:
+		return "clear"
+	case gputypes.LoadOpLoad:
+		return "load"
+	default:
+		return "load"
+	}
+}
+
+// StoreOpToJS converts a gputypes.StoreOp to the WebGPU JS string.
+// Returns "store" for StoreOpStore, "discard" for StoreOpDiscard, and "store" as default.
+func StoreOpToJS(op gputypes.StoreOp) string {
+	switch op {
+	case gputypes.StoreOpDiscard:
+		return "discard"
+	case gputypes.StoreOpStore:
+		return "store"
+	default:
+		return "store"
+	}
+}

--- a/internal/browser/convert_enums_test.go
+++ b/internal/browser/convert_enums_test.go
@@ -1,0 +1,601 @@
+package browser
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+)
+
+// TestTextureFormatToJS verifies every texture format maps to the correct WebGPU string.
+func TestTextureFormatToJS(t *testing.T) {
+	tests := []struct {
+		format gputypes.TextureFormat
+		want   string
+	}{
+		// 8-bit
+		{gputypes.TextureFormatR8Unorm, "r8unorm"},
+		{gputypes.TextureFormatR8Snorm, "r8snorm"},
+		{gputypes.TextureFormatR8Uint, "r8uint"},
+		{gputypes.TextureFormatR8Sint, "r8sint"},
+		// 16-bit
+		{gputypes.TextureFormatR16Uint, "r16uint"},
+		{gputypes.TextureFormatR16Sint, "r16sint"},
+		{gputypes.TextureFormatR16Float, "r16float"},
+		{gputypes.TextureFormatRG8Unorm, "rg8unorm"},
+		{gputypes.TextureFormatRG8Snorm, "rg8snorm"},
+		{gputypes.TextureFormatRG8Uint, "rg8uint"},
+		{gputypes.TextureFormatRG8Sint, "rg8sint"},
+		// 32-bit
+		{gputypes.TextureFormatR32Float, "r32float"},
+		{gputypes.TextureFormatR32Uint, "r32uint"},
+		{gputypes.TextureFormatR32Sint, "r32sint"},
+		{gputypes.TextureFormatRG16Uint, "rg16uint"},
+		{gputypes.TextureFormatRG16Sint, "rg16sint"},
+		{gputypes.TextureFormatRG16Float, "rg16float"},
+		{gputypes.TextureFormatRGBA8Unorm, "rgba8unorm"},
+		{gputypes.TextureFormatRGBA8UnormSrgb, "rgba8unorm-srgb"},
+		{gputypes.TextureFormatRGBA8Snorm, "rgba8snorm"},
+		{gputypes.TextureFormatRGBA8Uint, "rgba8uint"},
+		{gputypes.TextureFormatRGBA8Sint, "rgba8sint"},
+		{gputypes.TextureFormatBGRA8Unorm, "bgra8unorm"},
+		{gputypes.TextureFormatBGRA8UnormSrgb, "bgra8unorm-srgb"},
+		// Packed 32-bit
+		{gputypes.TextureFormatRGB10A2Uint, "rgb10a2uint"},
+		{gputypes.TextureFormatRGB10A2Unorm, "rgb10a2unorm"},
+		{gputypes.TextureFormatRG11B10Ufloat, "rg11b10ufloat"},
+		{gputypes.TextureFormatRGB9E5Ufloat, "rgb9e5ufloat"},
+		// 64-bit
+		{gputypes.TextureFormatRG32Float, "rg32float"},
+		{gputypes.TextureFormatRG32Uint, "rg32uint"},
+		{gputypes.TextureFormatRG32Sint, "rg32sint"},
+		{gputypes.TextureFormatRGBA16Uint, "rgba16uint"},
+		{gputypes.TextureFormatRGBA16Sint, "rgba16sint"},
+		{gputypes.TextureFormatRGBA16Float, "rgba16float"},
+		// 128-bit
+		{gputypes.TextureFormatRGBA32Float, "rgba32float"},
+		{gputypes.TextureFormatRGBA32Uint, "rgba32uint"},
+		{gputypes.TextureFormatRGBA32Sint, "rgba32sint"},
+		// Depth/stencil
+		{gputypes.TextureFormatStencil8, "stencil8"},
+		{gputypes.TextureFormatDepth16Unorm, "depth16unorm"},
+		{gputypes.TextureFormatDepth24Plus, "depth24plus"},
+		{gputypes.TextureFormatDepth24PlusStencil8, "depth24plus-stencil8"},
+		{gputypes.TextureFormatDepth32Float, "depth32float"},
+		{gputypes.TextureFormatDepth32FloatStencil8, "depth32float-stencil8"},
+		// BC compressed
+		{gputypes.TextureFormatBC1RGBAUnorm, "bc1-rgba-unorm"},
+		{gputypes.TextureFormatBC1RGBAUnormSrgb, "bc1-rgba-unorm-srgb"},
+		{gputypes.TextureFormatBC2RGBAUnorm, "bc2-rgba-unorm"},
+		{gputypes.TextureFormatBC2RGBAUnormSrgb, "bc2-rgba-unorm-srgb"},
+		{gputypes.TextureFormatBC3RGBAUnorm, "bc3-rgba-unorm"},
+		{gputypes.TextureFormatBC3RGBAUnormSrgb, "bc3-rgba-unorm-srgb"},
+		{gputypes.TextureFormatBC4RUnorm, "bc4-r-unorm"},
+		{gputypes.TextureFormatBC4RSnorm, "bc4-r-snorm"},
+		{gputypes.TextureFormatBC5RGUnorm, "bc5-rg-unorm"},
+		{gputypes.TextureFormatBC5RGSnorm, "bc5-rg-snorm"},
+		{gputypes.TextureFormatBC6HRGBUfloat, "bc6h-rgb-ufloat"},
+		{gputypes.TextureFormatBC6HRGBFloat, "bc6h-rgb-float"},
+		{gputypes.TextureFormatBC7RGBAUnorm, "bc7-rgba-unorm"},
+		{gputypes.TextureFormatBC7RGBAUnormSrgb, "bc7-rgba-unorm-srgb"},
+		// ETC2 compressed
+		{gputypes.TextureFormatETC2RGB8Unorm, "etc2-rgb8unorm"},
+		{gputypes.TextureFormatETC2RGB8UnormSrgb, "etc2-rgb8unorm-srgb"},
+		{gputypes.TextureFormatETC2RGB8A1Unorm, "etc2-rgb8a1unorm"},
+		{gputypes.TextureFormatETC2RGB8A1UnormSrgb, "etc2-rgb8a1unorm-srgb"},
+		{gputypes.TextureFormatETC2RGBA8Unorm, "etc2-rgba8unorm"},
+		{gputypes.TextureFormatETC2RGBA8UnormSrgb, "etc2-rgba8unorm-srgb"},
+		{gputypes.TextureFormatEACR11Unorm, "eac-r11unorm"},
+		{gputypes.TextureFormatEACR11Snorm, "eac-r11snorm"},
+		{gputypes.TextureFormatEACRG11Unorm, "eac-rg11unorm"},
+		{gputypes.TextureFormatEACRG11Snorm, "eac-rg11snorm"},
+		// ASTC compressed (spot check)
+		{gputypes.TextureFormatASTC4x4Unorm, "astc-4x4-unorm"},
+		{gputypes.TextureFormatASTC4x4UnormSrgb, "astc-4x4-unorm-srgb"},
+		{gputypes.TextureFormatASTC12x12Unorm, "astc-12x12-unorm"},
+		{gputypes.TextureFormatASTC12x12UnormSrgb, "astc-12x12-unorm-srgb"},
+		// Undefined returns empty
+		{gputypes.TextureFormatUndefined, ""},
+	}
+	for _, tc := range tests {
+		got := TextureFormatToJS(tc.format)
+		if got != tc.want {
+			t.Errorf("TextureFormatToJS(%v) = %q, want %q", tc.format, got, tc.want)
+		}
+	}
+}
+
+// TestTextureDimensionToJS verifies all texture dimension mappings.
+func TestTextureDimensionToJS(t *testing.T) {
+	tests := []struct {
+		dim  gputypes.TextureDimension
+		want string
+	}{
+		{gputypes.TextureDimension1D, "1d"},
+		{gputypes.TextureDimension2D, "2d"},
+		{gputypes.TextureDimension3D, "3d"},
+		{gputypes.TextureDimensionUndefined, ""},
+	}
+	for _, tc := range tests {
+		got := TextureDimensionToJS(tc.dim)
+		if got != tc.want {
+			t.Errorf("TextureDimensionToJS(%v) = %q, want %q", tc.dim, got, tc.want)
+		}
+	}
+}
+
+// TestTextureViewDimensionToJS verifies all view dimension mappings.
+func TestTextureViewDimensionToJS(t *testing.T) {
+	tests := []struct {
+		dim  gputypes.TextureViewDimension
+		want string
+	}{
+		{gputypes.TextureViewDimension1D, "1d"},
+		{gputypes.TextureViewDimension2D, "2d"},
+		{gputypes.TextureViewDimension2DArray, "2d-array"},
+		{gputypes.TextureViewDimensionCube, "cube"},
+		{gputypes.TextureViewDimensionCubeArray, "cube-array"},
+		{gputypes.TextureViewDimension3D, "3d"},
+		{gputypes.TextureViewDimensionUndefined, ""},
+	}
+	for _, tc := range tests {
+		got := TextureViewDimensionToJS(tc.dim)
+		if got != tc.want {
+			t.Errorf("TextureViewDimensionToJS(%v) = %q, want %q", tc.dim, got, tc.want)
+		}
+	}
+}
+
+// TestTextureAspectToJS verifies all texture aspect mappings.
+func TestTextureAspectToJS(t *testing.T) {
+	tests := []struct {
+		aspect gputypes.TextureAspect
+		want   string
+	}{
+		{gputypes.TextureAspectAll, "all"},
+		{gputypes.TextureAspectStencilOnly, "stencil-only"},
+		{gputypes.TextureAspectDepthOnly, "depth-only"},
+		{gputypes.TextureAspectUndefined, ""},
+	}
+	for _, tc := range tests {
+		got := TextureAspectToJS(tc.aspect)
+		if got != tc.want {
+			t.Errorf("TextureAspectToJS(%v) = %q, want %q", tc.aspect, got, tc.want)
+		}
+	}
+}
+
+// TestAddressModeToJS verifies all address mode mappings.
+func TestAddressModeToJS(t *testing.T) {
+	tests := []struct {
+		mode gputypes.AddressMode
+		want string
+	}{
+		{gputypes.AddressModeClampToEdge, "clamp-to-edge"},
+		{gputypes.AddressModeRepeat, "repeat"},
+		{gputypes.AddressModeMirrorRepeat, "mirror-repeat"},
+		{gputypes.AddressModeUndefined, "clamp-to-edge"},
+	}
+	for _, tc := range tests {
+		got := AddressModeToJS(tc.mode)
+		if got != tc.want {
+			t.Errorf("AddressModeToJS(%v) = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// TestFilterModeToJS verifies all filter mode mappings.
+func TestFilterModeToJS(t *testing.T) {
+	tests := []struct {
+		mode gputypes.FilterMode
+		want string
+	}{
+		{gputypes.FilterModeNearest, "nearest"},
+		{gputypes.FilterModeLinear, "linear"},
+		{gputypes.FilterModeUndefined, "nearest"},
+	}
+	for _, tc := range tests {
+		got := FilterModeToJS(tc.mode)
+		if got != tc.want {
+			t.Errorf("FilterModeToJS(%v) = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// TestCompareFunctionToJS verifies all compare function mappings.
+func TestCompareFunctionToJS(t *testing.T) {
+	tests := []struct {
+		fn   gputypes.CompareFunction
+		want string
+	}{
+		{gputypes.CompareFunctionNever, "never"},
+		{gputypes.CompareFunctionLess, "less"},
+		{gputypes.CompareFunctionEqual, "equal"},
+		{gputypes.CompareFunctionLessEqual, "less-equal"},
+		{gputypes.CompareFunctionGreater, "greater"},
+		{gputypes.CompareFunctionNotEqual, "not-equal"},
+		{gputypes.CompareFunctionGreaterEqual, "greater-equal"},
+		{gputypes.CompareFunctionAlways, "always"},
+		{gputypes.CompareFunctionUndefined, ""},
+	}
+	for _, tc := range tests {
+		got := CompareFunctionToJS(tc.fn)
+		if got != tc.want {
+			t.Errorf("CompareFunctionToJS(%v) = %q, want %q", tc.fn, got, tc.want)
+		}
+	}
+}
+
+// TestPrimitiveTopologyToJS verifies all primitive topology mappings.
+func TestPrimitiveTopologyToJS(t *testing.T) {
+	tests := []struct {
+		topo gputypes.PrimitiveTopology
+		want string
+	}{
+		{gputypes.PrimitiveTopologyPointList, "point-list"},
+		{gputypes.PrimitiveTopologyLineList, "line-list"},
+		{gputypes.PrimitiveTopologyLineStrip, "line-strip"},
+		{gputypes.PrimitiveTopologyTriangleList, "triangle-list"},
+		{gputypes.PrimitiveTopologyTriangleStrip, "triangle-strip"},
+	}
+	for _, tc := range tests {
+		got := PrimitiveTopologyToJS(tc.topo)
+		if got != tc.want {
+			t.Errorf("PrimitiveTopologyToJS(%v) = %q, want %q", tc.topo, got, tc.want)
+		}
+	}
+}
+
+// TestFrontFaceToJS verifies all front face mappings.
+func TestFrontFaceToJS(t *testing.T) {
+	tests := []struct {
+		face gputypes.FrontFace
+		want string
+	}{
+		{gputypes.FrontFaceCCW, "ccw"},
+		{gputypes.FrontFaceCW, "cw"},
+	}
+	for _, tc := range tests {
+		got := FrontFaceToJS(tc.face)
+		if got != tc.want {
+			t.Errorf("FrontFaceToJS(%v) = %q, want %q", tc.face, got, tc.want)
+		}
+	}
+}
+
+// TestCullModeToJS verifies all cull mode mappings.
+func TestCullModeToJS(t *testing.T) {
+	tests := []struct {
+		mode gputypes.CullMode
+		want string
+	}{
+		{gputypes.CullModeNone, "none"},
+		{gputypes.CullModeFront, "front"},
+		{gputypes.CullModeBack, "back"},
+	}
+	for _, tc := range tests {
+		got := CullModeToJS(tc.mode)
+		if got != tc.want {
+			t.Errorf("CullModeToJS(%v) = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// TestIndexFormatToJS verifies all index format mappings.
+func TestIndexFormatToJS(t *testing.T) {
+	tests := []struct {
+		fmt  gputypes.IndexFormat
+		want string
+	}{
+		{gputypes.IndexFormatUint16, "uint16"},
+		{gputypes.IndexFormatUint32, "uint32"},
+		{gputypes.IndexFormatUndefined, ""},
+	}
+	for _, tc := range tests {
+		got := IndexFormatToJS(tc.fmt)
+		if got != tc.want {
+			t.Errorf("IndexFormatToJS(%v) = %q, want %q", tc.fmt, got, tc.want)
+		}
+	}
+}
+
+// TestVertexFormatToJS verifies all vertex format mappings.
+func TestVertexFormatToJS(t *testing.T) {
+	tests := []struct {
+		fmt  gputypes.VertexFormat
+		want string
+	}{
+		{gputypes.VertexFormatUint8x2, "uint8x2"},
+		{gputypes.VertexFormatUint8x4, "uint8x4"},
+		{gputypes.VertexFormatSint8x2, "sint8x2"},
+		{gputypes.VertexFormatSint8x4, "sint8x4"},
+		{gputypes.VertexFormatUnorm8x2, "unorm8x2"},
+		{gputypes.VertexFormatUnorm8x4, "unorm8x4"},
+		{gputypes.VertexFormatSnorm8x2, "snorm8x2"},
+		{gputypes.VertexFormatSnorm8x4, "snorm8x4"},
+		{gputypes.VertexFormatUint16x2, "uint16x2"},
+		{gputypes.VertexFormatUint16x4, "uint16x4"},
+		{gputypes.VertexFormatSint16x2, "sint16x2"},
+		{gputypes.VertexFormatSint16x4, "sint16x4"},
+		{gputypes.VertexFormatUnorm16x2, "unorm16x2"},
+		{gputypes.VertexFormatUnorm16x4, "unorm16x4"},
+		{gputypes.VertexFormatSnorm16x2, "snorm16x2"},
+		{gputypes.VertexFormatSnorm16x4, "snorm16x4"},
+		{gputypes.VertexFormatFloat16x2, "float16x2"},
+		{gputypes.VertexFormatFloat16x4, "float16x4"},
+		{gputypes.VertexFormatFloat32, "float32"},
+		{gputypes.VertexFormatFloat32x2, "float32x2"},
+		{gputypes.VertexFormatFloat32x3, "float32x3"},
+		{gputypes.VertexFormatFloat32x4, "float32x4"},
+		{gputypes.VertexFormatUint32, "uint32"},
+		{gputypes.VertexFormatUint32x2, "uint32x2"},
+		{gputypes.VertexFormatUint32x3, "uint32x3"},
+		{gputypes.VertexFormatUint32x4, "uint32x4"},
+		{gputypes.VertexFormatSint32, "sint32"},
+		{gputypes.VertexFormatSint32x2, "sint32x2"},
+		{gputypes.VertexFormatSint32x3, "sint32x3"},
+		{gputypes.VertexFormatSint32x4, "sint32x4"},
+		{gputypes.VertexFormatUnorm1010102, "unorm10-10-10-2"},
+		// Undefined returns empty
+		{gputypes.VertexFormatUndefined, ""},
+	}
+	for _, tc := range tests {
+		got := VertexFormatToJS(tc.fmt)
+		if got != tc.want {
+			t.Errorf("VertexFormatToJS(%v) = %q, want %q", tc.fmt, got, tc.want)
+		}
+	}
+}
+
+// TestVertexStepModeToJS verifies all vertex step mode mappings.
+func TestVertexStepModeToJS(t *testing.T) {
+	tests := []struct {
+		mode gputypes.VertexStepMode
+		want string
+	}{
+		{gputypes.VertexStepModeVertex, "vertex"},
+		{gputypes.VertexStepModeInstance, "instance"},
+		{gputypes.VertexStepModeUndefined, "vertex"},
+	}
+	for _, tc := range tests {
+		got := VertexStepModeToJS(tc.mode)
+		if got != tc.want {
+			t.Errorf("VertexStepModeToJS(%v) = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// TestBlendFactorToJS verifies all blend factor mappings.
+func TestBlendFactorToJS(t *testing.T) {
+	tests := []struct {
+		factor gputypes.BlendFactor
+		want   string
+	}{
+		{gputypes.BlendFactorZero, "zero"},
+		{gputypes.BlendFactorOne, "one"},
+		{gputypes.BlendFactorSrc, "src"},
+		{gputypes.BlendFactorOneMinusSrc, "one-minus-src"},
+		{gputypes.BlendFactorSrcAlpha, "src-alpha"},
+		{gputypes.BlendFactorOneMinusSrcAlpha, "one-minus-src-alpha"},
+		{gputypes.BlendFactorDst, "dst"},
+		{gputypes.BlendFactorOneMinusDst, "one-minus-dst"},
+		{gputypes.BlendFactorDstAlpha, "dst-alpha"},
+		{gputypes.BlendFactorOneMinusDstAlpha, "one-minus-dst-alpha"},
+		{gputypes.BlendFactorSrcAlphaSaturated, "src-alpha-saturated"},
+		{gputypes.BlendFactorConstant, "constant"},
+		{gputypes.BlendFactorOneMinusConstant, "one-minus-constant"},
+	}
+	for _, tc := range tests {
+		got := BlendFactorToJS(tc.factor)
+		if got != tc.want {
+			t.Errorf("BlendFactorToJS(%v) = %q, want %q", tc.factor, got, tc.want)
+		}
+	}
+}
+
+// TestBlendOperationToJS verifies all blend operation mappings.
+func TestBlendOperationToJS(t *testing.T) {
+	tests := []struct {
+		op   gputypes.BlendOperation
+		want string
+	}{
+		{gputypes.BlendOperationAdd, "add"},
+		{gputypes.BlendOperationSubtract, "subtract"},
+		{gputypes.BlendOperationReverseSubtract, "reverse-subtract"},
+		{gputypes.BlendOperationMin, "min"},
+		{gputypes.BlendOperationMax, "max"},
+	}
+	for _, tc := range tests {
+		got := BlendOperationToJS(tc.op)
+		if got != tc.want {
+			t.Errorf("BlendOperationToJS(%v) = %q, want %q", tc.op, got, tc.want)
+		}
+	}
+}
+
+// TestStencilOperationToJS verifies all stencil operation mappings.
+func TestStencilOperationToJS(t *testing.T) {
+	tests := []struct {
+		op   gputypes.StencilOperation
+		want string
+	}{
+		{gputypes.StencilOperationKeep, "keep"},
+		{gputypes.StencilOperationZero, "zero"},
+		{gputypes.StencilOperationReplace, "replace"},
+		{gputypes.StencilOperationInvert, "invert"},
+		{gputypes.StencilOperationIncrementClamp, "increment-clamp"},
+		{gputypes.StencilOperationDecrementClamp, "decrement-clamp"},
+		{gputypes.StencilOperationIncrementWrap, "increment-wrap"},
+		{gputypes.StencilOperationDecrementWrap, "decrement-wrap"},
+	}
+	for _, tc := range tests {
+		got := StencilOperationToJS(tc.op)
+		if got != tc.want {
+			t.Errorf("StencilOperationToJS(%v) = %q, want %q", tc.op, got, tc.want)
+		}
+	}
+}
+
+// TestBufferBindingTypeToJS verifies all buffer binding type mappings.
+func TestBufferBindingTypeToJS(t *testing.T) {
+	tests := []struct {
+		typ  gputypes.BufferBindingType
+		want string
+	}{
+		{gputypes.BufferBindingTypeUniform, "uniform"},
+		{gputypes.BufferBindingTypeStorage, "storage"},
+		{gputypes.BufferBindingTypeReadOnlyStorage, "read-only-storage"},
+		{gputypes.BufferBindingTypeUndefined, "uniform"},
+	}
+	for _, tc := range tests {
+		got := BufferBindingTypeToJS(tc.typ)
+		if got != tc.want {
+			t.Errorf("BufferBindingTypeToJS(%v) = %q, want %q", tc.typ, got, tc.want)
+		}
+	}
+}
+
+// TestSamplerBindingTypeToJS verifies all sampler binding type mappings.
+func TestSamplerBindingTypeToJS(t *testing.T) {
+	tests := []struct {
+		typ  gputypes.SamplerBindingType
+		want string
+	}{
+		{gputypes.SamplerBindingTypeFiltering, "filtering"},
+		{gputypes.SamplerBindingTypeNonFiltering, "non-filtering"},
+		{gputypes.SamplerBindingTypeComparison, "comparison"},
+		{gputypes.SamplerBindingTypeUndefined, "filtering"},
+	}
+	for _, tc := range tests {
+		got := SamplerBindingTypeToJS(tc.typ)
+		if got != tc.want {
+			t.Errorf("SamplerBindingTypeToJS(%v) = %q, want %q", tc.typ, got, tc.want)
+		}
+	}
+}
+
+// TestTextureSampleTypeToJS verifies all texture sample type mappings.
+func TestTextureSampleTypeToJS(t *testing.T) {
+	tests := []struct {
+		typ  gputypes.TextureSampleType
+		want string
+	}{
+		{gputypes.TextureSampleTypeFloat, "float"},
+		{gputypes.TextureSampleTypeUnfilterableFloat, "unfilterable-float"},
+		{gputypes.TextureSampleTypeDepth, "depth"},
+		{gputypes.TextureSampleTypeSint, "sint"},
+		{gputypes.TextureSampleTypeUint, "uint"},
+		{gputypes.TextureSampleTypeUndefined, "float"},
+	}
+	for _, tc := range tests {
+		got := TextureSampleTypeToJS(tc.typ)
+		if got != tc.want {
+			t.Errorf("TextureSampleTypeToJS(%v) = %q, want %q", tc.typ, got, tc.want)
+		}
+	}
+}
+
+// TestStorageTextureAccessToJS verifies all storage texture access mappings.
+func TestStorageTextureAccessToJS(t *testing.T) {
+	tests := []struct {
+		access gputypes.StorageTextureAccess
+		want   string
+	}{
+		{gputypes.StorageTextureAccessWriteOnly, "write-only"},
+		{gputypes.StorageTextureAccessReadOnly, "read-only"},
+		{gputypes.StorageTextureAccessReadWrite, "read-write"},
+		{gputypes.StorageTextureAccessUndefined, "write-only"},
+	}
+	for _, tc := range tests {
+		got := StorageTextureAccessToJS(tc.access)
+		if got != tc.want {
+			t.Errorf("StorageTextureAccessToJS(%v) = %q, want %q", tc.access, got, tc.want)
+		}
+	}
+}
+
+// TestTextureFormatMapCompleteness verifies that every non-Undefined format in
+// gputypes has a mapping. Missing entries would cause silent empty strings at runtime.
+func TestTextureFormatMapCompleteness(t *testing.T) {
+	// All non-Undefined, non-Unorm16/Snorm16 formats from gputypes
+	allFormats := []gputypes.TextureFormat{
+		gputypes.TextureFormatR8Unorm, gputypes.TextureFormatR8Snorm,
+		gputypes.TextureFormatR8Uint, gputypes.TextureFormatR8Sint,
+		gputypes.TextureFormatR16Uint, gputypes.TextureFormatR16Sint, gputypes.TextureFormatR16Float,
+		gputypes.TextureFormatRG8Unorm, gputypes.TextureFormatRG8Snorm,
+		gputypes.TextureFormatRG8Uint, gputypes.TextureFormatRG8Sint,
+		gputypes.TextureFormatR32Float, gputypes.TextureFormatR32Uint, gputypes.TextureFormatR32Sint,
+		gputypes.TextureFormatRG16Uint, gputypes.TextureFormatRG16Sint, gputypes.TextureFormatRG16Float,
+		gputypes.TextureFormatRGBA8Unorm, gputypes.TextureFormatRGBA8UnormSrgb,
+		gputypes.TextureFormatRGBA8Snorm, gputypes.TextureFormatRGBA8Uint, gputypes.TextureFormatRGBA8Sint,
+		gputypes.TextureFormatBGRA8Unorm, gputypes.TextureFormatBGRA8UnormSrgb,
+		gputypes.TextureFormatRGB10A2Uint, gputypes.TextureFormatRGB10A2Unorm,
+		gputypes.TextureFormatRG11B10Ufloat, gputypes.TextureFormatRGB9E5Ufloat,
+		gputypes.TextureFormatRG32Float, gputypes.TextureFormatRG32Uint, gputypes.TextureFormatRG32Sint,
+		gputypes.TextureFormatRGBA16Uint, gputypes.TextureFormatRGBA16Sint, gputypes.TextureFormatRGBA16Float,
+		gputypes.TextureFormatRGBA32Float, gputypes.TextureFormatRGBA32Uint, gputypes.TextureFormatRGBA32Sint,
+		gputypes.TextureFormatStencil8, gputypes.TextureFormatDepth16Unorm,
+		gputypes.TextureFormatDepth24Plus, gputypes.TextureFormatDepth24PlusStencil8,
+		gputypes.TextureFormatDepth32Float, gputypes.TextureFormatDepth32FloatStencil8,
+		gputypes.TextureFormatBC1RGBAUnorm, gputypes.TextureFormatBC1RGBAUnormSrgb,
+		gputypes.TextureFormatBC2RGBAUnorm, gputypes.TextureFormatBC2RGBAUnormSrgb,
+		gputypes.TextureFormatBC3RGBAUnorm, gputypes.TextureFormatBC3RGBAUnormSrgb,
+		gputypes.TextureFormatBC4RUnorm, gputypes.TextureFormatBC4RSnorm,
+		gputypes.TextureFormatBC5RGUnorm, gputypes.TextureFormatBC5RGSnorm,
+		gputypes.TextureFormatBC6HRGBUfloat, gputypes.TextureFormatBC6HRGBFloat,
+		gputypes.TextureFormatBC7RGBAUnorm, gputypes.TextureFormatBC7RGBAUnormSrgb,
+		gputypes.TextureFormatETC2RGB8Unorm, gputypes.TextureFormatETC2RGB8UnormSrgb,
+		gputypes.TextureFormatETC2RGB8A1Unorm, gputypes.TextureFormatETC2RGB8A1UnormSrgb,
+		gputypes.TextureFormatETC2RGBA8Unorm, gputypes.TextureFormatETC2RGBA8UnormSrgb,
+		gputypes.TextureFormatEACR11Unorm, gputypes.TextureFormatEACR11Snorm,
+		gputypes.TextureFormatEACRG11Unorm, gputypes.TextureFormatEACRG11Snorm,
+		gputypes.TextureFormatASTC4x4Unorm, gputypes.TextureFormatASTC4x4UnormSrgb,
+		gputypes.TextureFormatASTC5x4Unorm, gputypes.TextureFormatASTC5x4UnormSrgb,
+		gputypes.TextureFormatASTC5x5Unorm, gputypes.TextureFormatASTC5x5UnormSrgb,
+		gputypes.TextureFormatASTC6x5Unorm, gputypes.TextureFormatASTC6x5UnormSrgb,
+		gputypes.TextureFormatASTC6x6Unorm, gputypes.TextureFormatASTC6x6UnormSrgb,
+		gputypes.TextureFormatASTC8x5Unorm, gputypes.TextureFormatASTC8x5UnormSrgb,
+		gputypes.TextureFormatASTC8x6Unorm, gputypes.TextureFormatASTC8x6UnormSrgb,
+		gputypes.TextureFormatASTC8x8Unorm, gputypes.TextureFormatASTC8x8UnormSrgb,
+		gputypes.TextureFormatASTC10x5Unorm, gputypes.TextureFormatASTC10x5UnormSrgb,
+		gputypes.TextureFormatASTC10x6Unorm, gputypes.TextureFormatASTC10x6UnormSrgb,
+		gputypes.TextureFormatASTC10x8Unorm, gputypes.TextureFormatASTC10x8UnormSrgb,
+		gputypes.TextureFormatASTC10x10Unorm, gputypes.TextureFormatASTC10x10UnormSrgb,
+		gputypes.TextureFormatASTC12x10Unorm, gputypes.TextureFormatASTC12x10UnormSrgb,
+		gputypes.TextureFormatASTC12x12Unorm, gputypes.TextureFormatASTC12x12UnormSrgb,
+	}
+	for _, f := range allFormats {
+		s := TextureFormatToJS(f)
+		if s == "" {
+			t.Errorf("TextureFormatToJS(%v) returned empty string — missing mapping", f)
+		}
+	}
+}
+
+// TestVertexFormatMapCompleteness verifies that every non-Undefined vertex format
+// has a mapping.
+func TestVertexFormatMapCompleteness(t *testing.T) {
+	allFormats := []gputypes.VertexFormat{
+		gputypes.VertexFormatUint8x2, gputypes.VertexFormatUint8x4,
+		gputypes.VertexFormatSint8x2, gputypes.VertexFormatSint8x4,
+		gputypes.VertexFormatUnorm8x2, gputypes.VertexFormatUnorm8x4,
+		gputypes.VertexFormatSnorm8x2, gputypes.VertexFormatSnorm8x4,
+		gputypes.VertexFormatUint16x2, gputypes.VertexFormatUint16x4,
+		gputypes.VertexFormatSint16x2, gputypes.VertexFormatSint16x4,
+		gputypes.VertexFormatUnorm16x2, gputypes.VertexFormatUnorm16x4,
+		gputypes.VertexFormatSnorm16x2, gputypes.VertexFormatSnorm16x4,
+		gputypes.VertexFormatFloat16x2, gputypes.VertexFormatFloat16x4,
+		gputypes.VertexFormatFloat32, gputypes.VertexFormatFloat32x2,
+		gputypes.VertexFormatFloat32x3, gputypes.VertexFormatFloat32x4,
+		gputypes.VertexFormatUint32, gputypes.VertexFormatUint32x2,
+		gputypes.VertexFormatUint32x3, gputypes.VertexFormatUint32x4,
+		gputypes.VertexFormatSint32, gputypes.VertexFormatSint32x2,
+		gputypes.VertexFormatSint32x3, gputypes.VertexFormatSint32x4,
+		gputypes.VertexFormatUnorm1010102,
+	}
+	for _, f := range allFormats {
+		s := VertexFormatToJS(f)
+		if s == "" {
+			t.Errorf("VertexFormatToJS(%v) returned empty string — missing mapping", f)
+		}
+	}
+}

--- a/internal/browser/convert_resources.go
+++ b/internal/browser/convert_resources.go
@@ -1,0 +1,743 @@
+//go:build js && wasm
+
+package browser
+
+import (
+	"syscall/js"
+
+	"github.com/gogpu/gputypes"
+)
+
+// newJSObject creates a new empty JavaScript object.
+func newJSObject() js.Value {
+	return js.Global().Get("Object").New()
+}
+
+// newJSArray creates a new empty JavaScript array.
+func newJSArray() js.Value {
+	return js.Global().Get("Array").New()
+}
+
+// --- Buffer descriptor ---
+
+// BuildBufferDescriptor constructs a JS GPUBufferDescriptor object.
+func BuildBufferDescriptor(label string, size uint64, usage uint64, mappedAtCreation bool) js.Value {
+	desc := newJSObject()
+	if label != "" {
+		desc.Set("label", label)
+	}
+	desc.Set("size", float64(size))
+	desc.Set("usage", float64(usage))
+	if mappedAtCreation {
+		desc.Set("mappedAtCreation", true)
+	}
+	return desc
+}
+
+// --- Texture descriptor ---
+
+// BuildTextureDescriptor constructs a JS GPUTextureDescriptor object.
+func BuildTextureDescriptor(
+	label string,
+	width, height, depthOrArrayLayers uint32,
+	mipLevelCount, sampleCount uint32,
+	dimension gputypes.TextureDimension,
+	format gputypes.TextureFormat,
+	usage gputypes.TextureUsage,
+	viewFormats []gputypes.TextureFormat,
+) js.Value {
+	desc := newJSObject()
+	if label != "" {
+		desc.Set("label", label)
+	}
+
+	// size: GPUExtent3DDict
+	size := newJSObject()
+	size.Set("width", width)
+	if height > 1 {
+		size.Set("height", height)
+	}
+	if depthOrArrayLayers > 1 {
+		size.Set("depthOrArrayLayers", depthOrArrayLayers)
+	}
+	desc.Set("size", size)
+
+	if mipLevelCount > 1 {
+		desc.Set("mipLevelCount", mipLevelCount)
+	}
+	if sampleCount > 1 {
+		desc.Set("sampleCount", sampleCount)
+	}
+
+	dimStr := TextureDimensionToJS(dimension)
+	if dimStr != "" {
+		desc.Set("dimension", dimStr)
+	}
+
+	desc.Set("format", TextureFormatToJS(format))
+	desc.Set("usage", float64(usage))
+
+	if len(viewFormats) > 0 {
+		arr := newJSArray()
+		for _, vf := range viewFormats {
+			arr.Call("push", TextureFormatToJS(vf))
+		}
+		desc.Set("viewFormats", arr)
+	}
+
+	return desc
+}
+
+// BuildTextureViewDescriptor constructs a JS GPUTextureViewDescriptor object.
+func BuildTextureViewDescriptor(
+	label string,
+	format gputypes.TextureFormat,
+	dimension gputypes.TextureViewDimension,
+	aspect gputypes.TextureAspect,
+	baseMipLevel, mipLevelCount uint32,
+	baseArrayLayer, arrayLayerCount uint32,
+) js.Value {
+	desc := newJSObject()
+	if label != "" {
+		desc.Set("label", label)
+	}
+	if format != gputypes.TextureFormatUndefined {
+		desc.Set("format", TextureFormatToJS(format))
+	}
+	if dimension != gputypes.TextureViewDimensionUndefined {
+		desc.Set("dimension", TextureViewDimensionToJS(dimension))
+	}
+	aspectStr := TextureAspectToJS(aspect)
+	if aspectStr != "" {
+		desc.Set("aspect", aspectStr)
+	}
+	if baseMipLevel > 0 {
+		desc.Set("baseMipLevel", baseMipLevel)
+	}
+	if mipLevelCount > 0 {
+		desc.Set("mipLevelCount", mipLevelCount)
+	}
+	if baseArrayLayer > 0 {
+		desc.Set("baseArrayLayer", baseArrayLayer)
+	}
+	if arrayLayerCount > 0 {
+		desc.Set("arrayLayerCount", arrayLayerCount)
+	}
+	return desc
+}
+
+// --- Sampler descriptor ---
+
+// BuildSamplerDescriptor constructs a JS GPUSamplerDescriptor object.
+func BuildSamplerDescriptor(
+	label string,
+	addressModeU, addressModeV, addressModeW gputypes.AddressMode,
+	magFilter, minFilter gputypes.FilterMode,
+	mipmapFilter gputypes.FilterMode,
+	lodMinClamp, lodMaxClamp float32,
+	compare gputypes.CompareFunction,
+	maxAnisotropy uint16,
+) js.Value {
+	desc := newJSObject()
+	if label != "" {
+		desc.Set("label", label)
+	}
+
+	if addressModeU != gputypes.AddressModeUndefined {
+		desc.Set("addressModeU", AddressModeToJS(addressModeU))
+	}
+	if addressModeV != gputypes.AddressModeUndefined {
+		desc.Set("addressModeV", AddressModeToJS(addressModeV))
+	}
+	if addressModeW != gputypes.AddressModeUndefined {
+		desc.Set("addressModeW", AddressModeToJS(addressModeW))
+	}
+
+	if magFilter != gputypes.FilterModeUndefined {
+		desc.Set("magFilter", FilterModeToJS(magFilter))
+	}
+	if minFilter != gputypes.FilterModeUndefined {
+		desc.Set("minFilter", FilterModeToJS(minFilter))
+	}
+	if mipmapFilter != gputypes.FilterModeUndefined {
+		desc.Set("mipmapFilter", FilterModeToJS(mipmapFilter))
+	}
+
+	if lodMinClamp != 0 {
+		desc.Set("lodMinClamp", lodMinClamp)
+	}
+	if lodMaxClamp != 0 {
+		desc.Set("lodMaxClamp", lodMaxClamp)
+	}
+
+	if compare != gputypes.CompareFunctionUndefined {
+		desc.Set("compare", CompareFunctionToJS(compare))
+	}
+
+	if maxAnisotropy > 1 {
+		desc.Set("maxAnisotropy", maxAnisotropy)
+	}
+
+	return desc
+}
+
+// --- Shader module descriptor ---
+
+// BuildShaderModuleDescriptor constructs a JS GPUShaderModuleDescriptor object.
+// On browser, WGSL code goes directly to the browser's createShaderModule.
+func BuildShaderModuleDescriptor(label string, code string) js.Value {
+	desc := newJSObject()
+	if label != "" {
+		desc.Set("label", label)
+	}
+	desc.Set("code", code)
+	return desc
+}
+
+// --- Bind group layout descriptor ---
+
+// BuildBindGroupLayoutDescriptor constructs a JS GPUBindGroupLayoutDescriptor object.
+func BuildBindGroupLayoutDescriptor(
+	label string,
+	entries []BindGroupLayoutEntryJS,
+) js.Value {
+	desc := newJSObject()
+	if label != "" {
+		desc.Set("label", label)
+	}
+
+	arr := newJSArray()
+	for _, e := range entries {
+		arr.Call("push", e.ToJS())
+	}
+	desc.Set("entries", arr)
+	return desc
+}
+
+// BindGroupLayoutEntryJS holds the data needed to build a single
+// GPUBindGroupLayoutEntry JS object.
+type BindGroupLayoutEntryJS struct {
+	Binding    uint32
+	Visibility uint32 // ShaderStages bitmask
+
+	// Exactly one of these should be non-nil.
+	Buffer         *BufferBindingLayoutJS
+	Sampler        *SamplerBindingLayoutJS
+	Texture        *TextureBindingLayoutJS
+	StorageTexture *StorageTextureBindingLayoutJS
+}
+
+// ToJS converts to a JS object.
+func (e *BindGroupLayoutEntryJS) ToJS() js.Value {
+	obj := newJSObject()
+	obj.Set("binding", e.Binding)
+	obj.Set("visibility", e.Visibility)
+
+	if e.Buffer != nil {
+		obj.Set("buffer", e.Buffer.ToJS())
+	}
+	if e.Sampler != nil {
+		obj.Set("sampler", e.Sampler.ToJS())
+	}
+	if e.Texture != nil {
+		obj.Set("texture", e.Texture.ToJS())
+	}
+	if e.StorageTexture != nil {
+		obj.Set("storageTexture", e.StorageTexture.ToJS())
+	}
+	return obj
+}
+
+// BufferBindingLayoutJS holds buffer binding layout data.
+type BufferBindingLayoutJS struct {
+	Type             string // "uniform", "storage", "read-only-storage"
+	HasDynamicOffset bool
+	MinBindingSize   uint64
+}
+
+// ToJS converts to a JS object.
+func (b *BufferBindingLayoutJS) ToJS() js.Value {
+	obj := newJSObject()
+	if b.Type != "" {
+		obj.Set("type", b.Type)
+	}
+	if b.HasDynamicOffset {
+		obj.Set("hasDynamicOffset", true)
+	}
+	if b.MinBindingSize > 0 {
+		obj.Set("minBindingSize", float64(b.MinBindingSize))
+	}
+	return obj
+}
+
+// SamplerBindingLayoutJS holds sampler binding layout data.
+type SamplerBindingLayoutJS struct {
+	Type string // "filtering", "non-filtering", "comparison"
+}
+
+// ToJS converts to a JS object.
+func (s *SamplerBindingLayoutJS) ToJS() js.Value {
+	obj := newJSObject()
+	if s.Type != "" {
+		obj.Set("type", s.Type)
+	}
+	return obj
+}
+
+// TextureBindingLayoutJS holds texture binding layout data.
+type TextureBindingLayoutJS struct {
+	SampleType    string // "float", "unfilterable-float", "depth", "sint", "uint"
+	ViewDimension string // "2d", "cube", etc.
+	Multisampled  bool
+}
+
+// ToJS converts to a JS object.
+func (t *TextureBindingLayoutJS) ToJS() js.Value {
+	obj := newJSObject()
+	if t.SampleType != "" {
+		obj.Set("sampleType", t.SampleType)
+	}
+	if t.ViewDimension != "" {
+		obj.Set("viewDimension", t.ViewDimension)
+	}
+	if t.Multisampled {
+		obj.Set("multisampled", true)
+	}
+	return obj
+}
+
+// StorageTextureBindingLayoutJS holds storage texture binding layout data.
+type StorageTextureBindingLayoutJS struct {
+	Access        string // "write-only", "read-only", "read-write"
+	Format        string // texture format string
+	ViewDimension string
+}
+
+// ToJS converts to a JS object.
+func (s *StorageTextureBindingLayoutJS) ToJS() js.Value {
+	obj := newJSObject()
+	if s.Access != "" {
+		obj.Set("access", s.Access)
+	}
+	if s.Format != "" {
+		obj.Set("format", s.Format)
+	}
+	if s.ViewDimension != "" {
+		obj.Set("viewDimension", s.ViewDimension)
+	}
+	return obj
+}
+
+// --- Bind group descriptor ---
+
+// BindGroupEntryJS holds a single bind group entry for JS conversion.
+type BindGroupEntryJS struct {
+	Binding uint32
+	// Exactly one of these should be set.
+	BufferRef      js.Value // GPUBuffer ref
+	BufferOffset   uint64
+	BufferSize     uint64
+	SamplerRef     js.Value // GPUSampler ref
+	TextureViewRef js.Value // GPUTextureView ref
+}
+
+// BuildBindGroupDescriptor constructs a JS GPUBindGroupDescriptor object.
+func BuildBindGroupDescriptor(
+	label string,
+	layoutRef js.Value,
+	entries []BindGroupEntryJS,
+) js.Value {
+	desc := newJSObject()
+	if label != "" {
+		desc.Set("label", label)
+	}
+	desc.Set("layout", layoutRef)
+
+	arr := newJSArray()
+	for _, e := range entries {
+		entry := newJSObject()
+		entry.Set("binding", e.Binding)
+
+		if !e.BufferRef.IsUndefined() && !e.BufferRef.IsNull() {
+			resource := newJSObject()
+			resource.Set("buffer", e.BufferRef)
+			if e.BufferOffset > 0 {
+				resource.Set("offset", float64(e.BufferOffset))
+			}
+			if e.BufferSize > 0 {
+				resource.Set("size", float64(e.BufferSize))
+			}
+			entry.Set("resource", resource)
+		} else if !e.SamplerRef.IsUndefined() && !e.SamplerRef.IsNull() {
+			entry.Set("resource", e.SamplerRef)
+		} else if !e.TextureViewRef.IsUndefined() && !e.TextureViewRef.IsNull() {
+			entry.Set("resource", e.TextureViewRef)
+		}
+
+		arr.Call("push", entry)
+	}
+	desc.Set("entries", arr)
+	return desc
+}
+
+// --- Pipeline layout descriptor ---
+
+// BuildPipelineLayoutDescriptor constructs a JS GPUPipelineLayoutDescriptor.
+func BuildPipelineLayoutDescriptor(label string, layoutRefs []js.Value) js.Value {
+	desc := newJSObject()
+	if label != "" {
+		desc.Set("label", label)
+	}
+
+	arr := newJSArray()
+	for _, ref := range layoutRefs {
+		arr.Call("push", ref)
+	}
+	desc.Set("bindGroupLayouts", arr)
+	return desc
+}
+
+// --- Render pipeline descriptor ---
+
+// BuildRenderPipelineDescriptor constructs a JS GPURenderPipelineDescriptor.
+func BuildRenderPipelineDescriptor(desc *RenderPipelineDescriptorJS) js.Value {
+	obj := newJSObject()
+	if desc.Label != "" {
+		obj.Set("label", desc.Label)
+	}
+
+	// layout: "auto" or GPUPipelineLayout reference.
+	if desc.LayoutRef.IsUndefined() || desc.LayoutRef.IsNull() {
+		obj.Set("layout", "auto")
+	} else {
+		obj.Set("layout", desc.LayoutRef)
+	}
+
+	// vertex state (required)
+	obj.Set("vertex", desc.Vertex.ToJS())
+
+	// primitive state
+	if desc.Primitive != nil {
+		obj.Set("primitive", desc.Primitive.ToJS())
+	}
+
+	// depth-stencil state
+	if desc.DepthStencil != nil {
+		obj.Set("depthStencil", desc.DepthStencil.ToJS())
+	}
+
+	// multisample state
+	if desc.Multisample != nil {
+		obj.Set("multisample", desc.Multisample.ToJS())
+	}
+
+	// fragment state
+	if desc.Fragment != nil {
+		obj.Set("fragment", desc.Fragment.ToJS())
+	}
+
+	return obj
+}
+
+// RenderPipelineDescriptorJS holds render pipeline creation data.
+type RenderPipelineDescriptorJS struct {
+	Label        string
+	LayoutRef    js.Value // GPUPipelineLayout or js.Undefined() for "auto"
+	Vertex       VertexStateJS
+	Primitive    *PrimitiveStateJS
+	DepthStencil *DepthStencilStateJS
+	Multisample  *MultisampleStateJS
+	Fragment     *FragmentStateJS
+}
+
+// VertexStateJS holds vertex shader state for JS.
+type VertexStateJS struct {
+	ModuleRef  js.Value // GPUShaderModule
+	EntryPoint string
+	Buffers    []VertexBufferLayoutJS
+}
+
+// ToJS converts to a JS object.
+func (v *VertexStateJS) ToJS() js.Value {
+	obj := newJSObject()
+	obj.Set("module", v.ModuleRef)
+	if v.EntryPoint != "" {
+		obj.Set("entryPoint", v.EntryPoint)
+	}
+
+	if len(v.Buffers) > 0 {
+		arr := newJSArray()
+		for _, buf := range v.Buffers {
+			arr.Call("push", buf.ToJS())
+		}
+		obj.Set("buffers", arr)
+	}
+	return obj
+}
+
+// VertexBufferLayoutJS holds a vertex buffer layout for JS.
+type VertexBufferLayoutJS struct {
+	ArrayStride uint64
+	StepMode    string // "vertex" or "instance"
+	Attributes  []VertexAttributeJS
+}
+
+// ToJS converts to a JS object.
+func (l *VertexBufferLayoutJS) ToJS() js.Value {
+	obj := newJSObject()
+	obj.Set("arrayStride", float64(l.ArrayStride))
+	if l.StepMode != "" {
+		obj.Set("stepMode", l.StepMode)
+	}
+
+	attrs := newJSArray()
+	for _, a := range l.Attributes {
+		attr := newJSObject()
+		attr.Set("format", a.Format)
+		attr.Set("offset", float64(a.Offset))
+		attr.Set("shaderLocation", a.ShaderLocation)
+		attrs.Call("push", attr)
+	}
+	obj.Set("attributes", attrs)
+	return obj
+}
+
+// VertexAttributeJS holds a vertex attribute for JS.
+type VertexAttributeJS struct {
+	Format         string // e.g. "float32x2"
+	Offset         uint64
+	ShaderLocation uint32
+}
+
+// PrimitiveStateJS holds primitive assembly state for JS.
+type PrimitiveStateJS struct {
+	Topology         string // "triangle-list", etc.
+	StripIndexFormat string // "uint16", "uint32" (only for strip topologies)
+	FrontFace        string // "ccw", "cw"
+	CullMode         string // "none", "front", "back"
+	UnclippedDepth   bool
+}
+
+// ToJS converts to a JS object.
+func (p *PrimitiveStateJS) ToJS() js.Value {
+	obj := newJSObject()
+	if p.Topology != "" {
+		obj.Set("topology", p.Topology)
+	}
+	if p.StripIndexFormat != "" {
+		obj.Set("stripIndexFormat", p.StripIndexFormat)
+	}
+	if p.FrontFace != "" {
+		obj.Set("frontFace", p.FrontFace)
+	}
+	if p.CullMode != "" {
+		obj.Set("cullMode", p.CullMode)
+	}
+	if p.UnclippedDepth {
+		obj.Set("unclippedDepth", true)
+	}
+	return obj
+}
+
+// DepthStencilStateJS holds depth-stencil state for JS.
+type DepthStencilStateJS struct {
+	Format              string
+	DepthWriteEnabled   bool
+	DepthCompare        string
+	StencilFront        *StencilFaceStateJS
+	StencilBack         *StencilFaceStateJS
+	StencilReadMask     uint32
+	StencilWriteMask    uint32
+	DepthBias           int32
+	DepthBiasSlopeScale float32
+	DepthBiasClamp      float32
+}
+
+// ToJS converts to a JS object.
+func (d *DepthStencilStateJS) ToJS() js.Value {
+	obj := newJSObject()
+	obj.Set("format", d.Format)
+	obj.Set("depthWriteEnabled", d.DepthWriteEnabled)
+	if d.DepthCompare != "" {
+		obj.Set("depthCompare", d.DepthCompare)
+	}
+	if d.StencilFront != nil {
+		obj.Set("stencilFront", d.StencilFront.ToJS())
+	}
+	if d.StencilBack != nil {
+		obj.Set("stencilBack", d.StencilBack.ToJS())
+	}
+	if d.StencilReadMask != 0 {
+		obj.Set("stencilReadMask", d.StencilReadMask)
+	}
+	if d.StencilWriteMask != 0 {
+		obj.Set("stencilWriteMask", d.StencilWriteMask)
+	}
+	if d.DepthBias != 0 {
+		obj.Set("depthBias", d.DepthBias)
+	}
+	if d.DepthBiasSlopeScale != 0 {
+		obj.Set("depthBiasSlopeScale", d.DepthBiasSlopeScale)
+	}
+	if d.DepthBiasClamp != 0 {
+		obj.Set("depthBiasClamp", d.DepthBiasClamp)
+	}
+	return obj
+}
+
+// StencilFaceStateJS holds stencil operations for a face.
+type StencilFaceStateJS struct {
+	Compare     string
+	FailOp      string
+	DepthFailOp string
+	PassOp      string
+}
+
+// ToJS converts to a JS object.
+func (s *StencilFaceStateJS) ToJS() js.Value {
+	obj := newJSObject()
+	if s.Compare != "" {
+		obj.Set("compare", s.Compare)
+	}
+	if s.FailOp != "" {
+		obj.Set("failOp", s.FailOp)
+	}
+	if s.DepthFailOp != "" {
+		obj.Set("depthFailOp", s.DepthFailOp)
+	}
+	if s.PassOp != "" {
+		obj.Set("passOp", s.PassOp)
+	}
+	return obj
+}
+
+// MultisampleStateJS holds multisample state for JS.
+type MultisampleStateJS struct {
+	Count                  uint32
+	Mask                   uint64
+	AlphaToCoverageEnabled bool
+}
+
+// ToJS converts to a JS object.
+func (m *MultisampleStateJS) ToJS() js.Value {
+	obj := newJSObject()
+	if m.Count > 0 {
+		obj.Set("count", m.Count)
+	}
+	if m.Mask > 0 {
+		obj.Set("mask", float64(m.Mask))
+	}
+	if m.AlphaToCoverageEnabled {
+		obj.Set("alphaToCoverageEnabled", true)
+	}
+	return obj
+}
+
+// FragmentStateJS holds fragment shader state for JS.
+type FragmentStateJS struct {
+	ModuleRef  js.Value // GPUShaderModule
+	EntryPoint string
+	Targets    []ColorTargetStateJS
+}
+
+// ToJS converts to a JS object.
+func (f *FragmentStateJS) ToJS() js.Value {
+	obj := newJSObject()
+	obj.Set("module", f.ModuleRef)
+	if f.EntryPoint != "" {
+		obj.Set("entryPoint", f.EntryPoint)
+	}
+
+	targets := newJSArray()
+	for _, t := range f.Targets {
+		targets.Call("push", t.ToJS())
+	}
+	obj.Set("targets", targets)
+	return obj
+}
+
+// ColorTargetStateJS holds a color target for JS.
+type ColorTargetStateJS struct {
+	Format    string
+	Blend     *BlendStateJS
+	WriteMask uint32
+}
+
+// ToJS converts to a JS object.
+func (c *ColorTargetStateJS) ToJS() js.Value {
+	obj := newJSObject()
+	obj.Set("format", c.Format)
+	if c.Blend != nil {
+		obj.Set("blend", c.Blend.ToJS())
+	}
+	if c.WriteMask > 0 {
+		obj.Set("writeMask", c.WriteMask)
+	}
+	return obj
+}
+
+// BlendStateJS holds blend state for JS.
+type BlendStateJS struct {
+	Color BlendComponentJS
+	Alpha BlendComponentJS
+}
+
+// ToJS converts to a JS object.
+func (b *BlendStateJS) ToJS() js.Value {
+	obj := newJSObject()
+	obj.Set("color", b.Color.ToJS())
+	obj.Set("alpha", b.Alpha.ToJS())
+	return obj
+}
+
+// BlendComponentJS holds a blend component for JS.
+type BlendComponentJS struct {
+	SrcFactor string
+	DstFactor string
+	Operation string
+}
+
+// ToJS converts to a JS object.
+func (bc *BlendComponentJS) ToJS() js.Value {
+	obj := newJSObject()
+	if bc.SrcFactor != "" {
+		obj.Set("srcFactor", bc.SrcFactor)
+	}
+	if bc.DstFactor != "" {
+		obj.Set("dstFactor", bc.DstFactor)
+	}
+	if bc.Operation != "" {
+		obj.Set("operation", bc.Operation)
+	}
+	return obj
+}
+
+// --- Compute pipeline descriptor ---
+
+// BuildComputePipelineDescriptor constructs a JS GPUComputePipelineDescriptor.
+func BuildComputePipelineDescriptor(
+	label string,
+	layoutRef js.Value,
+	moduleRef js.Value,
+	entryPoint string,
+) js.Value {
+	desc := newJSObject()
+	if label != "" {
+		desc.Set("label", label)
+	}
+
+	if layoutRef.IsUndefined() || layoutRef.IsNull() {
+		desc.Set("layout", "auto")
+	} else {
+		desc.Set("layout", layoutRef)
+	}
+
+	compute := newJSObject()
+	compute.Set("module", moduleRef)
+	if entryPoint != "" {
+		compute.Set("entryPoint", entryPoint)
+	}
+	desc.Set("compute", compute)
+
+	return desc
+}

--- a/internal/browser/convert_resources.go
+++ b/internal/browser/convert_resources.go
@@ -712,6 +712,199 @@ func (bc *BlendComponentJS) ToJS() js.Value {
 	return obj
 }
 
+// --- Command encoder descriptor ---
+
+// BuildCommandEncoderDescriptor constructs a JS GPUCommandEncoderDescriptor.
+func BuildCommandEncoderDescriptor(label string) js.Value {
+	desc := newJSObject()
+	if label != "" {
+		desc.Set("label", label)
+	}
+	return desc
+}
+
+// --- Render pass descriptor ---
+
+// RenderPassColorAttachmentJS holds data for building a GPURenderPassColorAttachment.
+type RenderPassColorAttachmentJS struct {
+	View          js.Value // GPUTextureView
+	ResolveTarget js.Value // GPUTextureView or js.Undefined()
+	LoadOp        string   // "load" or "clear"
+	StoreOp       string   // "store" or "discard"
+	ClearR        float64
+	ClearG        float64
+	ClearB        float64
+	ClearA        float64
+}
+
+// RenderPassDepthStencilAttachmentJS holds data for building a
+// GPURenderPassDepthStencilAttachment.
+type RenderPassDepthStencilAttachmentJS struct {
+	View              js.Value // GPUTextureView
+	DepthLoadOp       string   // "load" or "clear"
+	DepthStoreOp      string   // "store" or "discard"
+	DepthClearValue   float32
+	DepthReadOnly     bool
+	StencilLoadOp     string // "load" or "clear"
+	StencilStoreOp    string // "store" or "discard"
+	StencilClearValue uint32
+	StencilReadOnly   bool
+}
+
+// BuildRenderPassDescriptor constructs a JS GPURenderPassDescriptor.
+//
+// Matches Rust wgpu's begin_render_pass which builds GpuRenderPassDescriptor
+// with color attachments array and optional depth-stencil attachment.
+func BuildRenderPassDescriptor(
+	label string,
+	colorAttachments []RenderPassColorAttachmentJS,
+	depthStencil *RenderPassDepthStencilAttachmentJS,
+) js.Value {
+	// Build color attachments array.
+	arr := newJSArray()
+	for _, ca := range colorAttachments {
+		att := newJSObject()
+		att.Set("view", ca.View)
+		att.Set("loadOp", ca.LoadOp)
+		att.Set("storeOp", ca.StoreOp)
+
+		// Set clear value when loadOp is "clear".
+		if ca.LoadOp == "clear" {
+			clearColor := newJSObject()
+			clearColor.Set("r", ca.ClearR)
+			clearColor.Set("g", ca.ClearG)
+			clearColor.Set("b", ca.ClearB)
+			clearColor.Set("a", ca.ClearA)
+			att.Set("clearValue", clearColor)
+		}
+
+		if !ca.ResolveTarget.IsUndefined() && !ca.ResolveTarget.IsNull() {
+			att.Set("resolveTarget", ca.ResolveTarget)
+		}
+
+		arr.Call("push", att)
+	}
+
+	desc := newJSObject()
+	if label != "" {
+		desc.Set("label", label)
+	}
+	desc.Set("colorAttachments", arr)
+
+	// Depth-stencil attachment (optional).
+	if depthStencil != nil {
+		ds := newJSObject()
+		ds.Set("view", depthStencil.View)
+
+		if !depthStencil.DepthReadOnly {
+			ds.Set("depthLoadOp", depthStencil.DepthLoadOp)
+			ds.Set("depthStoreOp", depthStencil.DepthStoreOp)
+			if depthStencil.DepthLoadOp == "clear" {
+				ds.Set("depthClearValue", depthStencil.DepthClearValue)
+			}
+		}
+		ds.Set("depthReadOnly", depthStencil.DepthReadOnly)
+
+		if !depthStencil.StencilReadOnly {
+			ds.Set("stencilLoadOp", depthStencil.StencilLoadOp)
+			ds.Set("stencilStoreOp", depthStencil.StencilStoreOp)
+			if depthStencil.StencilLoadOp == "clear" {
+				ds.Set("stencilClearValue", depthStencil.StencilClearValue)
+			}
+		}
+		ds.Set("stencilReadOnly", depthStencil.StencilReadOnly)
+
+		desc.Set("depthStencilAttachment", ds)
+	}
+
+	return desc
+}
+
+// --- Compute pass descriptor ---
+
+// BuildComputePassDescriptor constructs a JS GPUComputePassDescriptor.
+func BuildComputePassDescriptor(label string) js.Value {
+	desc := newJSObject()
+	if label != "" {
+		desc.Set("label", label)
+	}
+	return desc
+}
+
+// --- Image copy descriptors (for copyBufferToTexture / copyTextureToBuffer) ---
+
+// BuildImageCopyBuffer constructs a JS GPUTexelCopyBufferInfo (formerly GPUImageCopyBuffer).
+func BuildImageCopyBuffer(buffer js.Value, offset uint64, bytesPerRow, rowsPerImage uint32) js.Value {
+	obj := newJSObject()
+	obj.Set("buffer", buffer)
+	if offset > 0 {
+		obj.Set("offset", float64(offset))
+	}
+	if bytesPerRow > 0 {
+		obj.Set("bytesPerRow", bytesPerRow)
+	}
+	if rowsPerImage > 0 {
+		obj.Set("rowsPerImage", rowsPerImage)
+	}
+	return obj
+}
+
+// BuildImageCopyTexture constructs a JS GPUTexelCopyTextureInfo (formerly GPUImageCopyTexture).
+func BuildImageCopyTexture(texture js.Value, mipLevel uint32, originX, originY, originZ uint32) js.Value {
+	obj := newJSObject()
+	obj.Set("texture", texture)
+	if mipLevel > 0 {
+		obj.Set("mipLevel", mipLevel)
+	}
+	if originX > 0 || originY > 0 || originZ > 0 {
+		origin := newJSObject()
+		origin.Set("x", originX)
+		origin.Set("y", originY)
+		origin.Set("z", originZ)
+		obj.Set("origin", origin)
+	}
+	return obj
+}
+
+// BuildExtent3D constructs a JS GPUExtent3DDict.
+func BuildExtent3D(width, height, depthOrArrayLayers uint32) js.Value {
+	obj := newJSObject()
+	obj.Set("width", width)
+	if height > 0 {
+		obj.Set("height", height)
+	}
+	if depthOrArrayLayers > 0 {
+		obj.Set("depthOrArrayLayers", depthOrArrayLayers)
+	}
+	return obj
+}
+
+// BuildColorDict constructs a JS GPUColorDict { r, g, b, a }.
+func BuildColorDict(r, g, b, a float64) js.Value {
+	obj := newJSObject()
+	obj.Set("r", r)
+	obj.Set("g", g)
+	obj.Set("b", b)
+	obj.Set("a", a)
+	return obj
+}
+
+// BuildTexelCopyBufferLayout constructs a JS GPUTexelCopyBufferLayout
+// (formerly GPUImageDataLayout).
+func BuildTexelCopyBufferLayout(offset uint64, bytesPerRow, rowsPerImage uint32) js.Value {
+	obj := newJSObject()
+	if offset > 0 {
+		obj.Set("offset", float64(offset))
+	}
+	if bytesPerRow > 0 {
+		obj.Set("bytesPerRow", bytesPerRow)
+	}
+	if rowsPerImage > 0 {
+		obj.Set("rowsPerImage", rowsPerImage)
+	}
+	return obj
+}
+
 // --- Compute pipeline descriptor ---
 
 // BuildComputePipelineDescriptor constructs a JS GPUComputePipelineDescriptor.

--- a/internal/browser/convert_surface.go
+++ b/internal/browser/convert_surface.go
@@ -1,0 +1,59 @@
+package browser
+
+import "github.com/gogpu/gputypes"
+
+// CompositeAlphaModeToJS converts a gputypes.CompositeAlphaMode to the WebGPU JS
+// canvas alpha mode string.
+//
+// Browser WebGPU only supports "opaque" and "premultiplied". PostMultiplied and
+// Inherit are not valid on the web (Rust wgpu panics on those). Auto and Opaque
+// both map to "opaque".
+//
+// See: https://www.w3.org/TR/webgpu/#enumdef-gpucanvasalphamode
+func CompositeAlphaModeToJS(mode gputypes.CompositeAlphaMode) string {
+	switch mode {
+	case gputypes.CompositeAlphaModePremultiplied:
+		return "premultiplied"
+	default:
+		// Auto, Opaque, Unpremultiplied, Inherit all fall back to opaque.
+		// Rust wgpu panics on PostMultiplied/Inherit; we gracefully default.
+		return "opaque" //nolint:goconst // intentional literal in enum-to-string conversion
+	}
+}
+
+// PresentModeToJS converts a gputypes.PresentMode to the WebGPU JS present mode string.
+//
+// Browser WebGPU does not expose present mode control; the browser always uses
+// FIFO (VSync). Rust wgpu panics on Mailbox/Immediate on the web.
+// We return "fifo" for all modes since the browser ignores it anyway.
+func PresentModeToJS(mode gputypes.PresentMode) string {
+	// Browser WebGPU only supports FIFO. The configure() call does not even
+	// accept a presentMode field -- the browser auto-presents with VSync.
+	_ = mode
+	return "fifo" //nolint:goconst // intentional literal; browser only supports FIFO
+}
+
+// TextureFormatFromJS converts a WebGPU JS texture format string to the
+// corresponding gputypes.TextureFormat. Returns TextureFormatUndefined if
+// the string is not recognized.
+//
+// This is the reverse of TextureFormatToJS and is needed for parsing the
+// preferred canvas format returned by navigator.gpu.getPreferredCanvasFormat().
+func TextureFormatFromJS(s string) gputypes.TextureFormat {
+	f, ok := textureFormatFromJSMap[s]
+	if ok {
+		return f
+	}
+	return gputypes.TextureFormatUndefined
+}
+
+// textureFormatFromJSMap is the reverse mapping of textureFormatMap.
+// Built at init time from textureFormatMap.
+var textureFormatFromJSMap map[string]gputypes.TextureFormat
+
+func init() {
+	textureFormatFromJSMap = make(map[string]gputypes.TextureFormat, len(textureFormatMap))
+	for k, v := range textureFormatMap {
+		textureFormatFromJSMap[v] = k
+	}
+}

--- a/internal/browser/convert_surface_js.go
+++ b/internal/browser/convert_surface_js.go
@@ -1,0 +1,52 @@
+//go:build js && wasm
+
+package browser
+
+import (
+	"syscall/js"
+
+	"github.com/gogpu/gputypes"
+)
+
+// BuildSurfaceConfiguration constructs a JS GPUCanvasConfiguration object.
+//
+// The returned object is passed to GPUCanvasContext.configure(). Fields match
+// the WebGPU spec GPUCanvasConfiguration dictionary:
+//   - device: GPUDevice
+//   - format: GPUTextureFormat string
+//   - usage: GPUTextureUsageFlags (default: RENDER_ATTACHMENT)
+//   - alphaMode: GPUCanvasAlphaMode ("opaque" or "premultiplied")
+//   - viewFormats: sequence<GPUTextureFormat>
+//
+// Note: the spec does not include width/height/presentMode in the configure()
+// call. Canvas dimensions are set separately via canvas.width/canvas.height.
+//
+// Matches Rust wgpu SurfaceInterface::configure for WebSurface which builds
+// GpuCanvasConfiguration with device, format, usage, alpha_mode, view_formats.
+func BuildSurfaceConfiguration(
+	deviceRef js.Value,
+	format gputypes.TextureFormat,
+	usage gputypes.TextureUsage,
+	alphaMode gputypes.CompositeAlphaMode,
+	viewFormats []gputypes.TextureFormat,
+) js.Value {
+	config := newJSObject()
+	config.Set("device", deviceRef)
+	config.Set("format", TextureFormatToJS(format))
+
+	// Usage defaults to RENDER_ATTACHMENT in the spec, but we set it explicitly
+	// for clarity (Rust wgpu also sets it explicitly).
+	config.Set("usage", float64(usage))
+
+	config.Set("alphaMode", CompositeAlphaModeToJS(alphaMode))
+
+	if len(viewFormats) > 0 {
+		arr := newJSArray()
+		for _, vf := range viewFormats {
+			arr.Call("push", TextureFormatToJS(vf))
+		}
+		config.Set("viewFormats", arr)
+	}
+
+	return config
+}

--- a/internal/browser/convert_surface_test.go
+++ b/internal/browser/convert_surface_test.go
@@ -1,0 +1,87 @@
+package browser
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+)
+
+// TestCompositeAlphaModeToJS verifies all composite alpha mode mappings.
+func TestCompositeAlphaModeToJS(t *testing.T) {
+	tests := []struct {
+		mode gputypes.CompositeAlphaMode
+		want string
+	}{
+		{gputypes.CompositeAlphaModeAuto, "opaque"},
+		{gputypes.CompositeAlphaModeOpaque, "opaque"},
+		{gputypes.CompositeAlphaModePremultiplied, "premultiplied"},
+		{gputypes.CompositeAlphaModeUnpremultiplied, "opaque"}, // not supported on web, falls back
+		{gputypes.CompositeAlphaModeInherit, "opaque"},         // not supported on web, falls back
+	}
+	for _, tc := range tests {
+		got := CompositeAlphaModeToJS(tc.mode)
+		if got != tc.want {
+			t.Errorf("CompositeAlphaModeToJS(%v) = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// TestPresentModeToJS verifies that all present modes return "fifo" on browser.
+func TestPresentModeToJS(t *testing.T) {
+	tests := []struct {
+		mode gputypes.PresentMode
+		want string
+	}{
+		{gputypes.PresentModeFifo, "fifo"},
+		{gputypes.PresentModeFifoRelaxed, "fifo"},
+		{gputypes.PresentModeImmediate, "fifo"},
+		{gputypes.PresentModeMailbox, "fifo"},
+		{gputypes.PresentModeUndefined, "fifo"},
+	}
+	for _, tc := range tests {
+		got := PresentModeToJS(tc.mode)
+		if got != tc.want {
+			t.Errorf("PresentModeToJS(%v) = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// TestTextureFormatFromJS verifies the reverse mapping from JS strings to Go format constants.
+func TestTextureFormatFromJS(t *testing.T) {
+	tests := []struct {
+		jsStr string
+		want  gputypes.TextureFormat
+	}{
+		// Canvas preferred formats (the primary use case)
+		{"bgra8unorm", gputypes.TextureFormatBGRA8Unorm},
+		{"rgba8unorm", gputypes.TextureFormatRGBA8Unorm},
+		{"rgba16float", gputypes.TextureFormatRGBA16Float},
+
+		// Spot check other common formats
+		{"r8unorm", gputypes.TextureFormatR8Unorm},
+		{"depth32float", gputypes.TextureFormatDepth32Float},
+		{"bc1-rgba-unorm", gputypes.TextureFormatBC1RGBAUnorm},
+
+		// Unknown returns Undefined
+		{"", gputypes.TextureFormatUndefined},
+		{"nonexistent-format", gputypes.TextureFormatUndefined},
+	}
+	for _, tc := range tests {
+		got := TextureFormatFromJS(tc.jsStr)
+		if got != tc.want {
+			t.Errorf("TextureFormatFromJS(%q) = %v, want %v", tc.jsStr, got, tc.want)
+		}
+	}
+}
+
+// TestTextureFormatRoundTrip verifies that every format in the forward map
+// can be recovered by the reverse map, and vice versa.
+func TestTextureFormatRoundTrip(t *testing.T) {
+	for goFmt, jsStr := range textureFormatMap {
+		recovered := TextureFormatFromJS(jsStr)
+		if recovered != goFmt {
+			t.Errorf("round trip failed: TextureFormatToJS(%v) = %q, TextureFormatFromJS(%q) = %v, want %v",
+				goFmt, jsStr, jsStr, recovered, goFmt)
+		}
+	}
+}

--- a/internal/browser/device.go
+++ b/internal/browser/device.go
@@ -1,0 +1,146 @@
+//go:build js && wasm
+
+package browser
+
+import "syscall/js"
+
+// Device wraps a browser GPUDevice with pre-bound creation methods.
+//
+// Pre-binding JS methods at construction time avoids repeated .Get("methodName")
+// calls on every frame. This pattern is used by Ebiten and other Go WASM libraries
+// for optimal performance.
+//
+// Matches Rust wgpu WebDevice which holds the webgpu_sys::GpuDevice value.
+type Device struct {
+	// ref_ is the GPUDevice JavaScript object.
+	ref_ js.Value
+
+	// queue is the device's command queue (GPUQueue).
+	queue *Queue
+
+	// features is the device's GPUSupportedFeatures.
+	features js.Value
+
+	// limits is the device's GPUSupportedLimits.
+	limits js.Value
+
+	// Pre-bound creation methods. Each is the result of
+	// device.methodName.bind(device), so calling fnX.Invoke(args...)
+	// is equivalent to device.methodName(args...) but without the
+	// property lookup overhead on each call.
+	fnCreateBuffer          js.Value
+	fnCreateTexture         js.Value
+	fnCreateShaderModule    js.Value
+	fnCreateBindGroupLayout js.Value
+	fnCreateBindGroup       js.Value
+	fnCreatePipelineLayout  js.Value
+	fnCreateRenderPipeline  js.Value
+	fnCreateComputePipeline js.Value
+	fnCreateCommandEncoder  js.Value
+	fnCreateSampler         js.Value
+	fnCreateQuerySet        js.Value
+}
+
+// NewDevice constructs a Device from a GPUDevice js.Value.
+// Pre-binds all creation methods and extracts the queue.
+func NewDevice(ref js.Value) *Device {
+	d := &Device{
+		ref_:     ref,
+		features: ref.Get("features"),
+		limits:   ref.Get("limits"),
+	}
+
+	// Extract the device's queue (GPUDevice.queue is a readonly attribute).
+	d.queue = NewQueue(ref.Get("queue"))
+
+	// Pre-bind all creation methods to avoid property lookups on hot paths.
+	// pattern: device.createX.bind(device) => fnCreateX
+	d.fnCreateBuffer = bindMethod(ref, "createBuffer")
+	d.fnCreateTexture = bindMethod(ref, "createTexture")
+	d.fnCreateShaderModule = bindMethod(ref, "createShaderModule")
+	d.fnCreateBindGroupLayout = bindMethod(ref, "createBindGroupLayout")
+	d.fnCreateBindGroup = bindMethod(ref, "createBindGroup")
+	d.fnCreatePipelineLayout = bindMethod(ref, "createPipelineLayout")
+	d.fnCreateRenderPipeline = bindMethod(ref, "createRenderPipeline")
+	d.fnCreateComputePipeline = bindMethod(ref, "createComputePipeline")
+	d.fnCreateCommandEncoder = bindMethod(ref, "createCommandEncoder")
+	d.fnCreateSampler = bindMethod(ref, "createSampler")
+	d.fnCreateQuerySet = bindMethod(ref, "createQuerySet")
+
+	return d
+}
+
+// bindMethod returns methodName.bind(obj) so that Invoke() calls the method
+// with the correct `this` context.
+func bindMethod(obj js.Value, methodName string) js.Value {
+	method := obj.Get(methodName)
+	if method.IsUndefined() || method.IsNull() {
+		// Method not available — return undefined. Callers will get a
+		// clear JS error when they try to invoke it.
+		return js.Undefined()
+	}
+	return method.Call("bind", obj)
+}
+
+// Queue returns the device's command queue.
+func (d *Device) Queue() *Queue {
+	return d.queue
+}
+
+// Features returns the device's GPUSupportedFeatures js.Value.
+func (d *Device) Features() js.Value {
+	return d.features
+}
+
+// Limits returns the device's GPUSupportedLimits js.Value.
+func (d *Device) Limits() js.Value {
+	return d.limits
+}
+
+// Ref returns the underlying GPUDevice js.Value.
+func (d *Device) Ref() js.Value {
+	return d.ref_
+}
+
+// CreateBuffer returns the pre-bound createBuffer function.
+// Call with: d.CreateBuffer().Invoke(descriptorObj)
+func (d *Device) CreateBuffer() js.Value { return d.fnCreateBuffer }
+
+// CreateTexture returns the pre-bound createTexture function.
+func (d *Device) CreateTexture() js.Value { return d.fnCreateTexture }
+
+// CreateShaderModule returns the pre-bound createShaderModule function.
+func (d *Device) CreateShaderModule() js.Value { return d.fnCreateShaderModule }
+
+// CreateBindGroupLayout returns the pre-bound createBindGroupLayout function.
+func (d *Device) CreateBindGroupLayout() js.Value { return d.fnCreateBindGroupLayout }
+
+// CreateBindGroup returns the pre-bound createBindGroup function.
+func (d *Device) CreateBindGroup() js.Value { return d.fnCreateBindGroup }
+
+// CreatePipelineLayout returns the pre-bound createPipelineLayout function.
+func (d *Device) CreatePipelineLayout() js.Value { return d.fnCreatePipelineLayout }
+
+// CreateRenderPipeline returns the pre-bound createRenderPipeline function.
+func (d *Device) CreateRenderPipeline() js.Value { return d.fnCreateRenderPipeline }
+
+// CreateComputePipeline returns the pre-bound createComputePipeline function.
+func (d *Device) CreateComputePipeline() js.Value { return d.fnCreateComputePipeline }
+
+// CreateCommandEncoder returns the pre-bound createCommandEncoder function.
+func (d *Device) CreateCommandEncoder() js.Value { return d.fnCreateCommandEncoder }
+
+// CreateSampler returns the pre-bound createSampler function.
+func (d *Device) CreateSampler() js.Value { return d.fnCreateSampler }
+
+// CreateQuerySet returns the pre-bound createQuerySet function.
+func (d *Device) CreateQuerySet() js.Value { return d.fnCreateQuerySet }
+
+// Destroy calls GPUDevice.destroy() to release GPU resources.
+// After this call the device is no longer usable.
+func (d *Device) Destroy() {
+	destroy := d.ref_.Get("destroy")
+	if !destroy.IsUndefined() && !destroy.IsNull() {
+		d.ref_.Call("destroy")
+	}
+}

--- a/internal/browser/device.go
+++ b/internal/browser/device.go
@@ -136,6 +136,60 @@ func (d *Device) CreateSampler() js.Value { return d.fnCreateSampler }
 // CreateQuerySet returns the pre-bound createQuerySet function.
 func (d *Device) CreateQuerySet() js.Value { return d.fnCreateQuerySet }
 
+// CreateBufferFromDesc creates a GPUBuffer from a JS descriptor object.
+func (d *Device) CreateBufferFromDesc(desc js.Value) *Buffer {
+	jsBuffer := d.fnCreateBuffer.Invoke(desc)
+	return NewBuffer(jsBuffer)
+}
+
+// CreateTextureFromDesc creates a GPUTexture from a JS descriptor object.
+func (d *Device) CreateTextureFromDesc(desc js.Value) *Texture {
+	jsTexture := d.fnCreateTexture.Invoke(desc)
+	return NewTexture(jsTexture)
+}
+
+// CreateSamplerFromDesc creates a GPUSampler from a JS descriptor object.
+func (d *Device) CreateSamplerFromDesc(desc js.Value) *Sampler {
+	jsSampler := d.fnCreateSampler.Invoke(desc)
+	return NewSampler(jsSampler)
+}
+
+// CreateShaderModuleFromDesc creates a GPUShaderModule from a JS descriptor object.
+func (d *Device) CreateShaderModuleFromDesc(desc js.Value) *ShaderModule {
+	jsModule := d.fnCreateShaderModule.Invoke(desc)
+	return NewShaderModule(jsModule)
+}
+
+// CreateBindGroupLayoutFromDesc creates a GPUBindGroupLayout from a JS descriptor object.
+func (d *Device) CreateBindGroupLayoutFromDesc(desc js.Value) *BindGroupLayout {
+	jsLayout := d.fnCreateBindGroupLayout.Invoke(desc)
+	return NewBindGroupLayout(jsLayout)
+}
+
+// CreateBindGroupFromDesc creates a GPUBindGroup from a JS descriptor object.
+func (d *Device) CreateBindGroupFromDesc(desc js.Value) *BindGroup {
+	jsGroup := d.fnCreateBindGroup.Invoke(desc)
+	return NewBindGroup(jsGroup)
+}
+
+// CreatePipelineLayoutFromDesc creates a GPUPipelineLayout from a JS descriptor object.
+func (d *Device) CreatePipelineLayoutFromDesc(desc js.Value) *PipelineLayout {
+	jsLayout := d.fnCreatePipelineLayout.Invoke(desc)
+	return NewPipelineLayout(jsLayout)
+}
+
+// CreateRenderPipelineFromDesc creates a GPURenderPipeline from a JS descriptor object.
+func (d *Device) CreateRenderPipelineFromDesc(desc js.Value) *RenderPipeline {
+	jsPipeline := d.fnCreateRenderPipeline.Invoke(desc)
+	return NewRenderPipeline(jsPipeline)
+}
+
+// CreateComputePipelineFromDesc creates a GPUComputePipeline from a JS descriptor object.
+func (d *Device) CreateComputePipelineFromDesc(desc js.Value) *ComputePipeline {
+	jsPipeline := d.fnCreateComputePipeline.Invoke(desc)
+	return NewComputePipeline(jsPipeline)
+}
+
 // Destroy calls GPUDevice.destroy() to release GPU resources.
 // After this call the device is no longer usable.
 func (d *Device) Destroy() {

--- a/internal/browser/encoder.go
+++ b/internal/browser/encoder.go
@@ -1,0 +1,111 @@
+//go:build js && wasm
+
+package browser
+
+import "syscall/js"
+
+// CommandEncoder wraps a browser GPUCommandEncoder with pre-bound methods.
+//
+// Pre-binding JS methods at construction time avoids repeated .Get("methodName")
+// calls on every frame. The browser's GPUCommandEncoder records GPU commands
+// that are later submitted via Queue.Submit.
+//
+// Matches Rust wgpu WebCommandEncoder which holds the webgpu_sys::GpuCommandEncoder.
+type CommandEncoder struct {
+	// ref_ is the GPUCommandEncoder JavaScript object.
+	ref_ js.Value
+
+	// Pre-bound methods for command recording.
+	fnBeginRenderPass      js.Value
+	fnBeginComputePass     js.Value
+	fnCopyBufferToBuffer   js.Value
+	fnCopyBufferToTexture  js.Value
+	fnCopyTextureToBuffer  js.Value
+	fnCopyTextureToTexture js.Value
+	fnClearBuffer          js.Value
+	fnFinish               js.Value
+}
+
+// NewCommandEncoder constructs a CommandEncoder from a GPUCommandEncoder js.Value.
+// Pre-binds all recording methods to avoid property lookups on hot paths.
+func NewCommandEncoder(ref js.Value) *CommandEncoder {
+	return &CommandEncoder{
+		ref_:                   ref,
+		fnBeginRenderPass:      bindMethod(ref, "beginRenderPass"),
+		fnBeginComputePass:     bindMethod(ref, "beginComputePass"),
+		fnCopyBufferToBuffer:   bindMethod(ref, "copyBufferToBuffer"),
+		fnCopyBufferToTexture:  bindMethod(ref, "copyBufferToTexture"),
+		fnCopyTextureToBuffer:  bindMethod(ref, "copyTextureToBuffer"),
+		fnCopyTextureToTexture: bindMethod(ref, "copyTextureToTexture"),
+		fnClearBuffer:          bindMethod(ref, "clearBuffer"),
+		fnFinish:               bindMethod(ref, "finish"),
+	}
+}
+
+// BeginRenderPass begins a render pass with the given JS descriptor.
+// Returns a RenderPassEncoder wrapping the browser GPURenderPassEncoder.
+func (e *CommandEncoder) BeginRenderPass(desc js.Value) *RenderPassEncoder {
+	jsPass := e.fnBeginRenderPass.Invoke(desc)
+	return NewRenderPassEncoder(jsPass)
+}
+
+// BeginComputePass begins a compute pass with the given JS descriptor.
+// Returns a ComputePassEncoder wrapping the browser GPUComputePassEncoder.
+func (e *CommandEncoder) BeginComputePass(desc js.Value) *ComputePassEncoder {
+	jsPass := e.fnBeginComputePass.Invoke(desc)
+	return NewComputePassEncoder(jsPass)
+}
+
+// CopyBufferToBuffer records a buffer-to-buffer copy command.
+// Matches Rust wgpu: copy_buffer_to_buffer_with_f64_and_f64_and_f64.
+func (e *CommandEncoder) CopyBufferToBuffer(src js.Value, srcOffset uint64, dst js.Value, dstOffset uint64, size uint64) {
+	e.fnCopyBufferToBuffer.Invoke(src, float64(srcOffset), dst, float64(dstOffset), float64(size))
+}
+
+// CopyBufferToTexture records a buffer-to-texture copy command.
+// source = GPUTexelCopyBufferInfo, destination = GPUTexelCopyTextureInfo, copySize = GPUExtent3DDict.
+func (e *CommandEncoder) CopyBufferToTexture(source, destination, copySize js.Value) {
+	e.fnCopyBufferToTexture.Invoke(source, destination, copySize)
+}
+
+// CopyTextureToBuffer records a texture-to-buffer copy command.
+// source = GPUTexelCopyTextureInfo, destination = GPUTexelCopyBufferInfo, copySize = GPUExtent3DDict.
+func (e *CommandEncoder) CopyTextureToBuffer(source, destination, copySize js.Value) {
+	e.fnCopyTextureToBuffer.Invoke(source, destination, copySize)
+}
+
+// CopyTextureToTexture records a texture-to-texture copy command.
+// source = GPUTexelCopyTextureInfo, destination = GPUTexelCopyTextureInfo, copySize = GPUExtent3DDict.
+func (e *CommandEncoder) CopyTextureToTexture(source, destination, copySize js.Value) {
+	e.fnCopyTextureToTexture.Invoke(source, destination, copySize)
+}
+
+// Finish completes command recording and returns a CommandBuffer.
+// An optional descriptor (or js.Undefined()) can be passed for the label.
+func (e *CommandEncoder) Finish(desc js.Value) *CommandBuffer {
+	var jsBuf js.Value
+	if desc.IsUndefined() || desc.IsNull() {
+		jsBuf = e.fnFinish.Invoke()
+	} else {
+		jsBuf = e.fnFinish.Invoke(desc)
+	}
+	return &CommandBuffer{ref_: jsBuf}
+}
+
+// Ref returns the underlying GPUCommandEncoder js.Value.
+func (e *CommandEncoder) Ref() js.Value {
+	return e.ref_
+}
+
+// CommandBuffer wraps a browser GPUCommandBuffer.
+// A command buffer is an opaque handle to recorded GPU commands, ready for
+// submission via Queue.Submit.
+type CommandBuffer struct {
+	// ref_ is the GPUCommandBuffer JavaScript object.
+	ref_ js.Value
+}
+
+// Ref returns the underlying GPUCommandBuffer js.Value.
+func (cb *CommandBuffer) Ref() js.Value {
+	return cb.ref_
+}

--- a/internal/browser/encoder.go
+++ b/internal/browser/encoder.go
@@ -80,6 +80,11 @@ func (e *CommandEncoder) CopyTextureToTexture(source, destination, copySize js.V
 	e.fnCopyTextureToTexture.Invoke(source, destination, copySize)
 }
 
+// ClearBuffer clears a buffer region to zero.
+func (e *CommandEncoder) ClearBuffer(buffer js.Value, offset, size uint64) {
+	e.fnClearBuffer.Invoke(buffer, float64(offset), float64(size))
+}
+
 // Finish completes command recording and returns a CommandBuffer.
 // An optional descriptor (or js.Undefined()) can be passed for the label.
 func (e *CommandEncoder) Finish(desc js.Value) *CommandBuffer {

--- a/internal/browser/errors.go
+++ b/internal/browser/errors.go
@@ -1,0 +1,60 @@
+//go:build js && wasm
+
+package browser
+
+import (
+	"errors"
+	"syscall/js"
+)
+
+// Common browser WebGPU errors.
+var (
+	// ErrWebGPUNotSupported is returned when navigator.gpu is unavailable.
+	ErrWebGPUNotSupported = errors.New("wgpu: WebGPU not supported in this browser")
+
+	// ErrNavigatorUnavailable is returned when navigator object is missing
+	// (e.g., running in a non-browser WASM environment like Node.js without gpu).
+	ErrNavigatorUnavailable = errors.New("wgpu: navigator not available")
+
+	// ErrAdapterNotFound is returned when requestAdapter yields null
+	// (no suitable GPU adapter found).
+	ErrAdapterNotFound = errors.New("wgpu: no suitable GPU adapter found")
+
+	// ErrDeviceCreationFailed is returned when requestDevice fails.
+	ErrDeviceCreationFailed = errors.New("wgpu: device creation failed")
+)
+
+// JSError wraps a JavaScript error value for Go error handling.
+type JSError struct {
+	// Message is the error message extracted from the JS error.
+	Message string
+	// Name is the JS error constructor name (e.g., "TypeError", "OperationError").
+	Name string
+}
+
+// Error implements the error interface.
+func (e *JSError) Error() string {
+	if e.Name != "" {
+		return e.Name + ": " + e.Message
+	}
+	return e.Message
+}
+
+// NewJSError creates a JSError from a js.Value.
+// Returns nil if the value is null or undefined.
+func NewJSError(v js.Value) *JSError {
+	if v.IsUndefined() || v.IsNull() {
+		return nil
+	}
+
+	name := ""
+	nameVal := v.Get("name")
+	if !nameVal.IsUndefined() && !nameVal.IsNull() {
+		name = nameVal.String()
+	}
+
+	return &JSError{
+		Message: extractErrorMessage(v),
+		Name:    name,
+	}
+}

--- a/internal/browser/instance.go
+++ b/internal/browser/instance.go
@@ -1,0 +1,72 @@
+//go:build js && wasm
+
+package browser
+
+import (
+	"fmt"
+	"syscall/js"
+)
+
+// Instance is the browser WebGPU entry point, wrapping navigator.gpu.
+//
+// Matches Rust wgpu ContextWebGpu which holds an Option<Gpu>.
+type Instance struct {
+	// gpu is the navigator.gpu JavaScript object (GPUInstance).
+	gpu js.Value
+}
+
+// NewInstance creates a new browser WebGPU instance by accessing navigator.gpu.
+//
+// Returns ErrNavigatorUnavailable if the navigator object is missing, or
+// ErrWebGPUNotSupported if navigator.gpu is undefined (browser does not
+// support WebGPU or the page is not in a secure context).
+func NewInstance() (*Instance, error) {
+	navigator := js.Global().Get("navigator")
+	if navigator.IsUndefined() || navigator.IsNull() {
+		return nil, ErrNavigatorUnavailable
+	}
+
+	gpu := navigator.Get("gpu")
+	if gpu.IsUndefined() || gpu.IsNull() {
+		return nil, ErrWebGPUNotSupported
+	}
+
+	return &Instance{gpu: gpu}, nil
+}
+
+// RequestAdapter requests a GPU adapter from the browser.
+//
+// The options parameter is a JS object matching GPURequestAdapterOptions
+// (built by convert.go helpers). Pass js.Undefined() for default options.
+//
+// Returns ErrAdapterNotFound if the browser cannot find a suitable adapter
+// (same as navigator.gpu.requestAdapter() returning null).
+//
+// Matches Rust wgpu ContextWebGpu::request_adapter which calls
+// gpu.request_adapter_with_options and awaits the promise.
+func (inst *Instance) RequestAdapter(options js.Value) (*Adapter, error) {
+	var promise js.Value
+	if options.IsUndefined() || options.IsNull() {
+		promise = inst.gpu.Call("requestAdapter")
+	} else {
+		promise = inst.gpu.Call("requestAdapter", options)
+	}
+
+	result, err := AwaitPromise(promise)
+	if err != nil {
+		return nil, fmt.Errorf("requestAdapter: %w", err)
+	}
+
+	// requestAdapter returns null when no suitable adapter is found.
+	if result.IsNull() || result.IsUndefined() {
+		return nil, ErrAdapterNotFound
+	}
+
+	return newAdapter(result), nil
+}
+
+// GPU returns the underlying navigator.gpu js.Value.
+// Exposed for testing and advanced interop scenarios.
+func (inst *Instance) GPU() js.Value {
+	return inst.gpu
+}

--- a/internal/browser/pipeline.go
+++ b/internal/browser/pipeline.go
@@ -1,0 +1,47 @@
+//go:build js && wasm
+
+package browser
+
+import "syscall/js"
+
+// RenderPipeline wraps a browser GPURenderPipeline.
+type RenderPipeline struct {
+	// ref_ is the GPURenderPipeline JavaScript object.
+	ref_ js.Value
+}
+
+// NewRenderPipeline constructs a RenderPipeline from a GPURenderPipeline js.Value.
+func NewRenderPipeline(ref js.Value) *RenderPipeline {
+	return &RenderPipeline{ref_: ref}
+}
+
+// Ref returns the underlying GPURenderPipeline js.Value.
+func (p *RenderPipeline) Ref() js.Value { return p.ref_ }
+
+// GetBindGroupLayout returns the bind group layout at the given index.
+// Wraps GPURenderPipeline.getBindGroupLayout(index).
+func (p *RenderPipeline) GetBindGroupLayout(index uint32) *BindGroupLayout {
+	jsLayout := p.ref_.Call("getBindGroupLayout", index)
+	return NewBindGroupLayout(jsLayout)
+}
+
+// ComputePipeline wraps a browser GPUComputePipeline.
+type ComputePipeline struct {
+	// ref_ is the GPUComputePipeline JavaScript object.
+	ref_ js.Value
+}
+
+// NewComputePipeline constructs a ComputePipeline from a GPUComputePipeline js.Value.
+func NewComputePipeline(ref js.Value) *ComputePipeline {
+	return &ComputePipeline{ref_: ref}
+}
+
+// Ref returns the underlying GPUComputePipeline js.Value.
+func (p *ComputePipeline) Ref() js.Value { return p.ref_ }
+
+// GetBindGroupLayout returns the bind group layout at the given index.
+// Wraps GPUComputePipeline.getBindGroupLayout(index).
+func (p *ComputePipeline) GetBindGroupLayout(index uint32) *BindGroupLayout {
+	jsLayout := p.ref_.Call("getBindGroupLayout", index)
+	return NewBindGroupLayout(jsLayout)
+}

--- a/internal/browser/promise.go
+++ b/internal/browser/promise.go
@@ -1,0 +1,79 @@
+//go:build js && wasm
+
+package browser
+
+import (
+	"fmt"
+	"syscall/js"
+)
+
+// AwaitPromise blocks the calling goroutine until a JS Promise resolves or rejects.
+//
+// On WASM, Go goroutines are cooperative (single-threaded). This function uses
+// Promise.then/catch with a channel to yield the goroutine until the JS event
+// loop resolves the promise. The caller MUST be on a goroutine (not the main
+// goroutine) or the program will deadlock.
+//
+// Pattern matches Rust wgpu's wasm_bindgen_futures::JsFuture::from(promise).
+func AwaitPromise(promise js.Value) (js.Value, error) {
+	ch := make(chan promiseResult, 1)
+
+	thenFn := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		var val js.Value
+		if len(args) > 0 {
+			val = args[0]
+		} else {
+			val = js.Undefined()
+		}
+		ch <- promiseResult{value: val}
+		return nil
+	})
+
+	catchFn := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		var val js.Value
+		if len(args) > 0 {
+			val = args[0]
+		} else {
+			val = js.Undefined()
+		}
+		ch <- promiseResult{value: val, rejected: true}
+		return nil
+	})
+
+	promise.Call("then", thenFn).Call("catch", catchFn)
+
+	result := <-ch
+
+	// Release JS functions after promise settles to prevent GC leaks.
+	thenFn.Release()
+	catchFn.Release()
+
+	if result.rejected {
+		msg := extractErrorMessage(result.value)
+		return js.Undefined(), fmt.Errorf("promise rejected: %s", msg)
+	}
+
+	return result.value, nil
+}
+
+// promiseResult carries either a resolved value or a rejection.
+type promiseResult struct {
+	value    js.Value
+	rejected bool
+}
+
+// extractErrorMessage extracts a human-readable message from a JS error value.
+func extractErrorMessage(v js.Value) string {
+	if v.IsUndefined() || v.IsNull() {
+		return "unknown error"
+	}
+
+	// Try .message property first (standard Error objects).
+	msg := v.Get("message")
+	if !msg.IsUndefined() && !msg.IsNull() {
+		return msg.String()
+	}
+
+	// Fall back to toString().
+	return v.Call("toString").String()
+}

--- a/internal/browser/queue.go
+++ b/internal/browser/queue.go
@@ -1,0 +1,24 @@
+//go:build js && wasm
+
+package browser
+
+import "syscall/js"
+
+// Queue wraps a browser GPUQueue.
+//
+// Phase 1 only holds the js.Value reference. Queue methods (submit, writeBuffer,
+// writeTexture) will be implemented in Phase 3.
+type Queue struct {
+	// ref_ is the GPUQueue JavaScript object.
+	ref_ js.Value
+}
+
+// NewQueue constructs a Queue from a GPUQueue js.Value.
+func NewQueue(ref js.Value) *Queue {
+	return &Queue{ref_: ref}
+}
+
+// Ref returns the underlying GPUQueue js.Value.
+func (q *Queue) Ref() js.Value {
+	return q.ref_
+}

--- a/internal/browser/queue.go
+++ b/internal/browser/queue.go
@@ -4,21 +4,74 @@ package browser
 
 import "syscall/js"
 
-// Queue wraps a browser GPUQueue.
+// Queue wraps a browser GPUQueue with pre-bound submission and write methods.
 //
-// Phase 1 only holds the js.Value reference. Queue methods (submit, writeBuffer,
-// writeTexture) will be implemented in Phase 3.
+// Pre-binding JS methods at construction time avoids repeated property lookups
+// on every submit/write call. Matches Rust wgpu WebQueue.
 type Queue struct {
 	// ref_ is the GPUQueue JavaScript object.
 	ref_ js.Value
+
+	// Pre-bound methods for submission and data transfer.
+	fnSubmit       js.Value
+	fnWriteBuffer  js.Value
+	fnWriteTexture js.Value
 }
 
 // NewQueue constructs a Queue from a GPUQueue js.Value.
+// Pre-binds submit, writeBuffer, and writeTexture methods.
 func NewQueue(ref js.Value) *Queue {
-	return &Queue{ref_: ref}
+	return &Queue{
+		ref_:           ref,
+		fnSubmit:       bindMethod(ref, "submit"),
+		fnWriteBuffer:  bindMethod(ref, "writeBuffer"),
+		fnWriteTexture: bindMethod(ref, "writeTexture"),
+	}
 }
 
 // Ref returns the underlying GPUQueue js.Value.
 func (q *Queue) Ref() js.Value {
 	return q.ref_
+}
+
+// Submit submits an array of GPUCommandBuffer js.Values for execution.
+// Rust wgpu collects command buffers into a js_sys::Array and calls queue.submit(&array).
+func (q *Queue) Submit(commandBuffers []js.Value) {
+	arr := js.Global().Get("Array").New(len(commandBuffers))
+	for i, cb := range commandBuffers {
+		arr.SetIndex(i, cb)
+	}
+	q.fnSubmit.Invoke(arr)
+}
+
+// WriteBuffer writes Go byte data to a GPU buffer.
+//
+// Rust wgpu creates a Uint8Array from the data, then passes its .buffer() (ArrayBuffer)
+// to writeBuffer. We use js.CopyBytesToJS for the Go-to-JS data transfer, which is the
+// standard Go WASM pattern (equivalent to Rust's Uint8Array::from(data)).
+//
+// Signature: queue.writeBuffer(buffer, bufferOffset, data, dataOffset, size)
+func (q *Queue) WriteBuffer(buffer js.Value, bufferOffset uint64, data []byte) {
+	jsArray := js.Global().Get("Uint8Array").New(len(data))
+	js.CopyBytesToJS(jsArray, data)
+	q.fnWriteBuffer.Invoke(
+		buffer,
+		float64(bufferOffset),
+		jsArray,
+		0,
+		len(data),
+	)
+}
+
+// WriteTexture writes Go byte data to a GPU texture.
+//
+// destination = GPUTexelCopyTextureInfo, dataLayout = GPUTexelCopyBufferLayout,
+// size = GPUExtent3DDict.
+//
+// Rust wgpu creates a Uint8Array from the data, passes .buffer() (ArrayBuffer) to
+// writeTexture. We use js.CopyBytesToJS for the Go→JS transfer.
+func (q *Queue) WriteTexture(destination js.Value, data []byte, dataLayout js.Value, size js.Value) {
+	jsArray := js.Global().Get("Uint8Array").New(len(data))
+	js.CopyBytesToJS(jsArray, data)
+	q.fnWriteTexture.Invoke(destination, jsArray, dataLayout, size)
 }

--- a/internal/browser/renderpass.go
+++ b/internal/browser/renderpass.go
@@ -1,0 +1,156 @@
+//go:build js && wasm
+
+package browser
+
+import "syscall/js"
+
+// RenderPassEncoder wraps a browser GPURenderPassEncoder with pre-bound methods.
+//
+// Pre-binding JS methods at construction time avoids repeated property lookups
+// on the hot path (draw calls). This matches the Ebiten pattern used by Device.
+//
+// Matches Rust wgpu WebRenderPassEncoder which holds webgpu_sys::GpuRenderPassEncoder.
+type RenderPassEncoder struct {
+	// ref_ is the GPURenderPassEncoder JavaScript object.
+	ref_ js.Value
+
+	// Pre-bound methods for draw calls and state setting.
+	fnSetPipeline         js.Value
+	fnSetBindGroup        js.Value
+	fnSetVertexBuffer     js.Value
+	fnSetIndexBuffer      js.Value
+	fnDraw                js.Value
+	fnDrawIndexed         js.Value
+	fnDrawIndirect        js.Value
+	fnDrawIndexedIndirect js.Value
+	fnSetViewport         js.Value
+	fnSetScissorRect      js.Value
+	fnSetBlendConstant    js.Value
+	fnSetStencilReference js.Value
+	fnEnd                 js.Value
+}
+
+// NewRenderPassEncoder constructs a RenderPassEncoder from a GPURenderPassEncoder js.Value.
+// Pre-binds all draw and state-setting methods.
+func NewRenderPassEncoder(ref js.Value) *RenderPassEncoder {
+	return &RenderPassEncoder{
+		ref_:                  ref,
+		fnSetPipeline:         bindMethod(ref, "setPipeline"),
+		fnSetBindGroup:        bindMethod(ref, "setBindGroup"),
+		fnSetVertexBuffer:     bindMethod(ref, "setVertexBuffer"),
+		fnSetIndexBuffer:      bindMethod(ref, "setIndexBuffer"),
+		fnDraw:                bindMethod(ref, "draw"),
+		fnDrawIndexed:         bindMethod(ref, "drawIndexed"),
+		fnDrawIndirect:        bindMethod(ref, "drawIndirect"),
+		fnDrawIndexedIndirect: bindMethod(ref, "drawIndexedIndirect"),
+		fnSetViewport:         bindMethod(ref, "setViewport"),
+		fnSetScissorRect:      bindMethod(ref, "setScissorRect"),
+		fnSetBlendConstant:    bindMethod(ref, "setBlendConstant"),
+		fnSetStencilReference: bindMethod(ref, "setStencilReference"),
+		fnEnd:                 bindMethod(ref, "end"),
+	}
+}
+
+// SetPipeline sets the active render pipeline.
+func (p *RenderPassEncoder) SetPipeline(pipeline js.Value) {
+	p.fnSetPipeline.Invoke(pipeline)
+}
+
+// SetBindGroup sets a bind group at the given index.
+//
+// When dynamicOffsets is non-empty, the offsets are passed as a Uint32Array
+// using the overload: setBindGroup(index, group, offsetsArray, 0, len).
+// This matches Rust wgpu's set_bind_group_with_u32_slice_and_f64_and_dynamic_offsets_data_length.
+func (p *RenderPassEncoder) SetBindGroup(index uint32, group js.Value, dynamicOffsets []uint32) {
+	if len(dynamicOffsets) == 0 {
+		p.fnSetBindGroup.Invoke(index, group)
+		return
+	}
+	// Build a Uint32Array for the dynamic offsets.
+	jsArray := js.Global().Get("Uint32Array").New(len(dynamicOffsets))
+	for i, offset := range dynamicOffsets {
+		jsArray.SetIndex(i, js.ValueOf(offset))
+	}
+	p.fnSetBindGroup.Invoke(index, group, jsArray, 0, len(dynamicOffsets))
+}
+
+// SetVertexBuffer sets a vertex buffer for the given slot.
+//
+// If size is 0, the size parameter is omitted (meaning "rest of buffer"),
+// matching Rust wgpu's set_vertex_buffer_with_f64 (no size variant).
+func (p *RenderPassEncoder) SetVertexBuffer(slot uint32, buffer js.Value, offset uint64, size uint64) {
+	if size == 0 {
+		// Omit size to use the rest of the buffer.
+		p.fnSetVertexBuffer.Invoke(slot, buffer, float64(offset))
+	} else {
+		p.fnSetVertexBuffer.Invoke(slot, buffer, float64(offset), float64(size))
+	}
+}
+
+// SetIndexBuffer sets the index buffer.
+//
+// format is a WebGPU string: "uint16" or "uint32".
+// If size is 0, the size parameter is omitted (meaning "rest of buffer"),
+// matching Rust wgpu's set_index_buffer_with_f64 (no size variant).
+func (p *RenderPassEncoder) SetIndexBuffer(buffer js.Value, format string, offset uint64, size uint64) {
+	if size == 0 {
+		p.fnSetIndexBuffer.Invoke(buffer, format, float64(offset))
+	} else {
+		p.fnSetIndexBuffer.Invoke(buffer, format, float64(offset), float64(size))
+	}
+}
+
+// Draw draws primitives.
+// Matches Rust: draw_with_instance_count_and_first_vertex_and_first_instance.
+func (p *RenderPassEncoder) Draw(vertexCount, instanceCount, firstVertex, firstInstance uint32) {
+	p.fnDraw.Invoke(vertexCount, instanceCount, firstVertex, firstInstance)
+}
+
+// DrawIndexed draws indexed primitives.
+// baseVertex is int32 (can be negative) per WebGPU spec.
+// Matches Rust: draw_indexed_with_instance_count_and_first_index_and_base_vertex_and_first_instance.
+func (p *RenderPassEncoder) DrawIndexed(indexCount, instanceCount, firstIndex uint32, baseVertex int32, firstInstance uint32) {
+	p.fnDrawIndexed.Invoke(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)
+}
+
+// DrawIndirect draws primitives with GPU-generated parameters from an indirect buffer.
+func (p *RenderPassEncoder) DrawIndirect(buffer js.Value, offset uint64) {
+	p.fnDrawIndirect.Invoke(buffer, float64(offset))
+}
+
+// DrawIndexedIndirect draws indexed primitives with GPU-generated parameters.
+func (p *RenderPassEncoder) DrawIndexedIndirect(buffer js.Value, offset uint64) {
+	p.fnDrawIndexedIndirect.Invoke(buffer, float64(offset))
+}
+
+// SetViewport sets the viewport transformation.
+func (p *RenderPassEncoder) SetViewport(x, y, w, h, minDepth, maxDepth float32) {
+	p.fnSetViewport.Invoke(x, y, w, h, minDepth, maxDepth)
+}
+
+// SetScissorRect sets the scissor rectangle for clipping.
+func (p *RenderPassEncoder) SetScissorRect(x, y, w, h uint32) {
+	p.fnSetScissorRect.Invoke(x, y, w, h)
+}
+
+// SetBlendConstant sets the blend constant color via a GPUColorDict.
+// Matches Rust: set_blend_constant_with_gpu_color_dict.
+func (p *RenderPassEncoder) SetBlendConstant(color js.Value) {
+	p.fnSetBlendConstant.Invoke(color)
+}
+
+// SetStencilReference sets the stencil reference value.
+func (p *RenderPassEncoder) SetStencilReference(ref uint32) {
+	p.fnSetStencilReference.Invoke(ref)
+}
+
+// End ends the render pass.
+// Matches Rust WebRenderPassEncoder Drop which calls end().
+func (p *RenderPassEncoder) End() {
+	p.fnEnd.Invoke()
+}
+
+// Ref returns the underlying GPURenderPassEncoder js.Value.
+func (p *RenderPassEncoder) Ref() js.Value {
+	return p.ref_
+}

--- a/internal/browser/sampler.go
+++ b/internal/browser/sampler.go
@@ -1,0 +1,19 @@
+//go:build js && wasm
+
+package browser
+
+import "syscall/js"
+
+// Sampler wraps a browser GPUSampler.
+type Sampler struct {
+	// ref_ is the GPUSampler JavaScript object.
+	ref_ js.Value
+}
+
+// NewSampler constructs a Sampler from a GPUSampler js.Value.
+func NewSampler(ref js.Value) *Sampler {
+	return &Sampler{ref_: ref}
+}
+
+// Ref returns the underlying GPUSampler js.Value.
+func (s *Sampler) Ref() js.Value { return s.ref_ }

--- a/internal/browser/shader.go
+++ b/internal/browser/shader.go
@@ -1,0 +1,23 @@
+//go:build js && wasm
+
+package browser
+
+import "syscall/js"
+
+// ShaderModule wraps a browser GPUShaderModule.
+//
+// On browser, shader modules hold WGSL code compiled by the browser's native
+// shader compiler. No naga compilation happens -- the WGSL goes directly to
+// the browser's createShaderModule.
+type ShaderModule struct {
+	// ref_ is the GPUShaderModule JavaScript object.
+	ref_ js.Value
+}
+
+// NewShaderModule constructs a ShaderModule from a GPUShaderModule js.Value.
+func NewShaderModule(ref js.Value) *ShaderModule {
+	return &ShaderModule{ref_: ref}
+}
+
+// Ref returns the underlying GPUShaderModule js.Value.
+func (m *ShaderModule) Ref() js.Value { return m.ref_ }

--- a/internal/browser/surface.go
+++ b/internal/browser/surface.go
@@ -1,0 +1,173 @@
+//go:build js && wasm
+
+package browser
+
+import (
+	"errors"
+	"fmt"
+	"syscall/js"
+)
+
+// ErrCanvasContextFailed is returned when canvas.getContext("webgpu") returns null.
+// This happens when WebGPU is not available or the canvas is already bound to
+// another context type (e.g., "2d" or "webgl2").
+//
+// Matches Rust wgpu's CreateSurfaceErrorKind::Web for the null-context case.
+var ErrCanvasContextFailed = errors.New("wgpu: canvas.getContext(\"webgpu\") returned null; webgpu not available or canvas already in use")
+
+// Surface wraps an HTML canvas element and its GPUCanvasContext.
+//
+// On the browser, a "surface" is a canvas + the GPUCanvasContext obtained from
+// canvas.getContext("webgpu"). The context is configured with a device, format,
+// and size, then getCurrentTexture() returns the next frame texture.
+//
+// Presentation happens automatically when the JS event loop runs -- there is no
+// explicit present() call. This matches Rust wgpu WebSurface / WebSurfaceOutputDetail
+// where present() and texture_discard() are both no-ops.
+type Surface struct {
+	// canvas is the HTMLCanvasElement (or OffscreenCanvas).
+	canvas js.Value
+
+	// context is the GPUCanvasContext from canvas.getContext("webgpu").
+	context js.Value
+
+	// gpu is the navigator.gpu reference, used for getPreferredCanvasFormat().
+	gpu js.Value
+
+	// Pre-bound context methods to avoid property lookups per frame.
+	fnGetCurrentTexture js.Value
+	fnConfigure         js.Value
+
+	// Configuration state.
+	configured bool
+	width      uint32
+	height     uint32
+	format     string
+}
+
+// NewSurface creates a Surface from a canvas element by obtaining its GPUCanvasContext.
+//
+// The gpu parameter is the navigator.gpu object (needed for getPreferredCanvasFormat).
+// The canvas must be an HTMLCanvasElement or OffscreenCanvas.
+//
+// Returns ErrCanvasContextFailed if getContext("webgpu") returns null (WebGPU
+// not available or canvas already in use). Panics if getContext throws an
+// exception (indicates misuse of canvas state).
+//
+// Matches Rust wgpu ContextWebGpu::create_surface_from_context.
+func NewSurface(gpu js.Value, canvas js.Value) (*Surface, error) {
+	// Call canvas.getContext("webgpu"). This may return null (not supported
+	// or canvas already has another context) or throw (canvas state misuse).
+	//
+	// See: https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-getcontext
+	context := canvas.Call("getContext", "webgpu")
+	if context.IsNull() || context.IsUndefined() {
+		return nil, ErrCanvasContextFailed
+	}
+
+	s := &Surface{
+		canvas:  canvas,
+		context: context,
+		gpu:     gpu,
+	}
+
+	// Pre-bind context methods for per-frame performance.
+	s.fnGetCurrentTexture = bindMethod(context, "getCurrentTexture")
+	s.fnConfigure = bindMethod(context, "configure")
+
+	return s, nil
+}
+
+// Configure sets the surface configuration on the GPUCanvasContext.
+//
+// This sets the canvas dimensions and calls context.configure() with the
+// provided parameters. After Configure, GetCurrentTexture() can be called.
+//
+// Matches Rust wgpu SurfaceInterface::configure for WebSurface.
+func (s *Surface) Configure(config js.Value, width, height uint32, format string) {
+	// Set canvas dimensions (Rust wgpu does this in configure too).
+	s.canvas.Set("width", width)
+	s.canvas.Set("height", height)
+
+	// Call context.configure(config).
+	s.fnConfigure.Invoke(config)
+
+	s.configured = true
+	s.width = width
+	s.height = height
+	s.format = format
+}
+
+// Unconfigure removes the surface configuration.
+// After this call, GetCurrentTexture() will fail until Configure is called again.
+func (s *Surface) Unconfigure() {
+	unconfigure := s.context.Get("unconfigure")
+	if !unconfigure.IsUndefined() && !unconfigure.IsNull() {
+		s.context.Call("unconfigure")
+	}
+	s.configured = false
+}
+
+// GetCurrentTexture returns the current frame texture from the GPUCanvasContext.
+//
+// The returned GPUTexture is automatically presented when control returns to
+// the browser event loop after the command buffer using it is submitted.
+//
+// Returns an error if the surface is not configured.
+//
+// Matches Rust wgpu SurfaceInterface::get_current_texture for WebSurface.
+func (s *Surface) GetCurrentTexture() (*Texture, error) {
+	if !s.configured {
+		return nil, fmt.Errorf("wgpu: surface not configured")
+	}
+
+	jsTexture := s.fnGetCurrentTexture.Invoke()
+	if jsTexture.IsNull() || jsTexture.IsUndefined() {
+		return nil, fmt.Errorf("wgpu: getCurrentTexture returned null")
+	}
+
+	return NewTexture(jsTexture), nil
+}
+
+// GetPreferredCanvasFormat returns the preferred texture format for the display.
+//
+// This calls navigator.gpu.getPreferredCanvasFormat() which returns either
+// "bgra8unorm" or "rgba8unorm" depending on the platform.
+//
+// See: https://www.w3.org/TR/webgpu/#dom-gpu-getpreferredcanvasformat
+//
+// Matches Rust wgpu SurfaceInterface::get_capabilities which reads
+// gpu.get_preferred_canvas_format() to order the formats list.
+func (s *Surface) GetPreferredCanvasFormat() string {
+	if s.gpu.IsUndefined() || s.gpu.IsNull() {
+		return "bgra8unorm" // safe fallback
+	}
+	return s.gpu.Call("getPreferredCanvasFormat").String()
+}
+
+// Canvas returns the underlying canvas js.Value.
+func (s *Surface) Canvas() js.Value { return s.canvas }
+
+// Context returns the underlying GPUCanvasContext js.Value.
+func (s *Surface) Context() js.Value { return s.context }
+
+// Width returns the configured canvas width in pixels.
+func (s *Surface) Width() uint32 { return s.width }
+
+// Height returns the configured canvas height in pixels.
+func (s *Surface) Height() uint32 { return s.height }
+
+// Format returns the configured texture format string (e.g., "bgra8unorm").
+func (s *Surface) Format() string { return s.format }
+
+// Configured reports whether the surface has been configured.
+func (s *Surface) Configured() bool { return s.configured }
+
+// Destroy releases the surface. On browser this unconfigures the context.
+// Matches Rust wgpu Drop for WebSurface (no-op in Rust, but we unconfigure
+// for clean teardown).
+func (s *Surface) Destroy() {
+	if s.configured {
+		s.Unconfigure()
+	}
+}

--- a/internal/browser/texture.go
+++ b/internal/browser/texture.go
@@ -1,0 +1,67 @@
+//go:build js && wasm
+
+package browser
+
+import "syscall/js"
+
+// Texture wraps a browser GPUTexture.
+type Texture struct {
+	// ref_ is the GPUTexture JavaScript object.
+	ref_ js.Value
+
+	// Cached properties to avoid repeated JS lookups.
+	width  uint32
+	height uint32
+	format string
+}
+
+// NewTexture constructs a Texture from a GPUTexture js.Value.
+func NewTexture(ref js.Value) *Texture {
+	return &Texture{
+		ref_:   ref,
+		width:  uint32(ref.Get("width").Int()),  //nolint:gosec // JS API returns safe integers
+		height: uint32(ref.Get("height").Int()), //nolint:gosec // JS API returns safe integers
+		format: ref.Get("format").String(),
+	}
+}
+
+// Ref returns the underlying GPUTexture js.Value.
+func (t *Texture) Ref() js.Value { return t.ref_ }
+
+// Width returns the texture width in pixels.
+func (t *Texture) Width() uint32 { return t.width }
+
+// Height returns the texture height in pixels.
+func (t *Texture) Height() uint32 { return t.height }
+
+// Format returns the texture format as a WebGPU string (e.g. "rgba8unorm").
+func (t *Texture) Format() string { return t.format }
+
+// CreateView calls GPUTexture.createView() with the given descriptor.
+// Pass js.Undefined() for default view parameters.
+func (t *Texture) CreateView(desc js.Value) *TextureView {
+	var jsView js.Value
+	if desc.IsUndefined() || desc.IsNull() {
+		jsView = t.ref_.Call("createView")
+	} else {
+		jsView = t.ref_.Call("createView", desc)
+	}
+	return &TextureView{ref_: jsView}
+}
+
+// Destroy calls GPUTexture.destroy() to release GPU memory.
+func (t *Texture) Destroy() {
+	destroy := t.ref_.Get("destroy")
+	if !destroy.IsUndefined() && !destroy.IsNull() {
+		t.ref_.Call("destroy")
+	}
+}
+
+// TextureView wraps a browser GPUTextureView.
+type TextureView struct {
+	// ref_ is the GPUTextureView JavaScript object.
+	ref_ js.Value
+}
+
+// Ref returns the underlying GPUTextureView js.Value.
+func (v *TextureView) Ref() js.Value { return v.ref_ }

--- a/map_pending_browser.go
+++ b/map_pending_browser.go
@@ -4,18 +4,78 @@ package wgpu
 
 import "context"
 
-// MapPending is a handle to an in-flight Buffer.MapAsync.
-type MapPending struct{}
+// MapPending is a handle to an in-flight Buffer.MapAsync on the browser.
+//
+// The browser backend uses a goroutine + channel pattern: MapAsync spawns
+// a goroutine that calls AwaitPromise on the GPUBuffer.mapAsync JS Promise.
+// The result (nil on success, error on rejection) is sent to the done channel.
+//
+// This differs from the native backend (which uses core.MapWaiter + Device.Poll)
+// because browser WebGPU resolves promises via the JS event loop, not via
+// explicit GPU polling.
+type MapPending struct {
+	buf      *Buffer
+	done     chan error
+	resolved bool
+	err      error
+}
 
-// Status returns the current state of the pending map.
+// Status returns the current state of the pending map without blocking.
+//
+//   - (true, nil)    -- mapping is ready; call Buffer.MappedRange.
+//   - (false, nil)   -- still pending; the JS event loop has not resolved
+//     the Promise yet.
+//   - (true, err)    -- mapping failed; the buffer is back in the Unmapped
+//     state and err describes why.
 func (p *MapPending) Status() (ready bool, err error) {
-	panic("wgpu: browser backend not yet implemented")
+	if p == nil || p.done == nil {
+		return true, ErrMapCanceled
+	}
+	if p.resolved {
+		return true, p.err
+	}
+	// Non-blocking check on the channel.
+	select {
+	case err := <-p.done:
+		p.resolved = true
+		p.err = err
+		return true, p.err
+	default:
+		return false, nil
+	}
 }
 
-// Wait blocks until the map resolves or ctx is canceled.
+// Wait blocks until the pending map resolves or ctx is canceled.
+//
+// If ctx is canceled before the JS Promise resolves, Wait returns
+// ctx.Err(). The mapping remains Pending -- the caller should normally
+// follow up with Buffer.Unmap to cancel it.
 func (p *MapPending) Wait(ctx context.Context) error {
-	panic("wgpu: browser backend not yet implemented")
+	if p == nil || p.done == nil {
+		return ErrMapCanceled
+	}
+	if p.resolved {
+		return p.err
+	}
+	select {
+	case err := <-p.done:
+		p.resolved = true
+		p.err = err
+		return p.err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
-// Release returns the handle to the pool.
-func (p *MapPending) Release() {}
+// Release discards the MapPending handle. Calling this while the map is
+// still in flight is allowed; the JS Promise continues to resolve but its
+// completion is not observable through this handle anymore.
+func (p *MapPending) Release() {
+	if p == nil {
+		return
+	}
+	p.buf = nil
+	p.done = nil
+	p.resolved = false
+	p.err = nil
+}

--- a/mapped_range_browser.go
+++ b/mapped_range_browser.go
@@ -3,9 +3,111 @@
 package wgpu
 
 // MappedRange is a safe view over a region of a mapped GPU buffer.
-type MappedRange struct{}
+//
+// On the browser backend, MappedRange lazily copies data from the JS
+// ArrayBuffer into a Go byte slice on first Bytes() call (read path),
+// or provides a staging slice for writes that is flushed back to JS on
+// Flush(). This matches the Rust wgpu WebBufferMappedRange pattern:
+// actual_mapping (JS Uint8Array) + temporary_mapping (Rust/WASM heap copy).
+//
+// The MappedRange is invalidated when the owning buffer is unmapped.
+type MappedRange struct {
+	buf    *Buffer
+	offset uint64
+	size   uint64
+	valid  bool
 
-// Bytes returns the underlying byte slice.
+	// cached holds the Go-side copy of the mapped data. Lazily populated
+	// on first Bytes() call (matching Rust temporary_mapping: OnceCell).
+	cached []byte
+
+	// dirty tracks whether the cached slice has been modified via
+	// BytesMut(). If true, Flush() or Unmap will write data back to JS.
+	// Matches Rust temporary_mapping_modified.
+	dirty bool
+}
+
+// Bytes returns the mapped data as a read-only byte slice.
+//
+// The data is lazily copied from the JS ArrayBuffer on the first call.
+// The returned slice is valid until the owning buffer is unmapped. After
+// Unmap, Bytes() returns nil.
 func (m *MappedRange) Bytes() []byte {
-	panic("wgpu: browser backend not yet implemented")
+	if m == nil || !m.valid || m.buf == nil || m.buf.browser == nil {
+		return nil
+	}
+	if m.cached == nil {
+		data, err := m.buf.browser.GetMappedRangeBytes(m.offset, m.size)
+		if err != nil {
+			return nil
+		}
+		m.cached = data
+	}
+	return m.cached
+}
+
+// BytesMut returns a mutable byte slice for writing into the mapped region.
+//
+// The returned slice is a Go-heap copy. Changes are NOT visible on the GPU
+// until Flush() is called (or the buffer is unmapped, which auto-flushes
+// dirty ranges). This matches the Rust wgpu pattern where Drop on
+// WebBufferMappedRange writes back if temporary_mapping_modified is true.
+func (m *MappedRange) BytesMut() []byte {
+	if m == nil || !m.valid || m.buf == nil || m.buf.browser == nil {
+		return nil
+	}
+	if m.cached == nil {
+		m.cached = make([]byte, m.size)
+	}
+	m.dirty = true
+	return m.cached
+}
+
+// Flush writes the cached data back to the JS ArrayBuffer.
+// Only needed after BytesMut(); Bytes()-only usage does not require Flush.
+//
+// This is the Go equivalent of the Rust WebBufferMappedRange Drop handler
+// that copies temporary_mapping back to actual_mapping when modified.
+func (m *MappedRange) Flush() error {
+	if m == nil || !m.valid || !m.dirty || m.buf == nil || m.buf.browser == nil {
+		return nil
+	}
+	err := m.buf.browser.WriteMappedRange(m.offset, m.cached)
+	if err != nil {
+		return err
+	}
+	m.dirty = false
+	return nil
+}
+
+// Len returns the size of the mapped range in bytes.
+func (m *MappedRange) Len() int {
+	if m == nil {
+		return 0
+	}
+	return int(m.size) //nolint:gosec // validated at creation
+}
+
+// Offset returns the byte offset of the mapped range within its buffer.
+func (m *MappedRange) Offset() uint64 {
+	if m == nil {
+		return 0
+	}
+	return m.offset
+}
+
+// Release invalidates the MappedRange. After Release, Bytes() returns nil.
+// If dirty data has not been flushed, Release auto-flushes it to JS.
+func (m *MappedRange) Release() {
+	if m == nil {
+		return
+	}
+	// Auto-flush dirty data (matches Rust Drop behavior).
+	if m.dirty && m.valid && m.buf != nil && m.buf.browser != nil {
+		_ = m.buf.browser.WriteMappedRange(m.offset, m.cached)
+	}
+	m.valid = false
+	m.buf = nil
+	m.cached = nil
+	m.dirty = false
 }

--- a/pipeline_browser.go
+++ b/pipeline_browser.go
@@ -2,6 +2,8 @@
 
 package wgpu
 
+import "github.com/gogpu/wgpu/internal/browser"
+
 // LateSizedBufferGroup holds the shader-required minimum buffer sizes for
 // bind group entries whose layout specifies MinBindingSize == 0.
 type LateSizedBufferGroup struct {
@@ -10,7 +12,20 @@ type LateSizedBufferGroup struct {
 
 // RenderPipeline represents a configured render pipeline.
 type RenderPipeline struct {
+	browser  *browser.RenderPipeline
 	released bool
+}
+
+// GetBindGroupLayout returns the bind group layout at the given index.
+// This wraps GPURenderPipeline.getBindGroupLayout(index) for "auto" layouts.
+func (p *RenderPipeline) GetBindGroupLayout(index uint32) *BindGroupLayout {
+	if p.browser == nil {
+		return nil
+	}
+	bl := p.browser.GetBindGroupLayout(index)
+	return &BindGroupLayout{
+		browser: bl,
+	}
 }
 
 // Release destroys the render pipeline.
@@ -23,7 +38,20 @@ func (p *RenderPipeline) Release() {
 
 // ComputePipeline represents a configured compute pipeline.
 type ComputePipeline struct {
+	browser  *browser.ComputePipeline
 	released bool
+}
+
+// GetBindGroupLayout returns the bind group layout at the given index.
+// This wraps GPUComputePipeline.getBindGroupLayout(index) for "auto" layouts.
+func (p *ComputePipeline) GetBindGroupLayout(index uint32) *BindGroupLayout {
+	if p.browser == nil {
+		return nil
+	}
+	bl := p.browser.GetBindGroupLayout(index)
+	return &BindGroupLayout{
+		browser: bl,
+	}
 }
 
 // Release destroys the compute pipeline.

--- a/queue_browser.go
+++ b/queue_browser.go
@@ -3,6 +3,8 @@
 package wgpu
 
 import (
+	"syscall/js"
+
 	"github.com/gogpu/wgpu/internal/browser"
 )
 
@@ -14,9 +16,21 @@ type Queue struct {
 }
 
 // Submit submits command buffers for execution.
-// Phase 3 — not yet implemented for browser.
+// Returns 0 for the submission index (browser does not track indices).
+// Matches Rust wgpu WebQueue::submit which collects into js_sys::Array.
 func (q *Queue) Submit(commandBuffers ...*CommandBuffer) (uint64, error) {
-	panic("wgpu: browser Queue.Submit not yet implemented (Phase 3)")
+	if q.released {
+		return 0, ErrReleased
+	}
+	jsBuffers := make([]js.Value, 0, len(commandBuffers))
+	for _, cb := range commandBuffers {
+		if cb != nil && cb.browser != nil && !cb.released {
+			jsBuffers = append(jsBuffers, cb.browser.Ref())
+			cb.released = true
+		}
+	}
+	q.browser.Submit(jsBuffers)
+	return 0, nil
 }
 
 // Poll returns the last completed submission index.
@@ -26,15 +40,56 @@ func (q *Queue) Poll() uint64 {
 }
 
 // WriteBuffer writes data to a buffer.
-// Phase 3 — not yet implemented for browser.
+// Uses js.CopyBytesToJS for Go-to-JS data transfer (same pattern as Rust's
+// Uint8Array::from(data).buffer()).
 func (q *Queue) WriteBuffer(buffer *Buffer, offset uint64, data []byte) error {
-	panic("wgpu: browser Queue.WriteBuffer not yet implemented (Phase 3)")
+	if q.released {
+		return ErrReleased
+	}
+	if buffer == nil || buffer.browser == nil {
+		return ErrReleased
+	}
+	q.browser.WriteBuffer(buffer.browser.Ref(), offset, data)
+	return nil
 }
 
 // WriteTexture writes data to a texture.
-// Phase 3 — not yet implemented for browser.
+// Matches Rust wgpu WebQueue::write_texture layout: offset/bytesPerRow/rowsPerImage
+// are set on a GPUTexelCopyBufferLayout JS object.
 func (q *Queue) WriteTexture(dst *ImageCopyTexture, data []byte, layout *ImageDataLayout, size *Extent3D) error {
-	panic("wgpu: browser Queue.WriteTexture not yet implemented (Phase 3)")
+	if q.released {
+		return ErrReleased
+	}
+	if dst == nil || dst.Texture == nil || dst.Texture.browser == nil {
+		return ErrReleased
+	}
+
+	jsDst := browser.BuildImageCopyTexture(
+		dst.Texture.browser.Ref(),
+		dst.MipLevel,
+		dst.Origin.X, dst.Origin.Y, dst.Origin.Z,
+	)
+
+	var jsLayout js.Value
+	if layout != nil {
+		jsLayout = browser.BuildTexelCopyBufferLayout(
+			layout.Offset,
+			layout.BytesPerRow,
+			layout.RowsPerImage,
+		)
+	} else {
+		jsLayout = browser.BuildTexelCopyBufferLayout(0, 0, 0)
+	}
+
+	var jsSize js.Value
+	if size != nil {
+		jsSize = browser.BuildExtent3D(size.Width, size.Height, size.DepthOrArrayLayers)
+	} else {
+		jsSize = browser.BuildExtent3D(0, 0, 0)
+	}
+
+	q.browser.WriteTexture(jsDst, data, jsLayout, jsSize)
+	return nil
 }
 
 // SetSwapchainSuppressed is a no-op on the browser backend.

--- a/queue_browser.go
+++ b/queue_browser.go
@@ -2,29 +2,39 @@
 
 package wgpu
 
+import (
+	"github.com/gogpu/wgpu/internal/browser"
+)
+
 // Queue handles command submission and data transfers.
+// On browser, this wraps a GPUQueue via internal/browser.Queue.
 type Queue struct {
+	browser  *browser.Queue
 	released bool
 }
 
 // Submit submits command buffers for execution.
+// Phase 3 — not yet implemented for browser.
 func (q *Queue) Submit(commandBuffers ...*CommandBuffer) (uint64, error) {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser Queue.Submit not yet implemented (Phase 3)")
 }
 
 // Poll returns the last completed submission index.
+// On browser, the GPU is polled automatically. Returns 0.
 func (q *Queue) Poll() uint64 {
-	panic("wgpu: browser backend not yet implemented")
+	return 0
 }
 
 // WriteBuffer writes data to a buffer.
+// Phase 3 — not yet implemented for browser.
 func (q *Queue) WriteBuffer(buffer *Buffer, offset uint64, data []byte) error {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser Queue.WriteBuffer not yet implemented (Phase 3)")
 }
 
 // WriteTexture writes data to a texture.
+// Phase 3 — not yet implemented for browser.
 func (q *Queue) WriteTexture(dst *ImageCopyTexture, data []byte, layout *ImageDataLayout, size *Extent3D) error {
-	panic("wgpu: browser backend not yet implemented")
+	panic("wgpu: browser Queue.WriteTexture not yet implemented (Phase 3)")
 }
 
 // SetSwapchainSuppressed is a no-op on the browser backend.
@@ -32,6 +42,7 @@ func (q *Queue) WriteTexture(dst *ImageCopyTexture, data []byte, layout *ImageDa
 func (q *Queue) SetSwapchainSuppressed(_ bool) {}
 
 // LastSubmissionIndex returns the most recent submission index.
+// On browser, submission indices are not tracked. Returns 0.
 func (q *Queue) LastSubmissionIndex() uint64 {
 	return 0
 }

--- a/renderpass_browser.go
+++ b/renderpass_browser.go
@@ -2,72 +2,108 @@
 
 package wgpu
 
+import "github.com/gogpu/wgpu/internal/browser"
+
 // RenderPassEncoder records draw commands within a render pass.
+// On browser, this wraps a GPURenderPassEncoder via internal/browser.RenderPassEncoder.
 type RenderPassEncoder struct {
+	browser  *browser.RenderPassEncoder
 	released bool
 }
 
 // SetPipeline sets the active render pipeline.
 func (p *RenderPassEncoder) SetPipeline(pipeline *RenderPipeline) {
-	panic("wgpu: browser backend not yet implemented")
+	if pipeline == nil || pipeline.browser == nil {
+		return
+	}
+	p.browser.SetPipeline(pipeline.browser.Ref())
 }
 
 // SetBindGroup sets a bind group for the given index.
 func (p *RenderPassEncoder) SetBindGroup(index uint32, group *BindGroup, offsets []uint32) {
-	panic("wgpu: browser backend not yet implemented")
+	if group == nil || group.browser == nil {
+		return
+	}
+	p.browser.SetBindGroup(index, group.browser.Ref(), offsets)
 }
 
 // SetVertexBuffer sets a vertex buffer for the given slot.
+// Offset is in bytes. Pass 0 for size to use the rest of the buffer.
 func (p *RenderPassEncoder) SetVertexBuffer(slot uint32, buffer *Buffer, offset uint64) {
-	panic("wgpu: browser backend not yet implemented")
+	if buffer == nil || buffer.browser == nil {
+		return
+	}
+	// size=0 tells the browser layer to omit the size parameter,
+	// which means "rest of buffer" per the WebGPU spec.
+	p.browser.SetVertexBuffer(slot, buffer.browser.Ref(), offset, 0)
 }
 
 // SetIndexBuffer sets the index buffer.
 func (p *RenderPassEncoder) SetIndexBuffer(buffer *Buffer, format IndexFormat, offset uint64) {
-	panic("wgpu: browser backend not yet implemented")
+	if buffer == nil || buffer.browser == nil {
+		return
+	}
+	formatStr := browser.IndexFormatToJS(format)
+	// size=0 tells the browser layer to omit the size parameter.
+	p.browser.SetIndexBuffer(buffer.browser.Ref(), formatStr, offset, 0)
 }
 
 // SetViewport sets the viewport transformation.
 func (p *RenderPassEncoder) SetViewport(x, y, width, height, minDepth, maxDepth float32) {
-	panic("wgpu: browser backend not yet implemented")
+	p.browser.SetViewport(x, y, width, height, minDepth, maxDepth)
 }
 
 // SetScissorRect sets the scissor rectangle for clipping.
 func (p *RenderPassEncoder) SetScissorRect(x, y, width, height uint32) {
-	panic("wgpu: browser backend not yet implemented")
+	p.browser.SetScissorRect(x, y, width, height)
 }
 
 // SetBlendConstant sets the blend constant color.
 func (p *RenderPassEncoder) SetBlendConstant(color *Color) {
-	panic("wgpu: browser backend not yet implemented")
+	if color == nil {
+		return
+	}
+	jsColor := browser.BuildColorDict(color.R, color.G, color.B, color.A)
+	p.browser.SetBlendConstant(jsColor)
 }
 
 // SetStencilReference sets the stencil reference value.
 func (p *RenderPassEncoder) SetStencilReference(reference uint32) {
-	panic("wgpu: browser backend not yet implemented")
+	p.browser.SetStencilReference(reference)
 }
 
 // Draw draws primitives.
 func (p *RenderPassEncoder) Draw(vertexCount, instanceCount, firstVertex, firstInstance uint32) {
-	panic("wgpu: browser backend not yet implemented")
+	p.browser.Draw(vertexCount, instanceCount, firstVertex, firstInstance)
 }
 
 // DrawIndexed draws indexed primitives.
 func (p *RenderPassEncoder) DrawIndexed(indexCount, instanceCount, firstIndex uint32, baseVertex int32, firstInstance uint32) {
-	panic("wgpu: browser backend not yet implemented")
+	p.browser.DrawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance)
 }
 
 // DrawIndirect draws primitives with GPU-generated parameters.
 func (p *RenderPassEncoder) DrawIndirect(buffer *Buffer, offset uint64) {
-	panic("wgpu: browser backend not yet implemented")
+	if buffer == nil || buffer.browser == nil {
+		return
+	}
+	p.browser.DrawIndirect(buffer.browser.Ref(), offset)
 }
 
 // DrawIndexedIndirect draws indexed primitives with GPU-generated parameters.
 func (p *RenderPassEncoder) DrawIndexedIndirect(buffer *Buffer, offset uint64) {
-	panic("wgpu: browser backend not yet implemented")
+	if buffer == nil || buffer.browser == nil {
+		return
+	}
+	p.browser.DrawIndexedIndirect(buffer.browser.Ref(), offset)
 }
 
 // End ends the render pass.
 func (p *RenderPassEncoder) End() error {
-	panic("wgpu: browser backend not yet implemented")
+	if p.released {
+		return ErrReleased
+	}
+	p.released = true
+	p.browser.End()
+	return nil
 }

--- a/sampler_browser.go
+++ b/sampler_browser.go
@@ -2,8 +2,11 @@
 
 package wgpu
 
+import "github.com/gogpu/wgpu/internal/browser"
+
 // Sampler represents a texture sampler.
 type Sampler struct {
+	browser  *browser.Sampler
 	released bool
 }
 

--- a/shader_browser.go
+++ b/shader_browser.go
@@ -2,8 +2,11 @@
 
 package wgpu
 
+import "github.com/gogpu/wgpu/internal/browser"
+
 // ShaderModule represents a compiled shader module.
 type ShaderModule struct {
+	browser  *browser.ShaderModule
 	released bool
 }
 

--- a/surface_browser.go
+++ b/surface_browser.go
@@ -2,35 +2,183 @@
 
 package wgpu
 
+import (
+	"fmt"
+	"syscall/js"
+
+	"github.com/gogpu/wgpu/internal/browser"
+)
+
 // Surface represents a platform rendering surface.
-// On browser, this wraps a GPUCanvasContext.
+// On browser, this wraps an HTMLCanvasElement + GPUCanvasContext.
+//
+// Matches Rust wgpu WebSurface which holds a Canvas enum, a GpuCanvasContext,
+// and an optional Gpu reference.
 type Surface struct {
+	browser  *browser.Surface
+	device   *Device
 	released bool
+
+	// Cached configuration for GetCurrentTexture texture creation.
+	configFormat TextureFormat
+}
+
+// CreateSurface creates a rendering surface from an HTML canvas element.
+//
+// On browser, displayHandle is ignored and windowHandle is treated as a
+// numeric canvas element ID (data-raw-handle attribute lookup). If windowHandle
+// is 0, the first <canvas> element in the document is used.
+//
+// For direct js.Value canvas access, use CreateSurfaceFromCanvas instead.
+//
+// Matches Rust wgpu InstanceInterface::create_surface for WebSurface which
+// uses RawWindowHandle::Web to query the DOM by data-raw-handle attribute.
+func (i *Instance) CreateSurface(displayHandle, windowHandle uintptr) (*Surface, error) {
+	if i.released {
+		return nil, ErrReleased
+	}
+
+	// On browser, resolve a canvas element from the DOM.
+	var canvas js.Value
+	doc := js.Global().Get("document")
+
+	if windowHandle == 0 {
+		// Default: use the first <canvas> in the document.
+		canvas = doc.Call("querySelector", "canvas")
+	} else {
+		// Lookup by data-raw-handle attribute (Rust wgpu convention).
+		selector := fmt.Sprintf("[data-raw-handle=\"%d\"]", windowHandle)
+		canvas = doc.Call("querySelector", selector)
+	}
+
+	if canvas.IsNull() || canvas.IsUndefined() {
+		return nil, fmt.Errorf("wgpu: no canvas element found for handle %d", windowHandle)
+	}
+
+	return i.createSurfaceFromCanvas(canvas)
+}
+
+// CreateSurfaceFromCanvas creates a rendering surface from a js.Value canvas.
+//
+// This is the browser-specific entry point that accepts a direct canvas
+// reference (HTMLCanvasElement or OffscreenCanvas). Use this when you have
+// a canvas js.Value from JavaScript interop.
+//
+// Matches Rust wgpu's SurfaceTarget::Canvas variant which takes an
+// HtmlCanvasElement directly.
+func (i *Instance) CreateSurfaceFromCanvas(canvas js.Value) (*Surface, error) {
+	if i.released {
+		return nil, ErrReleased
+	}
+	return i.createSurfaceFromCanvas(canvas)
+}
+
+// createSurfaceFromCanvas is the shared implementation for both CreateSurface
+// and CreateSurfaceFromCanvas.
+func (i *Instance) createSurfaceFromCanvas(canvas js.Value) (*Surface, error) {
+	bs, err := browser.NewSurface(i.browser.GPU(), canvas)
+	if err != nil {
+		return nil, fmt.Errorf("wgpu: failed to create surface: %w", err)
+	}
+	return &Surface{browser: bs}, nil
 }
 
 // Configure configures the surface for presentation.
+//
+// Must be called before GetCurrentTexture(). Sets the canvas dimensions and
+// calls GPUCanvasContext.configure() with the device, format, usage, and alpha mode.
+//
+// On browser, PresentMode is ignored (browser always uses FIFO / VSync).
+//
+// Matches Rust wgpu SurfaceInterface::configure for WebSurface.
 func (s *Surface) Configure(device *Device, config *SurfaceConfiguration) error {
-	panic("wgpu: browser backend not yet implemented")
+	if s.released {
+		return ErrReleased
+	}
+	if config == nil {
+		return fmt.Errorf("wgpu: surface configuration is nil")
+	}
+	if device == nil {
+		return fmt.Errorf("wgpu: device is nil")
+	}
+
+	// Validate present mode (Rust wgpu panics on Mailbox/Immediate on web).
+	switch config.PresentMode {
+	case PresentModeMailbox, PresentModeImmediate:
+		return fmt.Errorf("wgpu: present mode %v not supported on browser; only Fifo is supported", config.PresentMode)
+	}
+
+	// Build the JS GPUCanvasConfiguration object.
+	jsConfig := browser.BuildSurfaceConfiguration(
+		device.browser.Ref(),
+		config.Format,
+		config.Usage,
+		config.AlphaMode,
+		nil, // viewFormats -- SurfaceConfiguration doesn't expose them yet
+	)
+
+	formatStr := browser.TextureFormatToJS(config.Format)
+	s.browser.Configure(jsConfig, config.Width, config.Height, formatStr)
+	s.device = device
+	s.configFormat = config.Format
+	return nil
 }
 
 // Unconfigure removes the surface configuration.
+// After this call, GetCurrentTexture() will fail until Configure is called again.
 func (s *Surface) Unconfigure() {
-	panic("wgpu: browser backend not yet implemented")
+	if s.released {
+		return
+	}
+	s.browser.Unconfigure()
+	s.device = nil
 }
 
 // GetCurrentTexture acquires the next texture for rendering.
+//
+// Returns the surface texture and whether the surface is suboptimal (always
+// false on browser). The texture is automatically presented when the command
+// buffer using it is submitted and control returns to the browser event loop.
+//
+// Matches Rust wgpu SurfaceInterface::get_current_texture for WebSurface.
 func (s *Surface) GetCurrentTexture() (*SurfaceTexture, bool, error) {
-	panic("wgpu: browser backend not yet implemented")
+	if s.released {
+		return nil, false, ErrReleased
+	}
+	if s.device == nil {
+		return nil, false, fmt.Errorf("wgpu: surface not configured")
+	}
+
+	bt, err := s.browser.GetCurrentTexture()
+	if err != nil {
+		return nil, false, fmt.Errorf("wgpu: %w", err)
+	}
+
+	return &SurfaceTexture{
+		texture: &Texture{
+			browser: bt,
+			format:  s.configFormat,
+		},
+	}, false, nil // Browser surfaces are never suboptimal
 }
 
 // Present presents a surface texture to the screen.
-func (s *Surface) Present(texture *SurfaceTexture) error {
-	panic("wgpu: browser backend not yet implemented")
+//
+// On browser, this is a NO-OP. The swapchain is presented automatically when
+// control returns to the browser event loop. This matches Rust wgpu where
+// WebSurfaceOutputDetail::present() is an empty function.
+func (s *Surface) Present(_ *SurfaceTexture) error {
+	// No-op on browser. Presentation is automatic.
+	return nil
 }
 
 // DiscardTexture discards the acquired surface texture without presenting it.
+//
+// On browser, this is a NO-OP. The browser does not support discarding a
+// surface texture -- it will be presented regardless when the event loop runs.
+// Matches Rust wgpu where WebSurfaceOutputDetail::texture_discard() is a no-op.
 func (s *Surface) DiscardTexture() {
-	panic("wgpu: browser backend not yet implemented")
+	// No-op on browser. Cannot discard the texture.
 }
 
 // Release releases the surface.
@@ -39,14 +187,48 @@ func (s *Surface) Release() {
 		return
 	}
 	s.released = true
+	if s.browser != nil {
+		s.browser.Destroy()
+	}
 }
 
 // SurfaceTexture is a texture acquired from a surface for rendering.
+//
+// On browser, the texture is automatically presented when the command buffer
+// using it is submitted and control returns to the browser event loop.
 type SurfaceTexture struct {
+	texture  *Texture
 	released bool
 }
 
 // CreateView creates a texture view of this surface texture.
+//
+// Pass nil for desc to create a default view (all mips, all layers, same format).
 func (st *SurfaceTexture) CreateView(desc *TextureViewDescriptor) (*TextureView, error) {
-	panic("wgpu: browser backend not yet implemented")
+	if st.released || st.texture == nil || st.texture.browser == nil {
+		return nil, ErrReleased
+	}
+
+	var jsDesc js.Value
+	if desc != nil {
+		jsDesc = browser.BuildTextureViewDescriptor(
+			desc.Label,
+			desc.Format, desc.Dimension, desc.Aspect,
+			desc.BaseMipLevel, desc.MipLevelCount,
+			desc.BaseArrayLayer, desc.ArrayLayerCount,
+		)
+	} else {
+		jsDesc = js.Undefined()
+	}
+
+	bv := st.texture.browser.CreateView(jsDesc)
+	return &TextureView{
+		browser: bv,
+	}, nil
+}
+
+// Texture returns the underlying Texture. This is useful for operations that
+// need direct texture access (e.g., creating additional views).
+func (st *SurfaceTexture) Texture() *Texture {
+	return st.texture
 }

--- a/texture_browser.go
+++ b/texture_browser.go
@@ -2,8 +2,11 @@
 
 package wgpu
 
+import "github.com/gogpu/wgpu/internal/browser"
+
 // Texture represents a GPU texture.
 type Texture struct {
+	browser  *browser.Texture
 	format   TextureFormat
 	released bool
 }
@@ -17,10 +20,14 @@ func (t *Texture) Release() {
 		return
 	}
 	t.released = true
+	if t.browser != nil {
+		t.browser.Destroy()
+	}
 }
 
 // TextureView represents a view into a texture.
 type TextureView struct {
+	browser  *browser.TextureView
 	released bool
 }
 


### PR DESCRIPTION
## Summary

**Browser WebGPU backend** — complete `syscall/js` → `navigator.gpu` implementation. Same public API, same user code — `GOOS=js GOARCH=wasm go build` produces a working WASM binary. Verified in Chrome: all smoke tests pass.

Closes gogpu#70.

### 5 Phases

- **Phase 1:** Instance + Adapter + Device — `navigator.gpu`, pre-bound JS methods (Ebiten pattern), promise→goroutine async
- **Phase 2:** Resources + Pipelines — Buffer, Texture, ShaderModule (WGSL passthrough), BindGroup, RenderPipeline, ComputePipeline. 97 TextureFormats + 31 VertexFormats + all WebGPU enum conversions
- **Phase 3:** Command Recording + Submit — CommandEncoder, RenderPassEncoder (13 methods), ComputePassEncoder, Queue.Submit/WriteBuffer/WriteTexture. Verified against Rust wgpu `backend/webgpu.rs`
- **Phase 4:** Surface/Canvas — HTMLCanvasElement + GPUCanvasContext, Configure, GetCurrentTexture, Present (no-op)
- **Phase 5:** Buffer Mapping — MapAsync, MappedRange (lazy copy, Rust OnceCell pattern), dirty write-back

### Also in this release

- **Flaky TestThread_CallAsync fix** — channel sync replaces time.Sleep
- **goffi v0.5.1** — struct ABI, XMM return, CGO_ENABLED=1
- **x/sys v0.44.0**
- **Defensive NULL handle guard** in TransitionTextures/Buffers (Vulkan, DX12)
- **Architecture docs updated** — dual-path diagram (native/browser), COMPUTE-BACKENDS browser column

### Stats

- ~6500 LOC browser backend (4000 internal/browser + 2500 root wrappers)
- 29+ tests (enum conversions, all run natively)
- Zero external dependencies — only `syscall/js`
- WASM binary: 3MB

## Test plan

- [x] `GOOS=js GOARCH=wasm go build .` — compiles
- [x] Browser smoke test in Chrome — ALL TESTS PASSED (Instance, Adapter, Device, Buffer, ShaderModule, Submit, WriteBuffer)
- [x] `go build ./...` — native Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `golangci-lint run --timeout=5m` — 0 issues (Windows, Linux, macOS)
- [x] Cross-reference audit against Rust wgpu `backend/webgpu.rs` (4047 LOC) — complete
