### PR TITLE
v0.28.2: Surface.ActualExtent + Vulkan swapchain extent logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.2] - 2026-05-17
+
+### Added
+
+- **`Surface.ActualExtent()`** — returns actual swapchain dimensions after driver clamping.
+  On Vulkan, the driver may clamp the requested extent to its capabilities range (common on
+  X11 HiDPI where compositor reports physical pixels). Previously silent — now logged with
+  `slog.Warn` when clamping occurs. All 8 backends implement the HAL interface method.
+  Non-Vulkan backends return configured dimensions (no clamping). Closes #183.
+
 ## [0.28.0] - 2026-05-14
 
 ### Added

--- a/hal/dx12/instance.go
+++ b/hal/dx12/instance.go
@@ -472,6 +472,13 @@ func (s *Surface) DiscardTexture(_ hal.SurfaceTexture) {
 	// continue to use the existing frame.
 }
 
+// ActualExtent returns the configured swapchain dimensions.
+// DX12 DXGI does not clamp the extent, so these always match the requested values.
+// Returns (0, 0) if the surface is not configured.
+func (s *Surface) ActualExtent() (width, height uint32) {
+	return s.width, s.height
+}
+
 // Destroy releases the surface.
 func (s *Surface) Destroy() {
 	s.Unconfigure(nil)

--- a/hal/gles/resource_linux.go
+++ b/hal/gles/resource_linux.go
@@ -140,6 +140,16 @@ func (s *Surface) AcquireTexture(_ hal.Fence) (*hal.AcquiredSurfaceTexture, erro
 // DiscardTexture discards a previously acquired texture.
 func (s *Surface) DiscardTexture(_ hal.SurfaceTexture) {}
 
+// ActualExtent returns the configured surface dimensions.
+// GLES does not clamp the extent, so these always match the requested values.
+// Returns (0, 0) if the surface is not configured.
+func (s *Surface) ActualExtent() (width, height uint32) {
+	if s.config == nil {
+		return 0, 0
+	}
+	return s.config.Width, s.config.Height
+}
+
 // Destroy releases the surface resources.
 func (s *Surface) Destroy() {
 	// Release swapchain FBO before tearing down the GL context.

--- a/hal/gles/resource_windows.go
+++ b/hal/gles/resource_windows.go
@@ -157,6 +157,16 @@ func (s *Surface) AcquireTexture(_ hal.Fence) (*hal.AcquiredSurfaceTexture, erro
 // DiscardTexture discards a previously acquired texture.
 func (s *Surface) DiscardTexture(_ hal.SurfaceTexture) {}
 
+// ActualExtent returns the configured surface dimensions.
+// GLES does not clamp the extent, so these always match the requested values.
+// Returns (0, 0) if the surface is not configured.
+func (s *Surface) ActualExtent() (width, height uint32) {
+	if s.config == nil {
+		return 0, 0
+	}
+	return s.config.Width, s.config.Height
+}
+
 // Destroy releases the surface resources.
 func (s *Surface) Destroy() {
 	// Release swapchain FBO before tearing down the GL context.

--- a/hal/metal/surface.go
+++ b/hal/metal/surface.go
@@ -145,6 +145,13 @@ func (s *Surface) DiscardTexture(tex hal.SurfaceTexture) {
 	}
 }
 
+// ActualExtent returns the configured surface dimensions.
+// Metal does not clamp the extent, so these always match the requested values.
+// Returns (0, 0) if the surface is not configured.
+func (s *Surface) ActualExtent() (width, height uint32) {
+	return s.width, s.height
+}
+
 // Destroy releases the surface.
 func (s *Surface) Destroy() {
 	hal.Logger().Debug("metal: surface destroyed")

--- a/hal/noop/resource.go
+++ b/hal/noop/resource.go
@@ -72,6 +72,12 @@ func (s *Surface) AcquireTexture(_ hal.Fence) (*hal.AcquiredSurfaceTexture, erro
 // DiscardTexture is a no-op.
 func (s *Surface) DiscardTexture(_ hal.SurfaceTexture) {}
 
+// ActualExtent returns (0, 0) for the noop backend.
+// The noop backend does not track configured dimensions.
+func (s *Surface) ActualExtent() (width, height uint32) {
+	return 0, 0
+}
+
 // SurfaceTexture implements hal.SurfaceTexture.
 type SurfaceTexture struct {
 	Texture

--- a/hal/registry_test.go
+++ b/hal/registry_test.go
@@ -46,6 +46,7 @@ func (m *mockSurface) AcquireTexture(_ hal.Fence) (*hal.AcquiredSurfaceTexture, 
 	}, nil
 }
 func (m *mockSurface) DiscardTexture(_ hal.SurfaceTexture) {}
+func (m *mockSurface) ActualExtent() (uint32, uint32)      { return 0, 0 }
 func (m *mockSurface) Destroy()                            {}
 
 // mockSurfaceTexture is a minimal surface texture implementation for testing.

--- a/hal/resource.go
+++ b/hal/resource.go
@@ -135,6 +135,19 @@ type Surface interface {
 	// DiscardTexture discards a surface texture without presenting it.
 	// Use this if rendering failed or was canceled.
 	DiscardTexture(texture SurfaceTexture)
+
+	// ActualExtent returns the actual swapchain dimensions after driver clamping.
+	//
+	// On Vulkan, the driver may clamp the requested extent to its supported
+	// range (e.g., on X11 HiDPI where the compositor reports a different
+	// physical size). The returned values reflect what the swapchain was
+	// actually created with, which may differ from the requested
+	// SurfaceConfiguration.Width/Height.
+	//
+	// On non-Vulkan backends (DX12, Metal, GLES, Software), the returned
+	// values match the configured dimensions since those backends do not
+	// clamp the extent. Returns (0, 0) if the surface is not configured.
+	ActualExtent() (width, height uint32)
 }
 
 // SurfaceTexture is a texture acquired from a surface.

--- a/hal/software/resource.go
+++ b/hal/software/resource.go
@@ -246,6 +246,15 @@ func (s *Surface) AcquireTexture(_ hal.Fence) (*hal.AcquiredSurfaceTexture, erro
 // DiscardTexture is a no-op (framebuffer stays allocated).
 func (s *Surface) DiscardTexture(_ hal.SurfaceTexture) {}
 
+// ActualExtent returns the configured surface dimensions.
+// The software backend does not clamp the extent, so these always match
+// the requested values. Returns (0, 0) if the surface is not configured.
+func (s *Surface) ActualExtent() (width, height uint32) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.width, s.height
+}
+
 // GetFramebuffer returns a copy of the current framebuffer data in RGBA byte
 // order (thread-safe). If the surface format is BGRA, R and B channels are
 // swapped so callers always receive consistent RGBA data. This allows

--- a/hal/vulkan/api.go
+++ b/hal/vulkan/api.go
@@ -291,6 +291,16 @@ func (s *Surface) Configure(device hal.Device, config *hal.SurfaceConfiguration)
 	return s.createSwapchain(vkDevice, config)
 }
 
+// ActualExtent returns the actual swapchain dimensions after driver clamping.
+// On Vulkan, the driver may clamp the requested extent to its supported range
+// (e.g., on X11 HiDPI). Returns (0, 0) if no swapchain is configured.
+func (s *Surface) ActualExtent() (width, height uint32) {
+	if s.swapchain == nil {
+		return 0, 0
+	}
+	return s.swapchain.extent.Width, s.swapchain.extent.Height
+}
+
 // Unconfigure removes surface configuration.
 func (s *Surface) Unconfigure(_ hal.Device) {
 	if s.swapchain != nil {

--- a/hal/vulkan/swapchain.go
+++ b/hal/vulkan/swapchain.go
@@ -116,11 +116,34 @@ func (s *Surface) createSwapchain(device *Device, config *hal.SurfaceConfigurati
 		Height: config.Height,
 	}
 
+	// Log surface capabilities for HiDPI diagnostics (BUG-VK-HIDPI-001).
+	hal.Logger().Debug("vulkan: surface capabilities",
+		"requestedWidth", config.Width,
+		"requestedHeight", config.Height,
+		"currentExtent", [2]uint32{capabilities.CurrentExtent.Width, capabilities.CurrentExtent.Height},
+		"minExtent", [2]uint32{capabilities.MinImageExtent.Width, capabilities.MinImageExtent.Height},
+		"maxExtent", [2]uint32{capabilities.MaxImageExtent.Width, capabilities.MaxImageExtent.Height},
+	)
+
 	// Clamp to driver-reported range when CurrentExtent is defined.
 	// CurrentExtent of 0xFFFFFFFF means the surface size is determined by the swapchain.
 	if capabilities.CurrentExtent.Width != 0xFFFFFFFF {
 		extent.Width = clampUint32(extent.Width, capabilities.MinImageExtent.Width, capabilities.MaxImageExtent.Width)
 		extent.Height = clampUint32(extent.Height, capabilities.MinImageExtent.Height, capabilities.MaxImageExtent.Height)
+	}
+
+	// Warn if the driver clamped the extent to different dimensions than
+	// requested. This commonly happens on X11 HiDPI where the compositor
+	// reports physical pixels that differ from the application's logical
+	// pixels. Downstream code (e.g., MSAA textures) should use
+	// Surface.ActualExtent() to match the real swapchain size.
+	if extent.Width != config.Width || extent.Height != config.Height {
+		hal.Logger().Warn("vulkan: swapchain extent clamped by driver",
+			"requestedWidth", config.Width,
+			"requestedHeight", config.Height,
+			"actualWidth", extent.Width,
+			"actualHeight", extent.Height,
+		)
 	}
 
 	// Zero extent means the window is minimized -- skip swapchain creation.

--- a/surface_browser.go
+++ b/surface_browser.go
@@ -180,6 +180,16 @@ func (s *Surface) PresentWithDamage(st *SurfaceTexture, _ []image.Rectangle) err
 	return s.Present(st)
 }
 
+// ActualExtent returns the configured surface dimensions.
+// On browser, the canvas dimensions are always used as-is (no driver clamping).
+// Returns (0, 0) if the surface is not configured.
+func (s *Surface) ActualExtent() (width, height uint32) {
+	if s.released || s.browser == nil {
+		return 0, 0
+	}
+	return s.browser.Width(), s.browser.Height()
+}
+
 // DiscardTexture discards the acquired surface texture without presenting it.
 //
 // On browser, this is a NO-OP. The browser does not support discarding a

--- a/surface_native.go
+++ b/surface_native.go
@@ -183,6 +183,31 @@ func (s *Surface) SetPrepareFrame(fn core.PrepareFrameFunc) {
 	s.core.SetPrepareFrame(fn)
 }
 
+// ActualExtent returns the actual swapchain dimensions after driver clamping.
+//
+// On Vulkan, the driver may clamp the requested extent to its supported range
+// (e.g., on X11 HiDPI where the compositor reports physical pixels that differ
+// from the application's logical pixels). The returned values reflect what the
+// swapchain was actually created with, which may differ from the configured
+// SurfaceConfiguration.Width/Height.
+//
+// On non-Vulkan backends (DX12, Metal, GLES, Software), the returned values
+// match the configured dimensions since those backends do not clamp the extent.
+// Returns (0, 0) if the surface is not configured.
+//
+// Use this to size MSAA resolve textures, offscreen targets, and any other
+// resources that must match the true swapchain size.
+func (s *Surface) ActualExtent() (width, height uint32) {
+	if s.released {
+		return 0, 0
+	}
+	raw := s.core.RawSurface()
+	if raw == nil {
+		return 0, 0
+	}
+	return raw.ActualExtent()
+}
+
 // DiscardTexture discards the acquired surface texture without presenting it.
 // Use this if rendering failed or was canceled. If no texture is currently
 // acquired, this is a no-op.


### PR DESCRIPTION
## Summary

- **`Surface.ActualExtent()`** — HAL interface method on all 8 backends. Returns actual swapchain dimensions after driver clamping.
- **Vulkan diagnostic logging** — `slog.Debug` after capabilities query, `slog.Warn` when extent is clamped (HiDPI root cause).
- Closes #183.

Root cause of X11 HiDPI quarter-screen (gg#327): Vulkan silently clamped extent, MSAA textures used unclamped dimensions.

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `GOOS=js GOARCH=wasm go build .` — WASM
- [x] `go test ./...` — all pass
- [x] `golangci-lint run --timeout=5m` — 0 issues (Windows, Linux, macOS)
- [x] `gofmt -l .` — clean