### PR TITLE
fix(core): trigger deferred GLES enumeration in RequestAdapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.7] - 2026-05-21
+
+### Fixed
+
+- **Core: trigger deferred GLES enumeration in RequestAdapter** — `RequestAdapter()` now
+  calls `enumerateDeferredGLES(nil)` before adapter selection. Previously, GLES adapters
+  were only enumerated via `RequestAdapterWithSurface(surface)` with a non-nil surface hint.
+  After gogpu LIFECYCLE Phase 2 decoupled adapter from surface, `RequestAdapter(nil)` skipped
+  GLES enumeration entirely, returning "Software Renderer" instead of "Intel Iris Xe". Safe
+  with nil since v0.28.6 (hidden window GL context ignores surface parameter).
+
 ## [0.28.6] - 2026-05-21
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.28.6
+## Current State: v0.28.7
 
 ✅ **All 5 HAL backends complete** (~127K LOC)
 ✅ **Three-layer WebGPU stack** — wgpu API → wgpu/core → wgpu/hal
@@ -151,6 +151,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.28.7** | 2026-05 | Core: deferred GLES enumeration in RequestAdapter (adapter name fix). |
 | **v0.28.6** | 2026-05 | **GLES hidden window context** (Rust parity). Instance-owned GL context, AdapterContext mutex, Surface lightweight. Fixes context death on window close. |
 | **v0.28.5** | 2026-05 | Metal: defer pool.Drain, drawable count. Core: indirect validation nil guard (#189). |
 | **v0.28.4** | 2026-05 | macOS blit (@k-chimi), GLES Rust parity (fence+copies+timestamps+adapter), GPU dispatch indirect validation. |

--- a/core/instance.go
+++ b/core/instance.go
@@ -155,10 +155,9 @@ func (i *Instance) enumerateRealAdapters(desc *gputypes.InstanceDescriptor) bool
 			continue
 		}
 
-		// GLES/GL backends require a surface (GL context) to enumerate adapters
-		// properly. Defer their enumeration until RequestAdapterWithSurface is
-		// called with a surface hint. Without a surface, EnumerateAdapters returns
-		// a placeholder adapter with nil glCtx that crashes on use.
+		// GLES/GL backends use lazy GL context initialization (hidden window,
+		// v0.28.6+). Defer enumeration until RequestAdapter, where the first
+		// Lock() call creates the GL context on the render thread via sync.Once.
 		if provider.Variant() == gputypes.BackendGL {
 			i.halInstances = append(i.halInstances, halInstance)
 			i.halInstanceMap[provider.Variant()] = halInstance
@@ -248,6 +247,13 @@ func (i *Instance) EnumerateAdapters() []AdapterID {
 //
 // If options is nil, the first available adapter is returned.
 func (i *Instance) RequestAdapter(options *gputypes.RequestAdapterOptions) (AdapterID, error) { //nolint:gocognit // adapter selection with GPU preference logic
+	// Trigger deferred GLES adapter enumeration if not yet done.
+	// Since v0.28.6, GLES uses a hidden window GL context (not a surface),
+	// so EnumerateAdapters is safe to call with nil surfaceHint.
+	// Must be called BEFORE RLock to avoid deadlock (enumerateDeferredGLES
+	// acquires a write lock internally).
+	i.enumerateDeferredGLES(nil)
+
 	i.mu.RLock()
 	defer i.mu.RUnlock()
 
@@ -341,24 +347,22 @@ func (i *Instance) RequestAdapter(options *gputypes.RequestAdapterOptions) (Adap
 }
 
 // RequestAdapterWithSurface requests an adapter matching the given options,
-// using the provided HAL surface as a hint for backends that require it (GLES).
+// using the provided HAL surface as a hint for backends that require it.
 //
-// For GLES/GL backends, adapter enumeration is deferred until a surface is
-// available because OpenGL requires a GL context to query capabilities.
-// This method triggers that deferred enumeration when surfaceHint is non-nil.
-//
-// If surfaceHint is nil, this behaves identically to RequestAdapter.
+// Since v0.28.6, GLES uses a hidden window GL context and does not need a
+// surface hint for enumeration. Deferred enumeration is now triggered in
+// RequestAdapter itself. This method is kept for API compatibility.
 func (i *Instance) RequestAdapterWithSurface(options *gputypes.RequestAdapterOptions, surfaceHint hal.Surface) (AdapterID, error) {
-	// Enumerate deferred GLES adapters if we have a surface and haven't done so yet.
-	if surfaceHint != nil {
-		i.enumerateDeferredGLES(surfaceHint)
-	}
-
+	// surfaceHint passed through for potential future use (multi-GPU selection).
+	// Deferred GLES enumeration happens in RequestAdapter (safe with nil since v0.28.6).
 	return i.RequestAdapter(options)
 }
 
-// enumerateDeferredGLES enumerates adapters for deferred GLES HAL instances
-// using the provided surface hint. This is called at most once per instance.
+// enumerateDeferredGLES enumerates adapters for deferred GLES HAL instances.
+// Called at most once per instance (guarded by glesEnumerated flag).
+//
+// Since v0.28.6, surfaceHint may be nil — GLES EnumerateAdapters uses the
+// hidden window GL context and ignores the surface parameter.
 //
 // Must NOT be called with i.mu held (it acquires mu internally).
 func (i *Instance) enumerateDeferredGLES(surfaceHint hal.Surface) {


### PR DESCRIPTION
## Summary

- `RequestAdapter()` now triggers deferred GLES adapter enumeration (safe with nil since v0.28.6 hidden window)
- Previously only `RequestAdapterWithSurface(surface)` with non-nil surface triggered GLES enumeration
- After gogpu LIFECYCLE Phase 2 decoupled adapter from surface, `RequestAdapter(nil)` skipped GLES → "Software Renderer" selected instead of "Intel Iris Xe"

## Change

1 file, `core/instance.go`: `enumerateDeferredGLES(nil)` called before RLock in `RequestAdapter()`

## Test plan
- [x] Build: Windows, Linux, macOS
- [x] Tests: 15/15 pass
- [x] Lint: 0 issues all platforms
- [ ] Visual: `GOGPU_GRAPHICS_API=gles` shows "Intel Iris Xe" in adapter log
- [ ] CI