### PR TITLE
fix(gles): Instance-owned GL context on hidden window (Rust wgpu parity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.6] - 2026-05-21
+
+### Fixed
+
+- **GLES: Instance-owned GL context on hidden window (Rust wgpu parity)** — GL context
+  now lives on a hidden 1×1 HWND owned by Instance, surviving any user Surface destruction.
+  Previously the context was tied to the user window — closing the window killed the context,
+  leaving Adapter/Device/Queue with dangling references. New `AdapterContext` wraps the context
+  with `sync.Mutex`-protected `MakeCurrent` switching: `Lock()` → hidden DC for resource
+  creation/submit, `LockForDC()` → user DC for presentation. Surface is lightweight (no context
+  ownership). Windows WGL Phase 1; Linux EGL Phase 2 planned.
+  Follows Rust wgpu-hal/src/gles/wgl.rs `AdapterContext::lock()`/`lock_with_dc()` pattern.
+
 ## [0.28.5] - 2026-05-21
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.28.5
+## Current State: v0.28.6
 
 ✅ **All 5 HAL backends complete** (~127K LOC)
 ✅ **Three-layer WebGPU stack** — wgpu API → wgpu/core → wgpu/hal
@@ -64,6 +64,7 @@
 ✅ **GLES compute memory barriers** — glMemoryBarrier for storage→draw/dispatch transitions (Rust parity)
 ✅ **Software render pass instrumentation** — slog debug events + RenderPassStats for CI e2e assertions
 ✅ **Browser WebGPU backend** — complete `syscall/js` → `navigator.gpu` implementation (~6500 LOC). Instance, Adapter, Device, Resources, Pipelines, Command Recording, Queue Submit, Surface/Canvas, Buffer Mapping. Bypasses core/hal (Rust wgpu pattern). 97 TextureFormats, 31 VertexFormats, 29+ tests. Zero external dependencies.
+✅ **GLES hidden window context (Windows)** — GL context owned by Instance on hidden 1×1 HWND, shared via mutex-protected `AdapterContext`. Adapter/Device/Queue survive Surface destruction. Follows Rust wgpu-hal `wgl.rs` `AdapterContext::lock()`/`lock_with_dc()` pattern. Surface lightweight — no context ownership.
 
 ### Remaining validation (planned)
 - **Phase C** (P2): Spec compliance edge cases, feature gates
@@ -74,7 +75,7 @@
 | Vulkan | Windows, Linux, macOS | ✅ Stable — text, compute, MSAA |
 | Metal | macOS | ✅ Stable — naga MSL 91/91 |
 | DX12 | Windows | ✅ Stable — TDR fixed, PendingWrites, deferred destruction |
-| GLES | Windows, Linux | ✅ Stable — glFenceSync, copy commands, timestamps, real adapter capabilities, compute barriers |
+| GLES | Windows, Linux | ✅ Stable — hidden window context (Rust parity), glFenceSync, copy commands, timestamps, real adapter capabilities, compute barriers |
 | Software | Windows, Linux, macOS | ✅ Stable — windowed presentation (GDI/X11/CG+Metal), SPIR-V interpreter. All 3 desktop platforms. |
 
 → **See [CHANGELOG.md](CHANGELOG.md) for detailed per-version notes**
@@ -85,7 +86,8 @@
 
 ### Next
 
