### PR TITLE
v0.28.1: browser API compatibility stubs for gogpu integration

### DIFF
--- a/device_browser.go
+++ b/device_browser.go
@@ -287,6 +287,16 @@ func (d *Device) Poll(pollType PollType) bool {
 	return true
 }
 
+// FreeCommandBuffer is a no-op on browser — JS GC handles GPU resource cleanup.
+// This exists for API compatibility with the native backend where command buffers
+// must be explicitly freed after GPU submission completes.
+func (d *Device) FreeCommandBuffer(_ *CommandBuffer) {}
+
+// HalDevice returns nil on browser — there is no HAL layer.
+// The browser backend talks directly to the browser WebGPU API.
+// This exists for API compatibility with the native backend.
+func (d *Device) HalDevice() any { return nil }
+
 // Release releases the device and all associated resources.
 func (d *Device) Release() {
 	if d.released {

--- a/instance_browser.go
+++ b/instance_browser.go
@@ -5,13 +5,16 @@ package wgpu
 import (
 	"syscall/js"
 
+	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/internal/browser"
 )
 
 // InstanceDescriptor configures instance creation.
+// On browser, Backends and Flags are accepted for API compatibility but
+// ignored — the browser has exactly one WebGPU backend.
 type InstanceDescriptor struct {
 	Backends Backends
-	Flags    uint32
+	Flags    gputypes.InstanceFlags
 }
 
 // Instance is the entry point for GPU operations.

--- a/surface_browser.go
+++ b/surface_browser.go
@@ -4,6 +4,7 @@ package wgpu
 
 import (
 	"fmt"
+	"image"
 	"syscall/js"
 
 	"github.com/gogpu/wgpu/internal/browser"
@@ -170,6 +171,13 @@ func (s *Surface) GetCurrentTexture() (*SurfaceTexture, bool, error) {
 func (s *Surface) Present(_ *SurfaceTexture) error {
 	// No-op on browser. Presentation is automatic.
 	return nil
+}
+
+// PresentWithDamage presents a surface texture, optionally with damage rects.
+// On browser, damage rects are ignored — the browser composites the full canvas.
+// This method exists for API compatibility with the native backend.
+func (s *Surface) PresentWithDamage(st *SurfaceTexture, _ []image.Rectangle) error {
+	return s.Present(st)
 }
 
 // DiscardTexture discards the acquired surface texture without presenting it.


### PR DESCRIPTION
## Summary

- `FreeCommandBuffer` no-op (browser GC handles cleanup)
- `HalDevice` returns nil (no HAL layer on browser)
- `PresentWithDamage` delegates to `Present` (browser ignores damage rects)
- `InstanceDescriptor.Flags` type aligned to `gputypes.InstanceFlags`

Required for gogpu `platform_browser.go` to compile against wgpu browser backend.

## Test plan

- [x] `GOOS=js GOARCH=wasm go build .`
- [x] `go build ./...` + `go test ./...`
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] Cross-platform build (Linux, macOS)