### PR TITLE
v0.28.3: Vulkan swapchain post-creation extent logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.3] - 2026-05-17
+
+### Fixed
+
+- **Vulkan: log actual swapchain extent after creation** — diagnostic logging after
+  `vkCreateSwapchainKHR` shows actual extent, image count, format, and present mode.
+  Complements v0.28.2 capabilities logging to verify driver-created images match
+  requested dimensions on HiDPI configurations. Closes #185.
+
 ## [0.28.2] - 2026-05-17
 
 ### Added

--- a/hal/vulkan/swapchain.go
+++ b/hal/vulkan/swapchain.go
@@ -224,6 +224,14 @@ func (s *Surface) createSwapchain(device *Device, config *hal.SurfaceConfigurati
 		return fmt.Errorf("vulkan: vkGetSwapchainImagesKHR (images) failed: %d", result)
 	}
 
+	// Log actual swapchain creation result (wgpu#185: HiDPI diagnostic).
+	hal.Logger().Info("vulkan: swapchain created",
+		"extent", fmt.Sprintf("%dx%d", extent.Width, extent.Height),
+		"images", swapchainImageCount,
+		"format", vkFormat,
+		"presentMode", presentMode,
+	)
+
 	// Create image views
 	imageViews := make([]vk.ImageView, len(images))
 	for i, img := range images {


### PR DESCRIPTION
## Summary

Log actual swapchain extent, image count, format, and present mode after `vkCreateSwapchainKHR`. Complements v0.28.2 pre-creation capabilities logging. HiDPI diagnostic for gg#327.

Closes #185.

## Test plan

- [x] `go build ./...` + `go test ./...`
- [x] `golangci-lint run --timeout=5m` — 0 issues