-- [ ] GLES Phase 1 — CopyBufferToTexture, CopyTextureToTexture, glFenceSync
+- [x] GLES hidden window context (Windows) — Instance-owned GL context, Rust wgpu parity (FEAT-GLES-002)
+- [ ] GLES hidden window context (Linux) — EGL surfaceless/pbuffer, Phase 2 of FEAT-GLES-002
 - [x] macOS software presentation — CGImage + CAMetalLayer (PR #187, @k-chimi, v0.28.4)
 - [ ] DX12 DeviceTextureTracker for proper barrier state tracking
 - [ ] GLES global UNPACK_ALIGNMENT=1 (Rust pattern — set once at device open)
@@ -149,6 +151,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.28.6** | 2026-05 | **GLES hidden window context** (Rust parity). Instance-owned GL context, AdapterContext mutex, Surface lightweight. Fixes context death on window close. |
 | **v0.28.5** | 2026-05 | Metal: defer pool.Drain, drawable count. Core: indirect validation nil guard (#189). |
 | **v0.28.4** | 2026-05 | macOS blit (@k-chimi), GLES Rust parity (fence+copies+timestamps+adapter), GPU dispatch indirect validation. |
 | **v0.28.0** | 2026-05 | **Browser WebGPU backend** (WASM-001). Complete `syscall/js` → `navigator.gpu`. 6500 LOC, 5 phases, zero deps. First Pure Go WebGPU in the browser. |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,12 +126,25 @@ Pure Go DX12 implementation via COM interfaces.
 
 Pure Go OpenGL ES 3.0+ / OpenGL 4.3+ implementation.
 
+**Context Architecture (Rust wgpu parity):**
+- GL context lives on a hidden 1×1 window (WGL/Windows) owned by Instance
+- `AdapterContext` — `sync.Mutex`-protected wrapper shared by Adapter → Device → Queue
+- `Lock()` → `wglMakeCurrent(hiddenDC)` for resource creation and command execution
+- `LockForDC(userDC)` → `wglMakeCurrent(userDC)` for presentation (blit + SwapBuffers)
+- `Unlock()` → `wglMakeCurrent(NULL)` — context unmade current between operations
+- Surface is lightweight — stores only user HWND + reference to shared AdapterContext
+- Adapter, Device, Queue survive user window destruction (context lives on hidden window)
+- Follows Rust wgpu-hal/src/gles/wgl.rs `AdapterContext::lock()` / `lock_with_dc()` pattern
+
+**Packages:**
 - `gl/` — OpenGL function bindings (Windows syscall + Linux goffi)
 - `egl/` — EGL context and display management (Linux)
-- `wgl/` — WGL context for Windows
+- `wgl/` — WGL context + hidden window lifecycle (Windows)
 - `shader.go` — WGSL → GLSL 4.30 via naga, with BindingMap for flat binding indices
 - `sampler.go` — GL sampler objects (glGenSamplers/glBindSampler, GL 3.3+)
 - `command.go` — SamplerBindMap: maps WGSL separate texture+sampler to GLSL combined sampler2D (from naga TextureMappings)
+
+**Key patterns:**
 - Texture completeness: `GL_TEXTURE_MAX_LEVEL = MipLevelCount-1` at creation (default 1000 makes non-mipmapped textures incomplete)
 - Texture updates via `glTexSubImage2D` (not `glTexImage2D`) — matches Rust wgpu-hal pattern
 - `GL_DYNAMIC_DRAW` for all writable buffers (Rust wgpu-hal parity — some vendors freeze STATIC_DRAW buffers)

--- a/hal/gles/adapter.go
+++ b/hal/gles/adapter.go
@@ -11,14 +11,12 @@ import (
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/hal"
 	"github.com/gogpu/wgpu/hal/gles/gl"
-	"github.com/gogpu/wgpu/hal/gles/wgl"
 )
 
 // Adapter implements hal.Adapter for OpenGL.
+// Holds a shared *AdapterContext (owned by Instance, not by Adapter).
 type Adapter struct {
-	glCtx    *gl.Context
-	wglCtx   *wgl.Context
-	hwnd     wgl.HWND
+	ctx      *AdapterContext
 	version  string
 	renderer string
 
@@ -29,34 +27,29 @@ type Adapter struct {
 }
 
 // Open creates a logical device with the requested features and limits.
+// The GL context is owned by Instance's AdapterContext; Device and Queue
+// share the same *AdapterContext pointer.
 func (a *Adapter) Open(_ gputypes.Features, _ gputypes.Limits) (hal.OpenDevice, error) {
-	// OpenGL requires a current context to do anything. If the adapter was
-	// created without a surface (placeholder from EnumerateAdapters(nil)),
-	// glCtx is nil and we cannot proceed.
-	if a.glCtx == nil {
-		return hal.OpenDevice{}, fmt.Errorf("gles: GL context not initialized — create a surface first")
+	if a.ctx == nil {
+		return hal.OpenDevice{}, fmt.Errorf("gles: adapter context not initialized")
 	}
 
-	// Make context current if we have one
-	if a.wglCtx != nil {
-		if err := a.wglCtx.MakeCurrent(); err != nil {
-			return hal.OpenDevice{}, err
-		}
-	}
+	glCtx := a.ctx.Lock()
+	defer a.ctx.Unlock()
 
 	// Create and bind a persistent VAO. OpenGL Core Profile requires a VAO
 	// to be bound for any draw call. We keep one bound for the device lifetime.
-	vao := a.glCtx.GenVertexArrays(1)
-	a.glCtx.BindVertexArray(vao)
+	vao := glCtx.GenVertexArrays(1)
+	glCtx.BindVertexArray(vao)
 
 	// Query hardware texture unit limit for binding validation.
 	var maxTexUnits int32
-	a.glCtx.GetIntegerv(gl.MAX_TEXTURE_IMAGE_UNITS, &maxTexUnits)
+	glCtx.GetIntegerv(gl.MAX_TEXTURE_IMAGE_UNITS, &maxTexUnits)
 	if maxTexUnits <= 0 {
 		maxTexUnits = 8 // Conservative default
 	}
 
-	vendor := a.glCtx.GetString(gl.VENDOR)
+	vendor := glCtx.GetString(gl.VENDOR)
 
 	hal.Logger().Info("gles: device opened",
 		"vendor", vendor,
@@ -66,17 +59,14 @@ func (a *Adapter) Open(_ gputypes.Features, _ gputypes.Limits) (hal.OpenDevice, 
 	)
 
 	device := &Device{
-		glCtx:           a.glCtx,
-		wglCtx:          a.wglCtx,
-		hwnd:            a.hwnd,
+		ctx:             a.ctx,
 		vao:             vao,
 		maxTextureUnits: maxTexUnits,
 	}
 
 	queue := &Queue{
-		glCtx:  a.glCtx,
-		wglCtx: a.wglCtx,
-		fence:  NewFence(a.glCtx),
+		ctx:   a.ctx,
+		fence: NewFence(glCtx),
 	}
 
 	return hal.OpenDevice{

--- a/hal/gles/adapter_context.go
+++ b/hal/gles/adapter_context.go
@@ -1,0 +1,167 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build windows && !(js && wasm)
+
+package gles
+
+import (
+	"fmt"
+	"log/slog"
+	"runtime"
+	"sync"
+
+	"github.com/gogpu/wgpu/hal/gles/gl"
+	"github.com/gogpu/wgpu/hal/gles/wgl"
+)
+
+// AdapterContext wraps a GL context with mutex-protected MakeCurrent switching.
+// Shared by Instance → Adapter → Device → Queue (all hold *AdapterContext).
+//
+// The GL context is lazily created on the first Lock() call, ensuring it is
+// born on the OS thread that will use it (the render thread). This avoids
+// cross-thread WGL issues: creating the context on the main thread and using
+// it on the render thread causes wglMakeCurrent failures because WGL binds
+// the context to the creating thread.
+//
+// Follows Rust wgpu-hal/src/gles/wgl.rs AdapterContext (lines 40-94):
+//   - lock()         → MakeCurrent to hidden DC
+//   - lock_with_dc() → MakeCurrent to user DC
+//   - Drop           → UnmakeCurrent
+type AdapterContext struct {
+	mu       sync.Mutex
+	gl       *gl.Context
+	hglrc    wgl.HGLRC
+	hiddenDC wgl.HDC
+
+	initOnce sync.Once
+	initErr  error
+}
+
+// NewAdapterContext creates an AdapterContext with a hidden window DC.
+// The GL context is NOT created here — it will be created lazily on the
+// first Lock() call, on whatever OS thread that call runs on.
+func NewAdapterContext(hiddenDC wgl.HDC) *AdapterContext {
+	return &AdapterContext{
+		hiddenDC: hiddenDC,
+	}
+}
+
+// ensureInit creates the GL context and loads GL functions on first call.
+// Must be called with the mutex held and LockOSThread active.
+func (c *AdapterContext) ensureInit() error {
+	c.initOnce.Do(func() {
+		hglrc, err := wgl.CreateContext(c.hiddenDC)
+		if err != nil {
+			c.initErr = fmt.Errorf("wglCreateContext: %w", err)
+			return
+		}
+		if err := wgl.MakeCurrent(c.hiddenDC, hglrc); err != nil {
+			_ = wgl.DeleteContext(hglrc)
+			c.initErr = fmt.Errorf("wglMakeCurrent: %w", err)
+			return
+		}
+
+		glCtx := &gl.Context{}
+		if err := glCtx.Load(wgl.GetGLProcAddress); err != nil {
+			_ = wgl.MakeCurrent(0, 0)
+			_ = wgl.DeleteContext(hglrc)
+			c.initErr = fmt.Errorf("GL load: %w", err)
+			return
+		}
+
+		c.hglrc = hglrc
+		c.gl = glCtx
+
+		slog.Info("gles: GL context created on render thread",
+			"hiddenDC", fmt.Sprintf("0x%x", c.hiddenDC),
+			"hglrc", fmt.Sprintf("0x%x", hglrc),
+			"version", glCtx.GetString(gl.VERSION),
+			"renderer", glCtx.GetString(gl.RENDERER))
+	})
+	return c.initErr
+}
+
+// Lock acquires the mutex, pins the goroutine to the current OS thread, and
+// makes the GL context current on the hidden window DC.
+//
+// On first call, lazily creates the GL context on the calling OS thread.
+// This ensures the context is born on the render thread — no cross-thread
+// WGL issues.
+//
+// Mirrors Rust AdapterContext::lock() (wgl.rs:62-80).
+func (c *AdapterContext) Lock() *gl.Context {
+	c.mu.Lock()
+	runtime.LockOSThread()
+
+	if err := c.ensureInit(); err != nil {
+		slog.Error("gles: AdapterContext.Lock init failed", "err", err)
+		return c.gl
+	}
+
+	if err := wgl.MakeCurrent(c.hiddenDC, c.hglrc); err != nil {
+		slog.Error("gles: AdapterContext.Lock MakeCurrent failed",
+			"err", err,
+			"hiddenDC", fmt.Sprintf("0x%x", c.hiddenDC),
+			"hglrc", fmt.Sprintf("0x%x", c.hglrc))
+	}
+	return c.gl
+}
+
+// LockForDC acquires the mutex, pins the goroutine to the current OS thread,
+// and makes the GL context current on the specified device context.
+//
+// Mirrors Rust AdapterContext::lock_with_dc() (wgl.rs:83-94).
+func (c *AdapterContext) LockForDC(hdc wgl.HDC) *gl.Context {
+	c.mu.Lock()
+	runtime.LockOSThread()
+
+	if err := c.ensureInit(); err != nil {
+		slog.Error("gles: AdapterContext.LockForDC init failed", "err", err)
+		return c.gl
+	}
+
+	if err := wgl.MakeCurrent(hdc, c.hglrc); err != nil {
+		slog.Error("gles: AdapterContext.LockForDC MakeCurrent failed",
+			"err", err,
+			"hdc", fmt.Sprintf("0x%x", hdc),
+			"hglrc", fmt.Sprintf("0x%x", c.hglrc))
+	}
+	return c.gl
+}
+
+// Unlock unmakes the GL context current, unpins the goroutine from the OS
+// thread, and releases the mutex.
+//
+// Guards against double-unmake: only calls wglMakeCurrent(0, 0) if a
+// context is actually current on this thread. Matches Rust wgpu-hal
+// WglContext::unmake_current() which checks wglGetCurrentContext().is_invalid()
+// before unmaking (wgl.rs:128-133).
+func (c *AdapterContext) Unlock() {
+	if wgl.GetCurrentContext() != 0 {
+		if err := wgl.MakeCurrent(0, 0); err != nil {
+			slog.Error("gles: AdapterContext.Unlock UnmakeCurrent failed", "err", err)
+		}
+	}
+	runtime.UnlockOSThread()
+	c.mu.Unlock()
+}
+
+// GL returns the GL function table. Must be called while locked.
+func (c *AdapterContext) GL() *gl.Context {
+	return c.gl
+}
+
+// HGLRC returns the GL rendering context handle. Zero if not yet initialized.
+func (c *AdapterContext) HGLRC() wgl.HGLRC {
+	return c.hglrc
+}
+
+// Destroy deletes the GL context if it was created.
+func (c *AdapterContext) Destroy() {
+	if c.hglrc != 0 {
+		_ = wgl.MakeCurrent(0, 0)
+		_ = wgl.DeleteContext(c.hglrc)
+		c.hglrc = 0
+	}
+}

--- a/hal/gles/api.go
+++ b/hal/gles/api.go
@@ -14,10 +14,6 @@ import (
 	"github.com/gogpu/wgpu/hal/gles/wgl"
 )
 
-// vendorUnknown is the placeholder vendor name used when the actual GPU vendor
-// cannot be determined (e.g., no surface available during adapter enumeration).
-const vendorUnknown = "Unknown"
-
 // Backend implements hal.Backend for OpenGL ES / OpenGL 3.3+.
 type Backend struct{}
 
@@ -27,93 +23,147 @@ func (Backend) Variant() gputypes.Backend {
 }
 
 // CreateInstance creates a new OpenGL instance.
+//
+// Creates a hidden 1×1 window and initializes a GL context on it. The context
+// lives for the Instance lifetime and survives any user Surface destruction.
+// Follows Rust wgpu-hal/src/gles/wgl.rs Instance::init (lines 448-563).
 func (Backend) CreateInstance(_ *hal.InstanceDescriptor) (hal.Instance, error) {
-	// Initialize WGL on Windows
 	if err := wgl.Init(); err != nil {
 		return nil, fmt.Errorf("gles: failed to initialize WGL: %w", err)
 	}
-	hal.Logger().Info("gles: instance created", "platform", "windows")
-	return &Instance{}, nil
+
+	// Create hidden 1×1 window to host the GL context (Rust: create_instance_device).
+	// GL context is NOT created here — it will be lazily created on the render
+	// thread's first Lock() call, avoiding cross-thread WGL issues.
+	hiddenWindow, err := wgl.NewHiddenWindow()
+	if err != nil {
+		return nil, fmt.Errorf("gles: failed to create hidden window: %w", err)
+	}
+
+	// Set pixel format on hidden window DC. This is thread-safe and must be
+	// done before wglCreateContext (which happens lazily in AdapterContext).
+	pfd := wgl.DefaultPixelFormat()
+	format, err := wgl.ChoosePixelFormat(hiddenWindow.DC(), &pfd)
+	if err != nil {
+		hiddenWindow.Destroy()
+		return nil, fmt.Errorf("gles: hidden window ChoosePixelFormat: %w", err)
+	}
+	if err := wgl.SetPixelFormat(hiddenWindow.DC(), format, &pfd); err != nil {
+		hiddenWindow.Destroy()
+		return nil, fmt.Errorf("gles: hidden window SetPixelFormat: %w", err)
+	}
+
+	ctx := NewAdapterContext(hiddenWindow.DC())
+
+	hal.Logger().Info("gles: instance created",
+		"platform", "windows",
+		"hiddenDC", fmt.Sprintf("0x%x", hiddenWindow.DC()),
+	)
+
+	return &Instance{
+		ctx:          ctx,
+		hiddenWindow: hiddenWindow,
+	}, nil
 }
 
 // Instance implements hal.Instance for the OpenGL backend.
-type Instance struct{}
+// Owns the hidden 1×1 window. The GL context is lazily created on the
+// render thread via AdapterContext.ensureInit().
+type Instance struct {
+	ctx          *AdapterContext
+	hiddenWindow *wgl.HiddenWindow
+}
 
 // CreateSurface creates an OpenGL surface from window handles.
 // On Windows: displayHandle is ignored, windowHandle is HWND.
+//
+// The Surface is lightweight — it does NOT own the GL context. The context
+// lives on the hidden window owned by Instance. Surface only stores the user
+// HWND and a reference to the shared AdapterContext. SetPixelFormat is called
+// on the user window DC so that wglMakeCurrent can switch between hidden and
+// user DCs during Present.
+//
+// Follows Rust wgpu-hal/src/gles/wgl.rs Instance::create_surface (lines 624-670).
 func (i *Instance) CreateSurface(_, windowHandle uintptr) (hal.Surface, error) {
-	// Create WGL context for the window
-	ctx, err := wgl.NewContext(wgl.HWND(windowHandle))
+	hwnd := wgl.HWND(windowHandle)
+
+	// Set pixel format on user window DC. Required for wglMakeCurrent to
+	// accept this DC with the hidden window's HGLRC — pixel formats must match.
+	hdc := wgl.GetDC(hwnd)
+	if hdc == 0 {
+		return nil, fmt.Errorf("gles: GetDC failed for window 0x%x", windowHandle)
+	}
+	pfd := wgl.DefaultPixelFormat()
+	format, err := wgl.ChoosePixelFormat(hdc, &pfd)
 	if err != nil {
-		return nil, fmt.Errorf("gles: failed to create WGL context: %w", err)
+		wgl.ReleaseDC(hwnd, hdc)
+		return nil, fmt.Errorf("gles: surface ChoosePixelFormat: %w", err)
 	}
-
-	// Make it current to load GL functions
-	if err := ctx.MakeCurrent(); err != nil {
-		ctx.Destroy(wgl.HWND(windowHandle))
-		return nil, fmt.Errorf("gles: failed to make context current: %w", err)
+	if err := wgl.SetPixelFormat(hdc, format, &pfd); err != nil {
+		wgl.ReleaseDC(hwnd, hdc)
+		return nil, fmt.Errorf("gles: surface SetPixelFormat: %w", err)
 	}
+	wgl.ReleaseDC(hwnd, hdc)
 
-	// Load GL function pointers
-	glCtx := &gl.Context{}
-	if err := glCtx.Load(wgl.GetGLProcAddress); err != nil {
-		ctx.Destroy(wgl.HWND(windowHandle))
-		return nil, fmt.Errorf("gles: failed to load GL functions: %w", err)
-	}
-
-	// Query OpenGL version
-	version := glCtx.GetString(gl.VERSION)
-	renderer := glCtx.GetString(gl.RENDERER)
-
-	hal.Logger().Info("gles: surface created",
-		"version", version,
-		"renderer", renderer,
-	)
+	hal.Logger().Info("gles: surface created", "hwnd", fmt.Sprintf("0x%x", windowHandle))
 
 	return &Surface{
-		hwnd:     wgl.HWND(windowHandle),
-		wglCtx:   ctx,
-		glCtx:    glCtx,
-		version:  version,
-		renderer: renderer,
+		hwnd: hwnd,
+		ctx:  i.ctx,
 	}, nil
 }
 
 // EnumerateAdapters returns available OpenGL adapters.
-// For OpenGL, there's typically one adapter per display.
-func (i *Instance) EnumerateAdapters(surfaceHint hal.Surface) []hal.ExposedAdapter {
-	// If we have a surface, use its GL context for info
-	if surface, ok := surfaceHint.(*Surface); ok {
-		return []hal.ExposedAdapter{
-			surface.GetAdapterInfo(),
-		}
+// Triggers lazy GL context creation on the calling thread (render thread).
+func (i *Instance) EnumerateAdapters(_ hal.Surface) []hal.ExposedAdapter {
+	glCtx := i.ctx.Lock()
+	defer i.ctx.Unlock()
+
+	if glCtx == nil {
+		hal.Logger().Error("gles: EnumerateAdapters: GL context not available")
+		return nil
 	}
 
-	// Without a surface, we can't query OpenGL info
-	// Return a placeholder that will be updated when surface is created
+	caps := queryAdapterCapabilities(glCtx)
+
+	version := glCtx.GetString(gl.VERSION)
+	renderer := glCtx.GetString(gl.RENDERER)
+
+	driverInfo := "OpenGL 3.3+"
+	if caps.IsES {
+		driverInfo = fmt.Sprintf("OpenGL ES %d.%d", caps.GLMajor, caps.GLMinor)
+	} else if caps.GLMajor > 0 {
+		driverInfo = fmt.Sprintf("OpenGL %d.%d", caps.GLMajor, caps.GLMinor)
+	}
+
 	return []hal.ExposedAdapter{
 		{
-			Adapter: &Adapter{},
+			Adapter: &Adapter{
+				ctx:      i.ctx,
+				version:  version,
+				renderer: renderer,
+				caps:     caps,
+			},
 			Info: gputypes.AdapterInfo{
-				Name:       "OpenGL Adapter",
-				Vendor:     vendorUnknown,
-				VendorID:   0,
+				Name:       caps.Renderer,
+				Vendor:     caps.Vendor,
+				VendorID:   caps.VendorID,
 				DeviceID:   0,
-				DeviceType: gputypes.DeviceTypeOther,
-				Driver:     "OpenGL",
-				DriverInfo: "OpenGL 3.3+ / ES 3.0+",
+				DeviceType: caps.DeviceType,
+				Driver:     caps.Version,
+				DriverInfo: driverInfo,
 				Backend:    gputypes.BackendGL,
 			},
-			Features: 0,
+			Features: caps.Features,
 			Capabilities: hal.Capabilities{
-				Limits: gputypes.DefaultLimits(),
+				Limits: caps.Limits,
 				AlignmentsMask: hal.Alignments{
 					BufferCopyOffset: 4,
-					BufferCopyPitch:  256,
+					BufferCopyPitch:  4,
 				},
 				DownlevelCapabilities: hal.DownlevelCapabilities{
 					ShaderModel: 50, // SM5.0
-					Flags:       0,
+					Flags:       caps.DownlevelFlags,
 				},
 			},
 		},
@@ -122,5 +172,11 @@ func (i *Instance) EnumerateAdapters(surfaceHint hal.Surface) []hal.ExposedAdapt
 
 // Destroy releases the instance resources.
 func (i *Instance) Destroy() {
-	// Nothing to clean up at instance level
+	if i.ctx != nil {
+		i.ctx.Destroy()
+	}
+	if i.hiddenWindow != nil {
+		i.hiddenWindow.Destroy()
+		i.hiddenWindow = nil
+	}
 }

--- a/hal/gles/device.go
+++ b/hal/gles/device.go
@@ -14,14 +14,13 @@ import (
 	"github.com/gogpu/naga/glsl"
 	"github.com/gogpu/wgpu/hal"
 	"github.com/gogpu/wgpu/hal/gles/gl"
-	"github.com/gogpu/wgpu/hal/gles/wgl"
 )
 
 // Device implements hal.Device for OpenGL.
+// Holds a shared *AdapterContext (owned by Instance). All GL operations
+// acquire the context lock, do MakeCurrent, execute, and unlock.
 type Device struct {
-	glCtx           *gl.Context
-	wglCtx          *wgl.Context
-	hwnd            wgl.HWND
+	ctx             *AdapterContext
 	vao             uint32 // persistent VAO (Core Profile requires one bound)
 	maxTextureUnits int32  // GL_MAX_TEXTURE_IMAGE_UNITS (queried at init)
 }
@@ -31,7 +30,11 @@ func (d *Device) CreateBuffer(desc *BufferDescriptor) (hal.Buffer, error) {
 	if desc == nil {
 		return nil, fmt.Errorf("BUG: buffer descriptor is nil in GLES.CreateBuffer — core validation gap")
 	}
-	id := d.glCtx.GenBuffers(1)
+
+	glCtx := d.ctx.Lock()
+	defer d.ctx.Unlock()
+
+	id := glCtx.GenBuffers(1)
 
 	// Determine GL buffer target from usage
 	target := uint32(gl.ARRAY_BUFFER)
@@ -54,16 +57,16 @@ func (d *Device) CreateBuffer(desc *BufferDescriptor) (hal.Buffer, error) {
 		usage = gl.DYNAMIC_READ
 	}
 
-	d.glCtx.BindBuffer(target, id)
-	d.glCtx.BufferData(target, int(desc.Size), nil, usage)
-	d.glCtx.BindBuffer(target, 0)
+	glCtx.BindBuffer(target, id)
+	glCtx.BufferData(target, int(desc.Size), nil, usage)
+	glCtx.BindBuffer(target, 0)
 
 	buf := &Buffer{
 		id:     id,
 		target: target,
 		size:   desc.Size,
 		usage:  desc.Usage,
-		glCtx:  d.glCtx,
+		glCtx:  glCtx,
 	}
 
 	// Handle MappedAtCreation
@@ -82,16 +85,6 @@ func (d *Device) DestroyBuffer(buffer hal.Buffer) {
 }
 
 // MapBuffer establishes a CPU-visible mapping for a GL buffer.
-//
-// GLES has no persistent host-mapped memory on legacy contexts, so this
-// implementation mirrors Rust wgpu-hal's CPU-shadow approach: for
-// BufferUsageMapRead we copy GPU contents into a Go slice via
-// glGetBufferSubData, hand out a pointer into that slice, and release it on
-// UnmapBuffer. For MapWrite we hand out a pointer into a zero-initialized
-// shadow and push it back to the GL buffer on UnmapBuffer.
-//
-// Because the shadow is a Go-allocated byte slice, the returned pointer is
-// valid Go memory and therefore always coherent; IsCoherent=true is safe.
 func (d *Device) MapBuffer(buffer hal.Buffer, offset, size uint64) (hal.BufferMapping, error) {
 	buf, ok := buffer.(*Buffer)
 	if !ok || buf == nil {
@@ -101,29 +94,25 @@ func (d *Device) MapBuffer(buffer hal.Buffer, offset, size uint64) (hal.BufferMa
 		return hal.BufferMapping{}, hal.ErrInvalidMapRange
 	}
 	if buf.mapped == nil {
-		// Allocate CPU shadow for the full buffer so offset arithmetic is simple.
 		buf.mapped = make([]byte, buf.size)
 
-		// For MapRead, pull the current GL contents down into the shadow.
-		// Prefer the CPU-side copy populated by CopyTextureToBuffer (buf.data)
-		// when available; otherwise map via glMapBuffer and copy out.
 		if buf.usage&gputypes.BufferUsageMapRead != 0 {
+			glCtx := d.ctx.Lock()
 			switch {
 			case len(buf.data) == int(buf.size):
 				copy(buf.mapped, buf.data)
 			case buf.id != 0:
-				d.glCtx.BindBuffer(gl.COPY_READ_BUFFER, buf.id)
-				glPtr := d.glCtx.MapBuffer(gl.COPY_READ_BUFFER, gl.READ_ONLY)
+				glCtx.BindBuffer(gl.COPY_READ_BUFFER, buf.id)
+				glPtr := glCtx.MapBuffer(gl.COPY_READ_BUFFER, gl.READ_ONLY)
 				if glPtr != 0 {
-					// GL returned a host pointer via FFI uintptr.
-					// Use double-indirection to satisfy go vet.
 					basePtr := *(**byte)(unsafe.Pointer(&glPtr))
 					src := unsafe.Slice(basePtr, buf.size)
 					copy(buf.mapped, src)
-					d.glCtx.UnmapBuffer(gl.COPY_READ_BUFFER)
+					glCtx.UnmapBuffer(gl.COPY_READ_BUFFER)
 				}
-				d.glCtx.BindBuffer(gl.COPY_READ_BUFFER, 0)
+				glCtx.BindBuffer(gl.COPY_READ_BUFFER, 0)
 			}
+			d.ctx.Unlock()
 		}
 	}
 	return hal.BufferMapping{
@@ -133,10 +122,6 @@ func (d *Device) MapBuffer(buffer hal.Buffer, offset, size uint64) (hal.BufferMa
 }
 
 // UnmapBuffer releases a GL buffer mapping.
-//
-// For writable buffers the CPU shadow is pushed back into the GL buffer via
-// glBufferSubData. The shadow is then released so subsequent MapBuffer calls
-// pick up fresh contents.
 func (d *Device) UnmapBuffer(buffer hal.Buffer) error {
 	buf, ok := buffer.(*Buffer)
 	if !ok || buf == nil {
@@ -145,11 +130,12 @@ func (d *Device) UnmapBuffer(buffer hal.Buffer) error {
 	if buf.mapped == nil {
 		return nil
 	}
-	// Only push back if the buffer was writable.
 	if buf.usage&gputypes.BufferUsageMapWrite != 0 && buf.id != 0 {
-		d.glCtx.BindBuffer(buf.target, buf.id)
-		d.glCtx.BufferSubData(buf.target, 0, len(buf.mapped), unsafe.Pointer(&buf.mapped[0]))
-		d.glCtx.BindBuffer(buf.target, 0)
+		glCtx := d.ctx.Lock()
+		glCtx.BindBuffer(buf.target, buf.id)
+		glCtx.BufferSubData(buf.target, 0, len(buf.mapped), unsafe.Pointer(&buf.mapped[0]))
+		glCtx.BindBuffer(buf.target, 0)
+		d.ctx.Unlock()
 	}
 	buf.mapped = nil
 	return nil
@@ -160,7 +146,11 @@ func (d *Device) CreateTexture(desc *TextureDescriptor) (hal.Texture, error) {
 	if desc == nil {
 		return nil, fmt.Errorf("BUG: texture descriptor is nil in GLES.CreateTexture — core validation gap")
 	}
-	id := d.glCtx.GenTextures(1)
+
+	glCtx := d.ctx.Lock()
+	defer d.ctx.Unlock()
+
+	id := glCtx.GenTextures(1)
 
 	sampleCount := desc.SampleCount
 	if sampleCount == 0 {
@@ -198,7 +188,7 @@ func (d *Device) CreateTexture(desc *TextureDescriptor) (hal.Texture, error) {
 		}
 	}
 
-	d.glCtx.BindTexture(target, id)
+	glCtx.BindTexture(target, id)
 
 	// Get GL format info
 	internalFormat, format, dataType := textureFormatToGL(desc.Format)
@@ -206,15 +196,14 @@ func (d *Device) CreateTexture(desc *TextureDescriptor) (hal.Texture, error) {
 	// Allocate texture storage
 	switch target {
 	case gl.TEXTURE_2D_MULTISAMPLE:
-		// Multisample textures use TexImage2DMultisample (no mip levels).
-		d.glCtx.TexImage2DMultisample(target, int32(sampleCount), internalFormat,
+		glCtx.TexImage2DMultisample(target, int32(sampleCount), internalFormat,
 			int32(desc.Size.Width), int32(desc.Size.Height), true)
 
 	case gl.TEXTURE_2D:
 		for level := uint32(0); level < desc.MipLevelCount; level++ {
 			width := maxInt32(1, int32(desc.Size.Width>>level))
 			height := maxInt32(1, int32(desc.Size.Height>>level))
-			d.glCtx.TexImage2D(target, int32(level), int32(internalFormat),
+			glCtx.TexImage2D(target, int32(level), int32(internalFormat),
 				width, height, 0, format, dataType, nil)
 		}
 
@@ -224,29 +213,21 @@ func (d *Device) CreateTexture(desc *TextureDescriptor) (hal.Texture, error) {
 			for level := uint32(0); level < desc.MipLevelCount; level++ {
 				width := maxInt32(1, int32(desc.Size.Width>>level))
 				height := maxInt32(1, int32(desc.Size.Height>>level))
-				d.glCtx.TexImage2D(faceTarget, int32(level), int32(internalFormat),
+				glCtx.TexImage2D(faceTarget, int32(level), int32(internalFormat),
 					width, height, 0, format, dataType, nil)
 			}
 		}
 	}
 
-	// Set default texture parameters (multisample textures don't support these).
 	if target != gl.TEXTURE_2D_MULTISAMPLE {
-		// Set NEAREST filter and MAX_LEVEL on all textures for completeness.
-		// Default GL_TEXTURE_MIN_FILTER is GL_NEAREST_MIPMAP_LINEAR and default
-		// GL_TEXTURE_MAX_LEVEL is 1000. For non-mipmapped textures (MipLevelCount=1),
-		// this combination makes the texture INCOMPLETE — sampling returns (0,0,0,0)
-		// because GL expects mip levels 0..1000 but only level 0 exists.
-		// Setting MAX_LEVEL = MipLevelCount-1 tells GL the actual mip chain length.
-		// Sampler objects override MIN/MAG_FILTER but NOT MAX_LEVEL.
-		d.glCtx.TexParameteri(target, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
-		d.glCtx.TexParameteri(target, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
-		d.glCtx.TexParameteri(target, gl.TEXTURE_MAX_LEVEL, int32(desc.MipLevelCount-1))
-		d.glCtx.TexParameteri(target, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
-		d.glCtx.TexParameteri(target, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+		glCtx.TexParameteri(target, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
+		glCtx.TexParameteri(target, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
+		glCtx.TexParameteri(target, gl.TEXTURE_MAX_LEVEL, int32(desc.MipLevelCount-1))
+		glCtx.TexParameteri(target, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+		glCtx.TexParameteri(target, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 	}
 
-	d.glCtx.BindTexture(target, 0)
+	glCtx.BindTexture(target, 0)
 
 	hal.Logger().Debug("gles: texture created",
 		"label", desc.Label,
@@ -263,7 +244,7 @@ func (d *Device) CreateTexture(desc *TextureDescriptor) (hal.Texture, error) {
 		size:        desc.Size,
 		mipLevels:   desc.MipLevelCount,
 		sampleCount: sampleCount,
-		glCtx:       d.glCtx,
+		glCtx:       glCtx,
 	}, nil
 }
 
@@ -310,13 +291,16 @@ func (d *Device) DestroyTextureView(view hal.TextureView) {
 
 // CreateSampler creates a texture sampler using GL sampler objects (GL 3.3+).
 func (d *Device) CreateSampler(desc *SamplerDescriptor) (hal.Sampler, error) {
+	glCtx := d.ctx.Lock()
+	defer d.ctx.Unlock()
+
 	if desc == nil {
-		return &Sampler{glCtx: d.glCtx}, nil
+		return &Sampler{glCtx: glCtx}, nil
 	}
-	id := configureSampler(d.glCtx, desc)
+	id := configureSampler(glCtx, desc)
 	return &Sampler{
 		id:    id,
-		glCtx: d.glCtx,
+		glCtx: glCtx,
 	}, nil
 }
 
@@ -385,10 +369,9 @@ func (d *Device) CreateShaderModule(desc *ShaderModuleDescriptor) (hal.ShaderMod
 	if desc == nil {
 		return nil, fmt.Errorf("BUG: shader module descriptor is nil in GLES.CreateShaderModule — core validation gap")
 	}
-	// For now, store the source - compilation happens at pipeline creation
 	return &ShaderModule{
 		source: desc.Source,
-		glCtx:  d.glCtx,
+		glCtx:  d.ctx.GL(),
 	}, nil
 }
 
@@ -404,6 +387,10 @@ func (d *Device) CreateRenderPipeline(desc *RenderPipelineDescriptor) (hal.Rende
 	if desc == nil {
 		return nil, fmt.Errorf("BUG: render pipeline descriptor is nil in GLES.CreateRenderPipeline — core validation gap")
 	}
+
+	glCtx := d.ctx.Lock()
+	defer d.ctx.Unlock()
+
 	start := time.Now()
 	// Handle nil layout (auto-layout for shaders without bindings).
 	var layout *PipelineLayout
@@ -428,18 +415,18 @@ func (d *Device) CreateRenderPipeline(desc *RenderPipelineDescriptor) (hal.Rende
 		return nil, fmt.Errorf("gles: vertex shader: %w", err)
 	}
 
-	vertexID := d.glCtx.CreateShader(gl.VERTEX_SHADER)
-	d.glCtx.ShaderSource(vertexID, vertexGLSL)
-	d.glCtx.CompileShader(vertexID)
+	vertexID := glCtx.CreateShader(gl.VERTEX_SHADER)
+	glCtx.ShaderSource(vertexID, vertexGLSL)
+	glCtx.CompileShader(vertexID)
 
 	var status int32
-	d.glCtx.GetShaderiv(vertexID, gl.COMPILE_STATUS, &status)
+	glCtx.GetShaderiv(vertexID, gl.COMPILE_STATUS, &status)
 	if status == gl.FALSE {
-		log := d.glCtx.GetShaderInfoLog(vertexID)
-		d.glCtx.DeleteShader(vertexID)
+		log := glCtx.GetShaderInfoLog(vertexID)
+		glCtx.DeleteShader(vertexID)
 		return nil, fmt.Errorf("gles: vertex shader compilation failed: %s", log)
 	}
-	if infoLog := d.glCtx.GetShaderInfoLog(vertexID); infoLog != "" {
+	if infoLog := glCtx.GetShaderInfoLog(vertexID); infoLog != "" {
 		hal.Logger().Debug("gles: vertex shader compile info", "info", infoLog)
 	}
 
@@ -448,39 +435,39 @@ func (d *Device) CreateRenderPipeline(desc *RenderPipelineDescriptor) (hal.Rende
 	var fragmentTranslationInfo glsl.TranslationInfo
 	if desc.Fragment != nil {
 		var err error
-		fragmentID, fragmentTranslationInfo, err = d.compileFragmentShader(desc.Fragment, layout.bindingMap)
+		fragmentID, fragmentTranslationInfo, err = compileFragmentShader(glCtx, desc.Fragment, layout.bindingMap)
 		if err != nil {
-			d.glCtx.DeleteShader(vertexID)
+			glCtx.DeleteShader(vertexID)
 			return nil, err
 		}
 	}
 
 	// Link program
-	programID := d.glCtx.CreateProgram()
-	d.glCtx.AttachShader(programID, vertexID)
+	programID := glCtx.CreateProgram()
+	glCtx.AttachShader(programID, vertexID)
 	if fragmentID != 0 {
-		d.glCtx.AttachShader(programID, fragmentID)
+		glCtx.AttachShader(programID, fragmentID)
 	}
-	d.glCtx.LinkProgram(programID)
+	glCtx.LinkProgram(programID)
 
-	d.glCtx.GetProgramiv(programID, gl.LINK_STATUS, &status)
+	glCtx.GetProgramiv(programID, gl.LINK_STATUS, &status)
 	if status == gl.FALSE {
-		log := d.glCtx.GetProgramInfoLog(programID)
-		d.glCtx.DeleteShader(vertexID)
+		log := glCtx.GetProgramInfoLog(programID)
+		glCtx.DeleteShader(vertexID)
 		if fragmentID != 0 {
-			d.glCtx.DeleteShader(fragmentID)
+			glCtx.DeleteShader(fragmentID)
 		}
-		d.glCtx.DeleteProgram(programID)
+		glCtx.DeleteProgram(programID)
 		return nil, fmt.Errorf("gles: program linking failed: %s", log)
 	}
-	if infoLog := d.glCtx.GetProgramInfoLog(programID); infoLog != "" {
+	if infoLog := glCtx.GetProgramInfoLog(programID); infoLog != "" {
 		hal.Logger().Debug("gles: program link info", "info", infoLog)
 	}
 
 	// Shaders can be deleted after linking
-	d.glCtx.DeleteShader(vertexID)
+	glCtx.DeleteShader(vertexID)
 	if fragmentID != 0 {
-		d.glCtx.DeleteShader(fragmentID)
+		glCtx.DeleteShader(fragmentID)
 	}
 
 	hal.Logger().Debug("gles: render pipeline created",
@@ -500,7 +487,7 @@ func (d *Device) CreateRenderPipeline(desc *RenderPipelineDescriptor) (hal.Rende
 	pipeline := &RenderPipeline{
 		programID:         programID,
 		layout:            layout,
-		glCtx:             d.glCtx,
+		glCtx:             glCtx,
 		primitiveTopology: desc.Primitive.Topology,
 		cullMode:          desc.Primitive.CullMode,
 		frontFace:         desc.Primitive.FrontFace,
@@ -555,6 +542,10 @@ func (d *Device) CreateComputePipeline(desc *ComputePipelineDescriptor) (hal.Com
 	if desc == nil {
 		return nil, fmt.Errorf("BUG: compute pipeline descriptor is nil in GLES.CreateComputePipeline — core validation gap")
 	}
+
+	glCtx := d.ctx.Lock()
+	defer d.ctx.Unlock()
+
 	start := time.Now()
 	layout, ok := desc.Layout.(*PipelineLayout)
 	if !ok {
@@ -572,38 +563,38 @@ func (d *Device) CreateComputePipeline(desc *ComputePipelineDescriptor) (hal.Com
 		return nil, fmt.Errorf("gles: compute shader: %w", err)
 	}
 
-	computeID := d.glCtx.CreateShader(gl.COMPUTE_SHADER)
-	d.glCtx.ShaderSource(computeID, computeGLSL)
-	d.glCtx.CompileShader(computeID)
+	computeID := glCtx.CreateShader(gl.COMPUTE_SHADER)
+	glCtx.ShaderSource(computeID, computeGLSL)
+	glCtx.CompileShader(computeID)
 
 	var status int32
-	d.glCtx.GetShaderiv(computeID, gl.COMPILE_STATUS, &status)
+	glCtx.GetShaderiv(computeID, gl.COMPILE_STATUS, &status)
 	if status == gl.FALSE {
-		log := d.glCtx.GetShaderInfoLog(computeID)
-		d.glCtx.DeleteShader(computeID)
+		log := glCtx.GetShaderInfoLog(computeID)
+		glCtx.DeleteShader(computeID)
 		return nil, fmt.Errorf("gles: compute shader compilation failed: %s", log)
 	}
-	if infoLog := d.glCtx.GetShaderInfoLog(computeID); infoLog != "" {
+	if infoLog := glCtx.GetShaderInfoLog(computeID); infoLog != "" {
 		hal.Logger().Debug("gles: compute shader compile info", "info", infoLog)
 	}
 
 	// Link program
-	programID := d.glCtx.CreateProgram()
-	d.glCtx.AttachShader(programID, computeID)
-	d.glCtx.LinkProgram(programID)
+	programID := glCtx.CreateProgram()
+	glCtx.AttachShader(programID, computeID)
+	glCtx.LinkProgram(programID)
 
-	d.glCtx.GetProgramiv(programID, gl.LINK_STATUS, &status)
+	glCtx.GetProgramiv(programID, gl.LINK_STATUS, &status)
 	if status == gl.FALSE {
-		log := d.glCtx.GetProgramInfoLog(programID)
-		d.glCtx.DeleteShader(computeID)
-		d.glCtx.DeleteProgram(programID)
+		log := glCtx.GetProgramInfoLog(programID)
+		glCtx.DeleteShader(computeID)
+		glCtx.DeleteProgram(programID)
 		return nil, fmt.Errorf("gles: compute program linking failed: %s", log)
 	}
-	if infoLog := d.glCtx.GetProgramInfoLog(programID); infoLog != "" {
+	if infoLog := glCtx.GetProgramInfoLog(programID); infoLog != "" {
 		hal.Logger().Debug("gles: compute program link info", "info", infoLog)
 	}
 
-	d.glCtx.DeleteShader(computeID)
+	glCtx.DeleteShader(computeID)
 
 	hal.Logger().Debug("gles: compute pipeline created",
 		"programID", programID,
@@ -614,7 +605,7 @@ func (d *Device) CreateComputePipeline(desc *ComputePipelineDescriptor) (hal.Com
 	return &ComputePipeline{
 		programID: programID,
 		layout:    layout,
-		glCtx:     d.glCtx,
+		glCtx:     glCtx,
 	}, nil
 }
 
@@ -633,11 +624,14 @@ func (d *Device) CreateQuerySet(desc *hal.QuerySetDescriptor) (hal.QuerySet, err
 		return nil, fmt.Errorf("gles: query set descriptor is nil")
 	}
 
+	glCtx := d.ctx.Lock()
+	defer d.ctx.Unlock()
+
 	// Determine GL query target.
 	var target uint32
 	switch desc.Type {
 	case hal.QueryTypeTimestamp:
-		if !d.glCtx.SupportsTimestampQueries() {
+		if !glCtx.SupportsTimestampQueries() {
 			return nil, hal.ErrTimestampsNotSupported
 		}
 		target = gl.TIMESTAMP
@@ -648,11 +642,11 @@ func (d *Device) CreateQuerySet(desc *hal.QuerySetDescriptor) (hal.QuerySet, err
 	// Create GL query objects.
 	queries := make([]uint32, desc.Count)
 	for i := uint32(0); i < desc.Count; i++ {
-		q := d.glCtx.GenQueries(1)
+		q := glCtx.GenQueries(1)
 		if q == 0 {
 			// Clean up already-created queries on failure.
 			for j := uint32(0); j < i; j++ {
-				d.glCtx.DeleteQueries(1, &queries[j])
+				glCtx.DeleteQueries(1, &queries[j])
 			}
 			return nil, fmt.Errorf("gles: failed to create query object %d/%d", i, desc.Count)
 		}
@@ -662,7 +656,7 @@ func (d *Device) CreateQuerySet(desc *hal.QuerySetDescriptor) (hal.QuerySet, err
 	return &QuerySet{
 		queries: queries,
 		target:  target,
-		glCtx:   d.glCtx,
+		glCtx:   glCtx,
 	}, nil
 }
 
@@ -676,7 +670,7 @@ func (d *Device) DestroyQuerySet(qs hal.QuerySet) {
 // CreateCommandEncoder creates a command encoder.
 func (d *Device) CreateCommandEncoder(_ *CommandEncoderDescriptor) (hal.CommandEncoder, error) {
 	return &CommandEncoder{
-		glCtx:           d.glCtx,
+		glCtx:           d.ctx.GL(),
 		vao:             d.vao,
 		maxTextureUnits: d.maxTextureUnits,
 	}, nil
@@ -684,7 +678,7 @@ func (d *Device) CreateCommandEncoder(_ *CommandEncoderDescriptor) (hal.CommandE
 
 // CreateFence creates a synchronization fence.
 func (d *Device) CreateFence() (hal.Fence, error) {
-	return NewFence(d.glCtx), nil
+	return NewFence(d.ctx.GL()), nil
 }
 
 // DestroyFence destroys a fence.
@@ -738,16 +732,18 @@ func (d *Device) DestroyRenderBundle(bundle hal.RenderBundle) {}
 
 // WaitIdle waits for all GPU work to complete.
 func (d *Device) WaitIdle() error {
-	if d.glCtx != nil {
-		d.glCtx.Finish()
-	}
+	glCtx := d.ctx.Lock()
+	glCtx.Finish()
+	d.ctx.Unlock()
 	return nil
 }
 
 // Destroy releases the device.
 func (d *Device) Destroy() {
-	if d.vao != 0 && d.glCtx != nil {
-		d.glCtx.DeleteVertexArrays(d.vao)
+	if d.vao != 0 {
+		glCtx := d.ctx.Lock()
+		glCtx.DeleteVertexArrays(d.vao)
+		d.ctx.Unlock()
 		d.vao = 0
 	}
 }
@@ -819,7 +815,9 @@ func maxInt32(a, b int32) int32 {
 }
 
 // compileFragmentShader compiles a fragment shader from WGSL source via GLSL.
-func (d *Device) compileFragmentShader(frag *hal.FragmentState, bindingMap map[glsl.BindingMapKey]uint8) (uint32, glsl.TranslationInfo, error) {
+// Caller must hold the AdapterContext lock. glCtx is passed explicitly to avoid
+// re-locking (this is called from CreateRenderPipeline which already holds the lock).
+func compileFragmentShader(glCtx *gl.Context, frag *hal.FragmentState, bindingMap map[glsl.BindingMapKey]uint8) (uint32, glsl.TranslationInfo, error) {
 	fragmentModule, ok := frag.Module.(*ShaderModule)
 	if !ok {
 		return 0, glsl.TranslationInfo{}, fmt.Errorf("gles: invalid fragment shader module type")
@@ -830,18 +828,18 @@ func (d *Device) compileFragmentShader(frag *hal.FragmentState, bindingMap map[g
 		return 0, glsl.TranslationInfo{}, fmt.Errorf("gles: fragment shader: %w", err)
 	}
 
-	fragmentID := d.glCtx.CreateShader(gl.FRAGMENT_SHADER)
-	d.glCtx.ShaderSource(fragmentID, fragmentGLSL)
-	d.glCtx.CompileShader(fragmentID)
+	fragmentID := glCtx.CreateShader(gl.FRAGMENT_SHADER)
+	glCtx.ShaderSource(fragmentID, fragmentGLSL)
+	glCtx.CompileShader(fragmentID)
 
 	var status int32
-	d.glCtx.GetShaderiv(fragmentID, gl.COMPILE_STATUS, &status)
+	glCtx.GetShaderiv(fragmentID, gl.COMPILE_STATUS, &status)
 	if status == gl.FALSE {
-		log := d.glCtx.GetShaderInfoLog(fragmentID)
-		d.glCtx.DeleteShader(fragmentID)
+		log := glCtx.GetShaderInfoLog(fragmentID)
+		glCtx.DeleteShader(fragmentID)
 		return 0, glsl.TranslationInfo{}, fmt.Errorf("gles: fragment shader compilation failed: %s", log)
 	}
-	if infoLog := d.glCtx.GetShaderInfoLog(fragmentID); infoLog != "" {
+	if infoLog := glCtx.GetShaderInfoLog(fragmentID); infoLog != "" {
 		hal.Logger().Debug("gles: fragment shader compile info", "info", infoLog)
 	}
 

--- a/hal/gles/queue.go
+++ b/hal/gles/queue.go
@@ -17,40 +17,38 @@ import (
 )
 
 // Queue implements hal.Queue for OpenGL.
+// Holds a shared *AdapterContext (owned by Instance).
 type Queue struct {
-	glCtx           *gl.Context
-	wglCtx          *wgl.Context
+	ctx             *AdapterContext
 	submissionIndex uint64
 	fence           *Fence // signaled at each submit for GPU completion tracking
 }
 
 // Submit submits command buffers to the GPU.
-// After executing all commands and flushing, signals the fence with a GL sync object
-// so that fence wait/poll can track actual GPU completion.
+// Acquires the AdapterContext lock, makes context current on hidden window DC,
+// executes all GL commands, flushes, and signals the fence.
 func (q *Queue) Submit(commandBuffers []hal.CommandBuffer) (uint64, error) {
+	glCtx := q.ctx.Lock()
+	defer q.ctx.Unlock()
+
 	for _, cb := range commandBuffers {
 		cmdBuf, ok := cb.(*CommandBuffer)
 		if !ok {
 			return 0, fmt.Errorf("gles: invalid command buffer type")
 		}
 
-		// Execute recorded commands with GL error checking.
 		for i, cmd := range cmdBuf.commands {
-			cmd.Execute(q.glCtx)
-			if glErr := q.glCtx.GetError(); glErr != 0 {
+			cmd.Execute(glCtx)
+			if glErr := glCtx.GetError(); glErr != 0 {
 				hal.Logger().Warn("gles: GL error after command", "error", fmt.Sprintf("0x%x", glErr), "index", i, "command", fmt.Sprintf("%T", cmd))
 			}
 		}
 	}
 
-	// Flush GL commands
-	q.glCtx.Flush()
+	glCtx.Flush()
 
 	q.submissionIndex++
 
-	// Signal the fence with a GL sync object at this submission index.
-	// This enables fence.Wait() to track real GPU completion instead of
-	// assuming all work is done immediately after Flush.
 	if q.fence != nil {
 		q.fence.Signal(q.submissionIndex)
 	}
@@ -79,9 +77,12 @@ func (q *Queue) WriteBuffer(buffer hal.Buffer, offset uint64, data []byte) error
 		return nil
 	}
 
-	q.glCtx.BindBuffer(buf.target, buf.id)
-	q.glCtx.BufferSubData(buf.target, int(offset), len(data), unsafe.Pointer(&data[0]))
-	q.glCtx.BindBuffer(buf.target, 0)
+	glCtx := q.ctx.Lock()
+	defer q.ctx.Unlock()
+
+	glCtx.BindBuffer(buf.target, buf.id)
+	glCtx.BufferSubData(buf.target, int(offset), len(data), unsafe.Pointer(&data[0]))
+	glCtx.BindBuffer(buf.target, 0)
 	return nil
 }
 
@@ -92,28 +93,26 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 		return fmt.Errorf("gles: invalid texture type for WriteTexture")
 	}
 
+	glCtx := q.ctx.Lock()
+	defer q.ctx.Unlock()
+
 	_, format, dataType := textureFormatToGL(tex.format)
 
-	q.glCtx.BindTexture(tex.target, tex.id)
+	glCtx.BindTexture(tex.target, tex.id)
 
 	if tex.target == gl.TEXTURE_2D {
-		// Set alignment to 1 for single-channel formats (R8) whose row stride
-		// may not be a multiple of the default 4-byte GL_UNPACK_ALIGNMENT.
 		if tex.format == gputypes.TextureFormatR8Unorm {
-			q.glCtx.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
+			glCtx.PixelStorei(gl.UNPACK_ALIGNMENT, 1)
 		}
-		// Use TexSubImage2D to update existing texture data (Rust wgpu-hal pattern).
-		// TexImage2D reallocates storage on every call; TexSubImage2D updates in-place.
-		q.glCtx.TexSubImage2D(tex.target, int32(dst.MipLevel),
+		glCtx.TexSubImage2D(tex.target, int32(dst.MipLevel),
 			0, 0, int32(size.Width), int32(size.Height), format, dataType,
 			unsafe.Pointer(&data[0]))
-		// Restore default alignment after upload.
 		if tex.format == gputypes.TextureFormatR8Unorm {
-			q.glCtx.PixelStorei(gl.UNPACK_ALIGNMENT, 4)
+			glCtx.PixelStorei(gl.UNPACK_ALIGNMENT, 4)
 		}
 	}
 
-	q.glCtx.BindTexture(tex.target, 0)
+	glCtx.BindTexture(tex.target, 0)
 
 	hal.Logger().Debug("gles: texture written",
 		"format", tex.format,
@@ -126,23 +125,33 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 
 // Present presents a surface texture to the screen.
 //
-// Before SwapBuffers, blits the Surface's swapchain offscreen FBO to the
-// default framebuffer (FBO 0) with an explicit Y-flip. User render passes
-// render upside-down into the swapchain FBO (driven by naga's in-shader
-// Y-flip); the blit un-flips for presentation. Mirrors Rust wgpu-hal
-// src/gles/egl.rs Surface::present (1280-1308).
+// Makes the GL context current on the user window's DC (via LockForDC),
+// blits the swapchain FBO to the default framebuffer with Y-flip, then
+// SwapBuffers. Mirrors Rust wgpu-hal wgl.rs Surface::present (682-750):
+// GetDC → lock_with_dc → blit → SwapBuffers → ReleaseDC.
 //
 // damageRects is accepted but ignored on Windows WGL — WGL has no
-// damage-aware swap API. GLES damage support is Linux-only (Phase 4, ADR-017).
+// damage-aware swap API.
 func (q *Queue) Present(surface hal.Surface, _ hal.SurfaceTexture, _ []image.Rectangle) error {
 	surf, ok := surface.(*Surface)
 	if !ok {
 		return fmt.Errorf("gles: invalid surface type")
 	}
 
-	surf.blitSwapchainToDefault()
+	// Get fresh DC for the user window (Rust: Gdi::GetDC(self.window)).
+	hdc := wgl.GetDC(surf.hwnd)
+	if hdc == 0 {
+		return fmt.Errorf("gles: GetDC failed for hwnd 0x%x", surf.hwnd)
+	}
+	defer wgl.ReleaseDC(surf.hwnd, hdc)
 
-	return surf.wglCtx.SwapBuffers()
+	// MakeCurrent to user window DC for presentation.
+	glCtx := q.ctx.LockForDC(hdc)
+	defer q.ctx.Unlock()
+
+	surf.blitSwapchainToDefaultWith(glCtx)
+
+	return wgl.SwapBuffers(hdc)
 }
 
 // GetTimestampPeriod returns the timestamp period in nanoseconds.

--- a/hal/gles/resource_windows.go
+++ b/hal/gles/resource_windows.go
@@ -10,35 +10,38 @@ import (
 
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/hal"
-	"github.com/gogpu/wgpu/hal/gles/gl"
 	"github.com/gogpu/wgpu/hal/gles/wgl"
 )
 
 // Surface implements hal.Surface for OpenGL on Windows.
+// Lightweight — does NOT own the GL context. The context lives on Instance's
+// hidden window via AdapterContext. Surface stores only the user HWND and a
+// reference to the shared AdapterContext.
+//
+// Follows Rust wgpu-hal/src/gles/wgl.rs Surface (lines 672-677).
 type Surface struct {
 	hwnd       wgl.HWND
-	wglCtx     *wgl.Context
-	glCtx      *gl.Context
-	version    string
-	renderer   string
+	ctx        *AdapterContext // shared, NOT owned
 	configured bool
 	config     *hal.SurfaceConfiguration
 
 	// Swapchain offscreen framebuffer. User render passes that target this
 	// Surface render into swapchainFBO (backed by colorRenderbuffer), not FBO 0.
 	// Queue.Present blits this FBO to the default framebuffer with an explicit
-	// Y-flip before SwapBuffers. Mirrors Rust wgpu-hal/src/gles/egl.rs
-	// Surface::configure (1537-1562) / Surface::present (1280-1308).
+	// Y-flip before SwapBuffers.
 	swapchainFBO        uint32
 	colorRenderbuffer   uint32
 	fboWidth, fboHeight uint32
 }
 
 // GetAdapterInfo returns adapter information from this surface's GL context.
-// Probes GL version, extensions, features, limits, and MSAA support to build
-// an accurate ExposedAdapter. Follows Rust wgpu-hal adapter.rs expose pattern.
+// Not used in the new architecture (Instance.EnumerateAdapters queries directly),
+// but kept for interface compatibility.
 func (s *Surface) GetAdapterInfo() hal.ExposedAdapter {
-	caps := queryAdapterCapabilities(s.glCtx)
+	glCtx := s.ctx.Lock()
+	defer s.ctx.Unlock()
+
+	caps := queryAdapterCapabilities(glCtx)
 
 	driverInfo := "OpenGL 3.3+"
 	if caps.IsES {
@@ -49,12 +52,9 @@ func (s *Surface) GetAdapterInfo() hal.ExposedAdapter {
 
 	return hal.ExposedAdapter{
 		Adapter: &Adapter{
-			glCtx:    s.glCtx,
-			wglCtx:   s.wglCtx,
-			hwnd:     s.hwnd,
-			version:  s.version,
-			renderer: s.renderer,
-			caps:     caps,
+			ctx:     s.ctx,
+			version: fmt.Sprintf("%d.%d", caps.GLMajor, caps.GLMinor),
+			caps:    caps,
 		},
 		Info: gputypes.AdapterInfo{
 			Name:       caps.Renderer,
@@ -74,7 +74,7 @@ func (s *Surface) GetAdapterInfo() hal.ExposedAdapter {
 				BufferCopyPitch:  4,
 			},
 			DownlevelCapabilities: hal.DownlevelCapabilities{
-				ShaderModel: 50, // SM5.0
+				ShaderModel: 50,
 				Flags:       caps.DownlevelFlags,
 			},
 		},
@@ -83,40 +83,41 @@ func (s *Surface) GetAdapterInfo() hal.ExposedAdapter {
 
 // Configure configures the surface for presentation.
 //
-// Returns hal.ErrZeroArea if width or height is zero.
-// This commonly happens when the window is minimized or not yet fully visible.
-// Wait until the window has valid dimensions before calling Configure again.
+// Uses two separate lock scopes to avoid stomping MakeCurrent state:
+// 1. LockForDC(userDC) — set swap interval (requires context on user DC)
+// 2. Lock() — allocate swapchain FBO (requires context on hidden DC)
 func (s *Surface) Configure(_ hal.Device, config *hal.SurfaceConfiguration) error {
-	// Validate dimensions first (before any side effects).
-	// This matches wgpu-core behavior which returns ConfigureSurfaceError::ZeroArea.
 	if config.Width == 0 || config.Height == 0 {
 		return hal.ErrZeroArea
 	}
 
-	// Load WGL extensions and set swap interval for VSync control.
-	// wglGetProcAddress requires a current GL context.
-	if s.wglCtx != nil {
-		wgl.LoadExtensions(s.wglCtx.HDC())
-
+	// Scope 1: Set swap interval on user window DC.
+	// SetSwapInterval requires a current context on the target DC.
+	hdc := wgl.GetDC(s.hwnd)
+	if hdc != 0 {
+		s.ctx.LockForDC(hdc)
+		wgl.LoadExtensions(hdc)
 		if wgl.HasSwapControl() {
 			var interval int
 			switch config.PresentMode {
 			case hal.PresentModeFifo, hal.PresentModeFifoRelaxed:
-				interval = 1 // VSync on
+				interval = 1
 			case hal.PresentModeImmediate, hal.PresentModeMailbox:
-				interval = 0 // VSync off
+				interval = 0
 			default:
-				interval = 1 // Default to VSync
+				interval = 1
 			}
-			if err := wgl.SetSwapInterval(interval); err != nil {
-				return fmt.Errorf("gles: failed to set swap interval: %w", err)
-			}
+			_ = wgl.SetSwapInterval(interval)
 		}
+		s.ctx.Unlock()
+		wgl.ReleaseDC(s.hwnd, hdc)
 	}
 
-	// Allocate / resize the swapchain offscreen FBO. User render passes
-	// target this FBO; Present blits it to FBO 0 with Y-flip.
-	if err := s.reconfigureSwapchainFBO(config.Format, config.Width, config.Height); err != nil {
+	// Scope 2: Allocate swapchain FBO on hidden DC.
+	glCtx := s.ctx.Lock()
+	defer s.ctx.Unlock()
+
+	if err := s.reconfigureSwapchainFBOWith(glCtx, config.Format, config.Width, config.Height); err != nil {
 		return fmt.Errorf("gles: failed to configure swapchain framebuffer: %w", err)
 	}
 
@@ -127,7 +128,10 @@ func (s *Surface) Configure(_ hal.Device, config *hal.SurfaceConfiguration) erro
 
 // Unconfigure marks the surface as unconfigured.
 func (s *Surface) Unconfigure(_ hal.Device) {
-	destroySwapchainFBO(s.glCtx, s.swapchainFBO, s.colorRenderbuffer)
+	glCtx := s.ctx.Lock()
+	defer s.ctx.Unlock()
+
+	destroySwapchainFBO(glCtx, s.swapchainFBO, s.colorRenderbuffer)
 	s.swapchainFBO = 0
 	s.colorRenderbuffer = 0
 	s.fboWidth = 0
@@ -150,8 +154,6 @@ func (s *Surface) AcquireTexture(_ hal.Fence) (*hal.AcquiredSurfaceTexture, erro
 func (s *Surface) DiscardTexture(_ hal.SurfaceTexture) {}
 
 // ActualExtent returns the configured surface dimensions.
-// GLES does not clamp the extent, so these always match the requested values.
-// Returns (0, 0) if the surface is not configured.
 func (s *Surface) ActualExtent() (width, height uint32) {
 	if s.config == nil {
 		return 0, 0
@@ -160,30 +162,24 @@ func (s *Surface) ActualExtent() (width, height uint32) {
 }
 
 // Destroy releases the surface resources.
+// Does NOT destroy the GL context — that's owned by Instance.
 func (s *Surface) Destroy() {
-	// Release swapchain FBO before tearing down the GL context.
-	destroySwapchainFBO(s.glCtx, s.swapchainFBO, s.colorRenderbuffer)
+	if s.ctx != nil {
+		glCtx := s.ctx.Lock()
+		destroySwapchainFBO(glCtx, s.swapchainFBO, s.colorRenderbuffer)
+		s.ctx.Unlock()
+	}
 	s.swapchainFBO = 0
 	s.colorRenderbuffer = 0
-	if s.wglCtx != nil {
-		s.wglCtx.Destroy(s.hwnd)
-		s.wglCtx = nil
-	}
 }
 
 // SurfaceTexture implements hal.SurfaceTexture for OpenGL on Windows.
-// It represents the default framebuffer.
 type SurfaceTexture struct {
 	surface *Surface
 }
 
-// CurrentUsage returns 0 — GLES surface textures have no state tracking.
 func (t *SurfaceTexture) CurrentUsage() gputypes.TextureUsage { return 0 }
 func (t *SurfaceTexture) AddPendingRef()                      {}
 func (t *SurfaceTexture) DecPendingRef()                      {}
-
-// Destroy is a no-op for surface textures.
-func (t *SurfaceTexture) Destroy() {}
-
-// NativeHandle returns 0 (OpenGL default framebuffer has no handle).
-func (t *SurfaceTexture) NativeHandle() uintptr { return 0 }
+func (t *SurfaceTexture) Destroy()                            {}
+func (t *SurfaceTexture) NativeHandle() uintptr               { return 0 }

--- a/hal/gles/surface.go
+++ b/hal/gles/surface.go
@@ -13,25 +13,8 @@ import (
 	"github.com/gogpu/wgpu/hal/gles/gl"
 )
 
-// allocateSwapchainFBO creates a persistent swapchain framebuffer for the
-// Surface. User render passes that target this Surface render into this FBO
-// (backed by a color renderbuffer), not the default framebuffer (FBO 0).
-// Queue.Present performs an explicit Y-flipping glBlitFramebuffer from this
-// FBO to FBO 0 before SwapBuffers.
-//
-// This closes an architectural gap vs Rust wgpu-hal/src/gles/egl.rs:
-//   - Surface::configure (1537-1562) allocates swapchain renderbuffer + FBO.
-//   - Surface::present    (1280-1308) blits with srcY0=height, srcY1=0.
-//
-// naga's in-shader Y-flip (`gl_Position.y = -gl_Position.y`, driven by
-// glsl.WriterFlagAdjustCoordinateSpace) intentionally renders the scene
-// upside-down inside this FBO; the present-time blit un-flips it. Together
-// this yields a WebGPU-compliant top-left framebuffer origin for users.
-//
-// Must be called on the thread where the GL context is current.
-// width/height must both be non-zero (caller should validate).
-// Returns the new FBO and color renderbuffer names, or an error if allocation
-// fails or the framebuffer is not complete.
+// allocateSwapchainFBO creates a persistent swapchain framebuffer.
+// Must be called with the GL context current (caller holds AdapterContext lock).
 func allocateSwapchainFBO(glCtx *gl.Context, format gputypes.TextureFormat, width, height uint32) (fbo, colorRbo uint32, err error) {
 	if glCtx == nil {
 		return 0, 0, fmt.Errorf("gles: allocateSwapchainFBO: nil gl context")
@@ -40,10 +23,6 @@ func allocateSwapchainFBO(glCtx *gl.Context, format gputypes.TextureFormat, widt
 		return 0, 0, hal.ErrZeroArea
 	}
 
-	// Derive a sized internal format from the surface's texture format.
-	// For typical sRGB / BGRA / RGBA surface formats this is GL_RGBA8 or
-	// GL_SRGB8_ALPHA8. If the format is unsupported, textureFormatToGL
-	// falls back to GL_RGBA8.
 	internalFormat, _, _ := textureFormatToGL(format)
 
 	colorRbo = glCtx.GenRenderbuffers(1)
@@ -64,7 +43,6 @@ func allocateSwapchainFBO(glCtx *gl.Context, format gputypes.TextureFormat, widt
 
 	status := glCtx.CheckFramebufferStatus(gl.FRAMEBUFFER)
 
-	// Restore default bindings before returning, regardless of success.
 	glCtx.BindFramebuffer(gl.FRAMEBUFFER, 0)
 	glCtx.BindRenderbuffer(gl.RENDERBUFFER, 0)
 
@@ -85,8 +63,7 @@ func allocateSwapchainFBO(glCtx *gl.Context, format gputypes.TextureFormat, widt
 }
 
 // destroySwapchainFBO releases the swapchain framebuffer and its attachments.
-// Safe to call with zero handles (no-op). Must be called on the thread where
-// the GL context is current.
+// Safe to call with zero handles or nil context.
 func destroySwapchainFBO(glCtx *gl.Context, fbo, colorRbo uint32) {
 	if glCtx == nil {
 		return
@@ -99,66 +76,47 @@ func destroySwapchainFBO(glCtx *gl.Context, fbo, colorRbo uint32) {
 	}
 }
 
-// blitSwapchainToDefault performs the present-time Y-flipping blit from the
-// Surface's swapchain offscreen FBO to the default framebuffer (FBO 0). Must
-// be called with the GL context current, immediately before SwapBuffers.
-//
-// The source rect is Y-inverted (srcY0=height, srcY1=0); the destination rect
-// is normal. Combined with naga's in-shader Y-flip this yields a top-left
-// framebuffer origin on screen, matching WebGPU semantics.
-//
-// This is a no-op when there is no swapchain FBO (e.g. surface not yet
-// configured, or failed allocation) — in that case whatever the user rendered
-// directly into FBO 0 is presented as-is.
+// blitSwapchainToDefaultWith performs the present-time Y-flipping blit from
+// the Surface's swapchain FBO to the default framebuffer (FBO 0).
+// Must be called with GL context current on the user window DC.
 //
 // Mirrors Rust wgpu-hal/src/gles/egl.rs Surface::present (1280-1308).
-func (s *Surface) blitSwapchainToDefault() {
-	if s.glCtx == nil || s.swapchainFBO == 0 {
+func (s *Surface) blitSwapchainToDefaultWith(glCtx *gl.Context) {
+	if glCtx == nil || s.swapchainFBO == 0 {
 		return
 	}
 	if s.fboWidth == 0 || s.fboHeight == 0 {
 		return
 	}
 
-	ctx := s.glCtx
+	glCtx.Disable(gl.SCISSOR_TEST)
 
-	// glBlitFramebuffer respects GL_SCISSOR_TEST on the draw framebuffer.
-	// Disable it so the entire surface is copied (gg#226).
-	ctx.Disable(gl.SCISSOR_TEST)
-
-	ctx.BindFramebuffer(gl.READ_FRAMEBUFFER, s.swapchainFBO)
-	ctx.BindFramebuffer(gl.DRAW_FRAMEBUFFER, 0)
+	glCtx.BindFramebuffer(gl.READ_FRAMEBUFFER, s.swapchainFBO)
+	glCtx.BindFramebuffer(gl.DRAW_FRAMEBUFFER, 0)
 
 	w := int32(s.fboWidth)
 	h := int32(s.fboHeight)
 
-	// Y-flip source rect: srcY0=h, srcY1=0.
-	// GL's presentation is bottom-left origin; main rendering is intentionally
-	// upside-down via naga's in-shader Y-flip. Un-flip here for presentation.
-	ctx.BlitFramebuffer(
-		0, h, w, 0, // source Y-flipped: top → bottom
-		0, 0, w, h, // dest: normal
+	glCtx.BlitFramebuffer(
+		0, h, w, 0, // source Y-flipped
+		0, 0, w, h, // dest normal
 		gl.COLOR_BUFFER_BIT, gl.NEAREST,
 	)
 
-	// Restore default bindings.
-	ctx.BindFramebuffer(gl.READ_FRAMEBUFFER, 0)
-	ctx.BindFramebuffer(gl.DRAW_FRAMEBUFFER, 0)
+	glCtx.BindFramebuffer(gl.READ_FRAMEBUFFER, 0)
+	glCtx.BindFramebuffer(gl.DRAW_FRAMEBUFFER, 0)
 }
 
-// reconfigureSwapchainFBO destroys the existing swapchain FBO (if any) and
-// allocates a new one at the new dimensions. On error, the Surface is left
-// with all swapchain fields zeroed so subsequent Configure calls can retry.
-func (s *Surface) reconfigureSwapchainFBO(format gputypes.TextureFormat, width, height uint32) error {
-	// Destroy previous allocation (if any) before allocating new one.
-	// Ensures no leak on resize.
-	destroySwapchainFBO(s.glCtx, s.swapchainFBO, s.colorRenderbuffer)
+// reconfigureSwapchainFBOWith destroys the existing swapchain FBO and
+// allocates a new one. Caller must hold the AdapterContext lock.
+func (s *Surface) reconfigureSwapchainFBOWith(glCtx *gl.Context, format gputypes.TextureFormat, width, height uint32) error {
+	destroySwapchainFBO(glCtx, s.swapchainFBO, s.colorRenderbuffer)
 	s.swapchainFBO = 0
 	s.colorRenderbuffer = 0
 	s.fboWidth = 0
 	s.fboHeight = 0
 
-	fbo, colorRbo, err := allocateSwapchainFBO(s.glCtx, format, width, height)
+	fbo, colorRbo, err := allocateSwapchainFBO(glCtx, format, width, height)
 	if err != nil {
 		return err
 	}

--- a/hal/gles/surface_linux_compat.go
+++ b/hal/gles/surface_linux_compat.go
@@ -1,0 +1,21 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build linux && !(js && wasm)
+
+package gles
+
+import "github.com/gogpu/gputypes"
+
+// Compatibility wrappers for Linux Surface which still owns its GL context
+// directly (Phase 1 = Windows only). These delegate to the *With() methods
+// using the Surface's own glCtx. Will be removed in Phase 2 when Linux
+// migrates to AdapterContext.
+
+func (s *Surface) reconfigureSwapchainFBO(format gputypes.TextureFormat, width, height uint32) error {
+	return s.reconfigureSwapchainFBOWith(s.glCtx, format, width, height)
+}
+
+func (s *Surface) blitSwapchainToDefault() {
+	s.blitSwapchainToDefaultWith(s.glCtx)
+}

--- a/hal/gles/wgl/hidden_window.go
+++ b/hal/gles/wgl/hidden_window.go
@@ -131,8 +131,8 @@ func NewHiddenWindow() (*HiddenWindow, error) {
 		&hiddenClassName[0], // lpClassName
 		nil,                 // lpWindowName
 		0,                   // dwStyle (no WS_VISIBLE)
-		0, 0, 1, 1,         // x, y, w, h
-		0, 0, 0, 0,         // parent, menu, instance, param
+		0, 0, 1, 1,          // x, y, w, h
+		0, 0, 0, 0, // parent, menu, instance, param
 	)
 	if err != nil {
 		return nil, fmt.Errorf("wgl: CreateWindowExW: %w", err)

--- a/hal/gles/wgl/hidden_window.go
+++ b/hal/gles/wgl/hidden_window.go
@@ -1,0 +1,196 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build windows && !(js && wasm)
+
+package wgl
+
+import (
+	"fmt"
+	"sync"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	procRegisterClassExW *syscall.Proc
+	procCreateWindowExW  *syscall.Proc
+	procDestroyWindow    *syscall.Proc
+	procDefWindowProcW   *syscall.Proc
+
+	hiddenClassOnce sync.Once
+	hiddenClassName [64]uint16
+)
+
+// WNDCLASSEXW is the Windows extended window class structure.
+type WNDCLASSEXW struct {
+	Size       uint32
+	Style      uint32
+	WndProc    uintptr
+	ClsExtra   int32
+	WndExtra   int32
+	Instance   uintptr
+	Icon       uintptr
+	Cursor     uintptr
+	Background uintptr
+	MenuName   *uint16
+	ClassName  *uint16
+	IconSm     uintptr
+}
+
+const (
+	csOwnDC = 0x0020
+)
+
+// initHiddenWindowProcs loads User32 procedures needed for hidden window management.
+// Must be called after wgl.Init() (which loads user32.dll).
+func initHiddenWindowProcs() error {
+	if user32 == nil {
+		return fmt.Errorf("wgl: user32.dll not loaded — call Init() first")
+	}
+
+	var err error
+	procRegisterClassExW, err = user32.FindProc("RegisterClassExW")
+	if err != nil {
+		return fmt.Errorf("RegisterClassExW: %w", err)
+	}
+
+	procCreateWindowExW, err = user32.FindProc("CreateWindowExW")
+	if err != nil {
+		return fmt.Errorf("CreateWindowExW: %w", err)
+	}
+
+	procDestroyWindow, err = user32.FindProc("DestroyWindow")
+	if err != nil {
+		return fmt.Errorf("DestroyWindow: %w", err)
+	}
+
+	procDefWindowProcW, err = user32.FindProc("DefWindowProcW")
+	if err != nil {
+		return fmt.Errorf("DefWindowProcW: %w", err)
+	}
+
+	return nil
+}
+
+// registerHiddenWindowClass registers a window class for hidden GL windows.
+// Uses CS_OWNDC so each window gets a persistent DC (required for WGL).
+// Follows Rust wgpu-hal wgl.rs:272-342.
+func registerHiddenWindowClass() error {
+	var regErr error
+	hiddenClassOnce.Do(func() {
+		if err := initHiddenWindowProcs(); err != nil {
+			regErr = err
+			return
+		}
+
+		name := "wgpu_gles_hidden"
+		for i, c := range name {
+			hiddenClassName[i] = uint16(c)
+		}
+		hiddenClassName[len(name)] = 0
+
+		wc := WNDCLASSEXW{
+			Size:      uint32(unsafe.Sizeof(WNDCLASSEXW{})),
+			Style:     csOwnDC,
+			WndProc:   procDefWindowProcW.Addr(),
+			ClassName: &hiddenClassName[0],
+		}
+
+		r, _, err := procRegisterClassExW.Call(uintptr(unsafe.Pointer(&wc)))
+		if r == 0 {
+			regErr = fmt.Errorf("RegisterClassExW failed: %w", err)
+		}
+	})
+	return regErr
+}
+
+// HiddenWindow holds a hidden 1×1 window used to host the GL context.
+// Created on the calling thread (not a goroutine) because Windows HWND/HDC
+// handles are thread-safe but CS_OWNDC gives a persistent DC tied to the window.
+// Follows Rust wgpu-hal wgl.rs:344-446 (InstanceDevice pattern).
+//
+// Rust uses a dedicated OS thread because Rust threads = OS threads.
+// In Go, goroutines migrate between OS threads, so we create the hidden window
+// on the caller's thread instead. The window has no message pump — it exists
+// solely to own a DC for the GL context.
+type HiddenWindow struct {
+	hwnd HWND
+	hdc  HDC
+}
+
+// NewHiddenWindow creates a hidden 1×1 window on the calling thread.
+// The DC returned via HiddenWindow.DC() is valid until Destroy() is called.
+func NewHiddenWindow() (*HiddenWindow, error) {
+	if err := registerHiddenWindowClass(); err != nil {
+		return nil, fmt.Errorf("wgl: register hidden window class: %w", err)
+	}
+
+	hwnd, err := createWindowEx(
+		0,                   // dwExStyle
+		&hiddenClassName[0], // lpClassName
+		nil,                 // lpWindowName
+		0,                   // dwStyle (no WS_VISIBLE)
+		0, 0, 1, 1,         // x, y, w, h
+		0, 0, 0, 0,         // parent, menu, instance, param
+	)
+	if err != nil {
+		return nil, fmt.Errorf("wgl: CreateWindowExW: %w", err)
+	}
+
+	hdc := GetDC(hwnd)
+	if hdc == 0 {
+		destroyWindow(hwnd)
+		return nil, fmt.Errorf("wgl: GetDC failed for hidden window")
+	}
+
+	return &HiddenWindow{
+		hwnd: hwnd,
+		hdc:  hdc,
+	}, nil
+}
+
+// DC returns the device context of the hidden window.
+func (hw *HiddenWindow) DC() HDC {
+	return hw.hdc
+}
+
+// HWND returns the hidden window handle.
+func (hw *HiddenWindow) HWND() HWND {
+	return hw.hwnd
+}
+
+// Destroy releases the DC and destroys the hidden window.
+func (hw *HiddenWindow) Destroy() {
+	if hw.hdc != 0 {
+		ReleaseDC(hw.hwnd, hw.hdc)
+		hw.hdc = 0
+	}
+	if hw.hwnd != 0 {
+		destroyWindow(hw.hwnd)
+		hw.hwnd = 0
+	}
+}
+
+// createWindowEx wraps CreateWindowExW.
+func createWindowEx(exStyle uint32, className *uint16, windowName *uint16, style uint32, x, y, w, h int32, parent, menu, instance, param uintptr) (HWND, error) {
+	r, _, err := procCreateWindowExW.Call(
+		uintptr(exStyle),
+		uintptr(unsafe.Pointer(className)),
+		uintptr(unsafe.Pointer(windowName)),
+		uintptr(style),
+		uintptr(x), uintptr(y), uintptr(w), uintptr(h),
+		parent, menu, instance, param,
+	)
+	if r == 0 {
+		return 0, fmt.Errorf("CreateWindowExW failed: %w", err)
+	}
+	return HWND(r), nil
+}
+
+// destroyWindow wraps DestroyWindow.
+func destroyWindow(hwnd HWND) {
+	if procDestroyWindow != nil {
+		procDestroyWindow.Call(uintptr(hwnd)) //nolint:errcheck // best-effort cleanup
+	}
+}


### PR DESCRIPTION
## Summary

- Move GL context ownership from Surface to Instance using a hidden 1×1 HWND
- Previously Surface owned the GL context — closing the window killed it, leaving Adapter/Device/Queue with dangling references
- New `AdapterContext` with `sync.Mutex` + `runtime.LockOSThread()` + lazy GL init via `sync.Once`
- Surface becomes lightweight (no context ownership), enabling multi-window support and renderer lifecycle decoupling
- Follows Rust wgpu-hal/src/gles/wgl.rs `AdapterContext::lock()`/`lock_with_dc()` pattern

## Architecture

| Component | Before | After |
|-----------|--------|-------|
| GL context owner | Surface | Instance (hidden 1×1 HWND) |
| Context creation | CreateSurface | Lazy in first Lock() on render thread |
| Thread safety | None | sync.Mutex + runtime.LockOSThread |
| Surface.Configure | Single lock scope (double unmake bug) | Two lock scopes: swap interval + FBO |
| Unlock guard | None | wglGetCurrentContext() check (Rust pattern) |
| Surface destruction | Kills GL context | Context survives (on hidden window) |

## New files (3)
- `wgl/hidden_window.go` — hidden HWND, CS_OWNDC window class, lifecycle
- `adapter_context.go` — mutex-protected GL context with lazy init
- `surface_linux_compat.go` — compat wrappers for Linux (Phase 2)

## Test plan
- [x] Build: Windows, Linux, macOS, WASM
- [x] Tests: 15/15 pass
- [x] Lint: 0 issues on all 3 platforms
- [x] Standalone MakeCurrent lifecycle test (cmd/gles-debug)
- [x] Visual: `GOGPU_GRAPHICS_API=gles` triangle renders on Intel Iris Xe, OpenGL 4.6
- [ ] CI: GitHub Actions (Linux Mesa Surfaceless for GLES integration test)