### PR TITLE
v0.28.5: Metal defer pool.Drain + drawable count + indirect validation nil guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.5] - 2026-05-21
+
+### Fixed
+
+- **Metal: autorelease pool leak in Present()** — `pool.Drain()` now deferred, preventing
+  ObjC autorelease pool leak on panic. Rust wgpu uses closure-scoped `autoreleasepool`.
+
+- **Metal: explicit drawable count in Configure()** — added `setMaximumDrawableCount:3`
+  matching Rust wgpu `surface.rs:176` (`maximum_frame_latency + 1`).
+
+- **Core: indirect validation nil pointer on noop backend** (#189) — `NewIndirectValidation`
+  now checks `MaxComputeWorkgroupSizeX > 0` before creating GPU resources. Noop/test backends
+  skip validation gracefully. Rust wgpu checks `DownlevelFlags::INDIRECT_EXECUTION`.
+
 ## [0.28.4] - 2026-05-21
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.28.4
+## Current State: v0.28.5
 
 ✅ **All 5 HAL backends complete** (~127K LOC)
 ✅ **Three-layer WebGPU stack** — wgpu API → wgpu/core → wgpu/hal
@@ -149,6 +149,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.28.5** | 2026-05 | Metal: defer pool.Drain, drawable count. Core: indirect validation nil guard (#189). |
 | **v0.28.4** | 2026-05 | macOS blit (@k-chimi), GLES Rust parity (fence+copies+timestamps+adapter), GPU dispatch indirect validation. |
 | **v0.28.0** | 2026-05 | **Browser WebGPU backend** (WASM-001). Complete `syscall/js` → `navigator.gpu`. 6500 LOC, 5 phases, zero deps. First Pure Go WebGPU in the browser. |
 | **v0.27.5** | 2026-05 | Defensive NULL handle guard in TransitionTextures/Buffers (Vulkan, DX12, public API). Prevents crash on destroyed resource barriers. |

--- a/core/indirect_validation.go
+++ b/core/indirect_validation.go
@@ -160,6 +160,12 @@ func NewIndirectValidation(halDevice hal.Device, limits gputypes.Limits) *Indire
 		return nil
 	}
 
+	// Check that the backend supports compute shaders (noop/test backends don't).
+	// Rust wgpu checks DownlevelFlags::INDIRECT_EXECUTION + instance flag.
+	if limits.MaxComputeWorkgroupSizeX == 0 {
+		return nil
+	}
+
 	b := &indirectValidationBuilder{device: halDevice}
 	iv, err := buildIndirectValidation(halDevice, maxWorkgroups, b)
 	if err != nil {
@@ -262,6 +268,9 @@ func buildIndirectValidation(
 	}
 
 	// 7. Create destination bind group (group 0: dst buffer + params uniform).
+	if b.dstBuffer == nil || b.paramsBuffer == nil {
+		return nil, fmt.Errorf("buffer creation returned nil")
+	}
 	b.dstBindGroup, err = halDevice.CreateBindGroup(&hal.BindGroupDescriptor{
 		Label:  "wgpu_indirect_dispatch_dst_group",
 		Layout: b.dstBindGroupLayout,

--- a/hal/metal/queue.go
+++ b/hal/metal/queue.go
@@ -388,8 +388,8 @@ func (q *Queue) Present(surface hal.Surface, texture hal.SurfaceTexture, _ []ima
 
 	if st.drawable != 0 {
 		pool := NewAutoreleasePool()
+		defer pool.Drain()
 
-		// Create a dedicated command buffer for presentation
 		cmdBuffer := MsgSend(q.commandQueue, Sel("commandBuffer"))
 		if cmdBuffer != 0 {
 			_ = MsgSend(cmdBuffer, Sel("presentDrawable:"), uintptr(st.drawable))
@@ -399,8 +399,6 @@ func (q *Queue) Present(surface hal.Surface, texture hal.SurfaceTexture, _ []ima
 
 		Release(st.drawable)
 		st.drawable = 0
-
-		pool.Drain()
 	}
 
 	return nil

--- a/hal/metal/surface.go
+++ b/hal/metal/surface.go
@@ -61,6 +61,11 @@ func (s *Surface) Configure(device hal.Device, config *hal.SurfaceConfiguration)
 	framebufferOnly := config.Usage&gputypes.TextureUsageStorageBinding == 0
 	msgSendVoid(s.layer, Sel("setFramebufferOnly:"), argBool(framebufferOnly))
 
+	// Set maximum drawable count for frame latency control.
+	// Rust wgpu: set_maximum_drawable_count(maximum_frame_latency + 1).
+	// Default maximum_frame_latency=2 → drawable_count=3 (Metal default).
+	_ = MsgSend(s.layer, Sel("setMaximumDrawableCount:"), uintptr(3))
+
 	// Set present mode
 	s.presentMode = config.PresentMode
 	// VSync is controlled by displaySyncEnabled (available since macOS 10.13)

--- a/hal/software/blit_darwin.go
+++ b/hal/software/blit_darwin.go
@@ -38,7 +38,7 @@ func (p *platformBlit) init() (err error) {
 	}
 
 	p.cg = new(coreGraphics)
-	if err := p.cg.Open(p.objc); err != nil {
+	if err := p.cg.Open(); err != nil {
 		return err
 	}
 
@@ -48,21 +48,24 @@ func (p *platformBlit) init() (err error) {
 	}
 
 	p.mtl = new(metal)
-	if err := p.mtl.Open(p.objc); err != nil {
+	if err := p.mtl.Open(); err != nil {
 		p.mtl = nil
 	}
 
-	if p.mtl != nil {
-		p.mtlDevice, err = p.mtl.CreateSystemDefaultDevice()
+	if p.mtl == nil {
+		p.isInitialized = true
+		return nil
+	}
+
+	p.mtlDevice, err = p.mtl.CreateSystemDefaultDevice()
+	if err != nil {
+		return err
+	}
+
+	if !p.mtlDevice.IsSamePointer(&objcAnyOpaqueNil) {
+		p.mtlQueue, err = p.mtlDevice.NewCommandQueue(p.objc)
 		if err != nil {
 			return err
-		}
-
-		if !p.mtlDevice.IsSamePointer(&objcAnyOpaqueNil) {
-			p.mtlQueue, err = p.mtlDevice.NewCommandQueue(p.objc)
-			if err != nil {
-				return err
-			}
 		}
 	}
 
@@ -93,11 +96,11 @@ func (s *Surface) blitFramebufferToWindow(data []byte, width, height int32) {
 		return
 	}
 
-	if !s.platformBlit.onceInit() {
+	if !s.onceInit() {
 		return
 	}
 
-	objc, cg, colorSpace, mtl := s.platformBlit.objc, s.platformBlit.cg, s.platformBlit.colorSpace, s.platformBlit.mtl
+	objc, cg, colorSpace, mtl := s.objc, s.cg, s.colorSpace, s.mtl
 	l := caLayer{objcAnyOpaqueFromPointer(unsafe.Pointer(s.hwnd))}
 
 	// true when s.hwnd is CAMetalLayer
@@ -110,7 +113,7 @@ func (s *Surface) blitFramebufferToWindow(data []byte, width, height int32) {
 	if isMetalNeeded {
 		// CAMetalLayer does not support `setContents:`
 
-		device, queue := s.platformBlit.mtlDevice, s.platformBlit.mtlQueue
+		device, queue := s.mtlDevice, s.mtlQueue
 
 		ml := initCAMetalLayer(objc, device, colorSpace, l)
 
@@ -129,11 +132,11 @@ func (s *Surface) blitDamageRectsToWindow(src []byte, w, h int32, rects []image.
 		return
 	}
 
-	if !s.platformBlit.onceInit() {
+	if !s.onceInit() {
 		return
 	}
 
-	objc, cg, colorSpace, mtl := s.platformBlit.objc, s.platformBlit.cg, s.platformBlit.colorSpace, s.platformBlit.mtl
+	objc, cg, colorSpace, mtl := s.objc, s.cg, s.colorSpace, s.mtl
 	l := caLayer{objcAnyOpaqueFromPointer(unsafe.Pointer(s.hwnd))}
 
 	isMetalNeeded := false
@@ -142,7 +145,7 @@ func (s *Surface) blitDamageRectsToWindow(src []byte, w, h int32, rects []image.
 	}
 
 	if isMetalNeeded {
-		device, queue := s.platformBlit.mtlDevice, s.platformBlit.mtlQueue
+		device, queue := s.mtlDevice, s.mtlQueue
 
 		ml := initCAMetalLayer(objc, device, colorSpace, l)
 
@@ -167,15 +170,21 @@ func createCGImageByFramebuffer(cg *coreGraphics, colorSpace cgColorSpace, data 
 
 	img, err = cg.ImageCreate(uintptr(width), uintptr(height), 8, 32, 4*uintptr(width), colorSpace, binfo, dataProvider, objcAnyOpaqueNil, false, cgColorRenderingIntentDefault)
 	if err != nil {
-		cg.DataProviderRelease(dataProvider)
+		if releaseErr := cg.DataProviderRelease(dataProvider); releaseErr != nil {
+			slog.Debug("software: failed to release CGDataProvider", slog.Any("error", releaseErr))
+		}
 
 		slog.Debug("software: failed to create CGImage", slog.Any("error", err))
 		return
 	}
 
 	release = func() {
-		defer cg.DataProviderRelease(dataProvider)
-		defer cg.ImageRelease(img)
+		if releaseErr := cg.DataProviderRelease(dataProvider); releaseErr != nil {
+			slog.Debug("software: failed to release CGDataProvider", slog.Any("error", releaseErr))
+		}
+		if releaseErr := cg.ImageRelease(img); releaseErr != nil {
+			slog.Debug("software: failed to release CGImage", slog.Any("error", releaseErr))
+		}
 	}
 
 	return img, release
@@ -233,7 +242,9 @@ func initCAMetalLayer(objc *objcReflect, device mtlDevice, colorSpace cgColorSpa
 		slog.Debug("software: failed to get device", slog.Any("error", err))
 	} else if d.IsSamePointer(&objcAnyOpaqueNil) {
 		d = device
-		ml.SetDevice(objc, d)
+		if err := ml.SetDevice(objc, d); err != nil {
+			slog.Debug("software: failed to set device", slog.Any("error", err))
+		}
 	}
 
 	col, err := ml.ColorSpace(objc)
@@ -349,11 +360,7 @@ func (m *mtlCommandBuffer) PresentDrawable(objc *objcReflect, dr caMTLDrawable) 
 	}
 
 	ret := objcAnyOpaqueNil
-	if err := objc.MsgSend(m.objcAnyOpaque, sel.objcAnyOpaque, &ret, &dr); err != nil {
-		return err
-	}
-
-	return nil
+	return objc.MsgSend(m.objcAnyOpaque, sel.objcAnyOpaque, &ret, &dr)
 }
 
 func (m *mtlCommandBuffer) Commit(objc *objcReflect) error {
@@ -363,11 +370,7 @@ func (m *mtlCommandBuffer) Commit(objc *objcReflect) error {
 	}
 
 	ret := objcAnyOpaqueNil
-	if err := objc.MsgSend(m.objcAnyOpaque, sel.objcAnyOpaque, &ret); err != nil {
-		return err
-	}
-
-	return nil
+	return objc.MsgSend(m.objcAnyOpaque, sel.objcAnyOpaque, &ret)
 }
 
 type mtlDevice struct{ objcAnyOpaque }
@@ -409,11 +412,7 @@ func (c *caMetalLayer) SetPixelFormat(objc *objcReflect, pixfmt uint64) error {
 	}
 
 	ret := objcAnyOpaqueNil
-	if err := objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret, objcBoxedWith(pixfmt, types.UInt64TypeDescriptor)); err != nil {
-		return err
-	}
-
-	return nil
+	return objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret, objcBoxedWith(pixfmt, types.UInt64TypeDescriptor))
 }
 
 func (c *caMetalLayer) DrawableSize(objc *objcReflect) (sz cgSize, err error) {
@@ -437,11 +436,7 @@ func (c *caMetalLayer) SetDrawableSize(objc *objcReflect, sz cgSize) error {
 	}
 
 	ret := objcAnyOpaqueNil
-	if err := objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret, objcBoxedWith(sz, cgSizeTypeDescriptor)); err != nil {
-		return err
-	}
-
-	return nil
+	return objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret, objcBoxedWith(sz, cgSizeTypeDescriptor))
 }
 
 func (c *caMetalLayer) Device(objc *objcReflect) (d mtlDevice, err error) {
@@ -466,11 +461,7 @@ func (c *caMetalLayer) SetDevice(objc *objcReflect, device mtlDevice) error {
 	}
 
 	ret := objcAnyOpaqueNil
-	if err := objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret, &device); err != nil {
-		return err
-	}
-
-	return nil
+	return objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret, &device)
 }
 
 func (c *caMetalLayer) ColorSpace(objc *objcReflect) (col cgColorSpace, err error) {
@@ -494,11 +485,7 @@ func (c *caMetalLayer) SetColorSpace(objc *objcReflect, col cgColorSpace) error 
 	}
 
 	ret := objcAnyOpaqueNil
-	if err := objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret, &col.objcAnyOpaque); err != nil {
-		return err
-	}
-
-	return nil
+	return objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret, &col.objcAnyOpaque)
 }
 
 func (c *caMetalLayer) NextDrawable(objc *objcReflect) (dr caMTLDrawable, err error) {
@@ -548,18 +535,12 @@ func (m *mtlTexture) ReplaceRegion_MipmapLevel_WithBytes_BytesPerRow(
 		return err
 	}
 
-	err = objc.MsgSend(m.objcAnyOpaque, sel.objcAnyOpaque, &objcAnyOpaqueNil,
+	return objc.MsgSend(m.objcAnyOpaque, sel.objcAnyOpaque, &objcAnyOpaqueNil,
 		objcBoxedWith(region, metalRegionType),
 		objcBoxedWith(mipmapLevel, types.UInt64TypeDescriptor),
 		objcBoxedWith(unsafe.Pointer(unsafe.SliceData(withBytes)), types.PointerTypeDescriptor),
 		objcBoxedWith(bytesPerRow, types.UInt64TypeDescriptor),
 	)
-
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (m *mtlTexture) Width(objc *objcReflect) (w uint64, err error) {
@@ -631,16 +612,6 @@ var (
 			metalSizeType,
 		},
 	}
-	cifMetalRegionMake2D = &types.CallInterface{
-		ArgCount: 4,
-		ArgTypes: []*types.TypeDescriptor{
-			types.UInt64TypeDescriptor,
-			types.UInt64TypeDescriptor,
-			types.UInt64TypeDescriptor,
-			types.UInt64TypeDescriptor,
-		},
-		ReturnType: metalRegionType,
-	}
 	cifMTLCreateSystemDefaultDevice = types.CallInterface{
 		ArgCount:   0,
 		ReturnType: types.PointerTypeDescriptor,
@@ -652,13 +623,9 @@ const metalLibraryLocation = "/System/Library/Frameworks/Metal.framework/Metal"
 type metal struct {
 	lib                             unsafe.Pointer
 	symMTLCreateSystemDefaultDevice unsafe.Pointer
-
-	objc *objcReflect
 }
 
-func (m *metal) Open(objc *objcReflect) (err error) {
-	m.objc = objc
-
+func (m *metal) Open() (err error) {
 	if _, err := os.Stat(metalLibraryLocation); err != nil {
 		return m.errorf("metal framework not found: %w", err)
 	}
@@ -699,11 +666,7 @@ func (c *caLayer) SetNeedsDisplayInRect(objc *objcReflect, rect cgRect) error {
 
 	ret := objcAnyOpaqueNil
 	src := objcBoxedWith(rect, cgRectTypeDescriptor)
-	if err := objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret, src); err != nil {
-		return err
-	}
-
-	return nil
+	return objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret, src)
 }
 
 // ref: https://developer.apple.com/documentation/quartzcore/calayer/setneedsdisplay()?language=objc
@@ -714,11 +677,7 @@ func (c *caLayer) SetNeedsDisplay(objc *objcReflect) error {
 	}
 
 	ret := objcAnyOpaqueNil
-	if err := objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret); err != nil {
-		return err
-	}
-
-	return nil
+	return objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret)
 }
 
 func (c *caLayer) SetContents(objc *objcReflect, obj objcAnyOpaque) error {
@@ -728,11 +687,7 @@ func (c *caLayer) SetContents(objc *objcReflect, obj objcAnyOpaque) error {
 	}
 
 	ret := objcAnyOpaqueNil
-	if err := objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret, &obj); err != nil {
-		return err
-	}
-
-	return nil
+	return objc.MsgSend(c.objcAnyOpaque, sel.objcAnyOpaque, &ret, &obj)
 }
 
 type cgImageAlphaInfo uint32
@@ -904,8 +859,6 @@ var (
 const coreGraphicsLibraryLocation = "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics"
 
 type coreGraphics struct {
-	objc *objcReflect
-
 	lib                             unsafe.Pointer
 	symCGImageCreate                unsafe.Pointer
 	symCGDataProviderCreateWithData unsafe.Pointer
@@ -914,7 +867,7 @@ type coreGraphics struct {
 	symCGColorSpaceCreateDeviceRGB  unsafe.Pointer
 }
 
-func (c *coreGraphics) Open(objc *objcReflect) (err error) {
+func (c *coreGraphics) Open() (err error) {
 	if c.lib, err = ffi.LoadLibrary(coreGraphicsLibraryLocation); err != nil {
 		return c.errorf("failed to load CoreGraphics: %w", err)
 	}
@@ -954,16 +907,16 @@ func (c *coreGraphics) ImageCreate(
 	// CGImageRef: (struct CGImage)*
 	cgimg.objcAnyOpaque = objcAnyOpaqueNil
 
-	err = ffi.CallFunction(cifCoreGraphicsImageCreate, c.symCGImageCreate, unsafe.Pointer(cgimg.Pointer()), []unsafe.Pointer{
+	err = ffi.CallFunction(cifCoreGraphicsImageCreate, c.symCGImageCreate, cgimg.Pointer(), []unsafe.Pointer{
 		unsafe.Pointer(&width),
 		unsafe.Pointer(&height),
 		unsafe.Pointer(&bitsPerComponent),
 		unsafe.Pointer(&bitsPerPixel),
 		unsafe.Pointer(&bytesPerRow),
-		unsafe.Pointer(space.Pointer()),
+		space.Pointer(),
 		unsafe.Pointer(&bitmapInfo),
-		unsafe.Pointer(provider.Pointer()),
-		unsafe.Pointer(decode.Pointer()),
+		provider.Pointer(),
+		decode.Pointer(),
 		unsafe.Pointer(&shouldInterpolate),
 		unsafe.Pointer(&intent),
 	})
@@ -983,11 +936,11 @@ func (c *coreGraphics) DataProviderCreateWithData(
 	// CGDataProviderRef: (struct CGDataProvider)*
 	cgprovider.objcAnyOpaque = objcAnyOpaqueNil
 
-	err = ffi.CallFunction(cifCoreGraphicsDataProviderCreateWithData, c.symCGDataProviderCreateWithData, unsafe.Pointer(cgprovider.Pointer()), []unsafe.Pointer{
-		unsafe.Pointer(info.Pointer()),
-		unsafe.Pointer(data.Pointer()),
+	err = ffi.CallFunction(cifCoreGraphicsDataProviderCreateWithData, c.symCGDataProviderCreateWithData, cgprovider.Pointer(), []unsafe.Pointer{
+		info.Pointer(),
+		data.Pointer(),
 		unsafe.Pointer(&size),
-		unsafe.Pointer(releaseDataCallback.Pointer()),
+		releaseDataCallback.Pointer(),
 	})
 	if err != nil {
 		return cgDataProvider{objcAnyOpaqueNil}, c.errorf("failed to CGDataProviderCreateWithData: %w", err)
@@ -997,7 +950,7 @@ func (c *coreGraphics) DataProviderCreateWithData(
 }
 
 func (c *coreGraphics) ImageRelease(cgimage cgImage) error {
-	err := ffi.CallFunction(cifCoreGraphicsImageRelease, c.symCGImageRelease, nil, []unsafe.Pointer{unsafe.Pointer(cgimage.Pointer())})
+	err := ffi.CallFunction(cifCoreGraphicsImageRelease, c.symCGImageRelease, nil, []unsafe.Pointer{cgimage.Pointer()})
 	if err != nil {
 		return c.errorf("failed to CGImageRelease: %w", err)
 	}
@@ -1006,7 +959,7 @@ func (c *coreGraphics) ImageRelease(cgimage cgImage) error {
 }
 
 func (c *coreGraphics) DataProviderRelease(cgprovider cgDataProvider) error {
-	err := ffi.CallFunction(cifCoreGraphicsDataProviderRelease, c.symCGDataProviderRelease, nil, []unsafe.Pointer{unsafe.Pointer(cgprovider.Pointer())})
+	err := ffi.CallFunction(cifCoreGraphicsDataProviderRelease, c.symCGDataProviderRelease, nil, []unsafe.Pointer{cgprovider.Pointer()})
 	if err != nil {
 		return c.errorf("failed to CGDataProviderRelease: %w", err)
 	}
@@ -1195,7 +1148,7 @@ func (o *objcReflect) GetClass(obj objcAnyOpaque) (cls objcAnyOpaque, err error)
 	cls = objcAnyOpaqueNil
 
 	err = ffi.CallFunction(cifOBJCGetClass, o.symObjectGetClass, unsafe.Pointer(&cls.data), []unsafe.Pointer{
-		unsafe.Pointer(obj.Pointer()),
+		obj.Pointer(),
 	})
 	if err != nil {
 		return objcAnyOpaqueNil, err


### PR DESCRIPTION
## Summary

- **Metal: defer pool.Drain()** in Present() — prevents autorelease leak on panic (Rust uses closure-scoped autoreleasepool)
- **Metal: setMaximumDrawableCount:3** in Configure() — Rust wgpu parity (surface.rs:176)
- **Core: indirect validation nil guard** (#189) — skip on noop/test backends where MaxComputeWorkgroupSizeX=0 (Rust checks DownlevelFlags::INDIRECT_EXECUTION)

All verified against Rust wgpu-hal Metal reference.

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `golangci-lint run --timeout=5m` — 0 issues