### PR TITLE
fix(core): Clone buffer ResourceRefs in SetBindGroup (use-after-free)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.28.8] - 2026-05-26
+
+### Fixed
+
+- **Core: Clone buffer ResourceRefs in SetBindGroup (use-after-free prevention)** —
+  `SetBindGroup` now calls `ResourceRef.Clone()` on each buffer referenced by the bind group,
+  keeping buffers alive until GPU completes the submission. Previously only `BindGroup.ref` was
+  Clone'd — individual buffer refs were tracked for validation only (VAL-A6), not refcounted.
+  If a caller called `Buffer.Release()` before `Queue.Submit()`, the buffer could be
+  HAL-destroyed while still referenced by a pending command buffer. Matches Rust wgpu
+  `merge_bind_group` → `ResourceMetadata.insert(Arc<Buffer>)` pattern. Affects both
+  `RenderPassEncoder.SetBindGroup` and `ComputePassEncoder.SetBindGroup`.
+
 ## [0.28.7] - 2026-05-21
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.28.7
+## Current State: v0.28.8
 
 ✅ **All 5 HAL backends complete** (~127K LOC)
 ✅ **Three-layer WebGPU stack** — wgpu API → wgpu/core → wgpu/hal
@@ -151,6 +151,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.28.8** | 2026-05 | Core: Clone buffer ResourceRefs in SetBindGroup — prevents use-after-free (Rust wgpu parity). |
 | **v0.28.7** | 2026-05 | Core: deferred GLES enumeration in RequestAdapter (adapter name fix). |
 | **v0.28.6** | 2026-05 | **GLES hidden window context** (Rust parity). Instance-owned GL context, AdapterContext mutex, Surface lightweight. Fixes context death on window close. |
 | **v0.28.5** | 2026-05 | Metal: defer pool.Drain, drawable count. Core: indirect validation nil guard (#189). |

--- a/computepass_native.go
+++ b/computepass_native.go
@@ -86,6 +86,13 @@ func (p *ComputePassEncoder) SetBindGroup(index uint32, group *BindGroup, offset
 	p.assignedBindGroups[index] = group
 	p.assignedDynOffsets[index] = offsets
 	p.trackRef(group.ref)
+	// Clone individual buffer ResourceRefs to keep them alive until GPU completes.
+	// Matches Rust wgpu merge_bind_group → ResourceMetadata.insert(Arc<Buffer>).
+	for _, buf := range group.boundBuffers {
+		if buf.core != nil && buf.core.Ref != nil {
+			p.trackRef(buf.core.Ref)
+		}
+	}
 	// Track bind group itself for submit-time validation (VAL-B5).
 	p.encoder.trackBindGroup(group)
 	// Track bind group resources for submit-time validation (VAL-A6).

--- a/renderpass_native.go
+++ b/renderpass_native.go
@@ -99,6 +99,15 @@ func (p *RenderPassEncoder) SetBindGroup(index uint32, group *BindGroup, offsets
 	p.binder.assign(index, group.layout)
 	p.binder.assignBindGroup(index, group)
 	p.trackRef(group.ref)
+	// Clone individual buffer ResourceRefs to keep them alive until GPU completes.
+	// Matches Rust wgpu merge_bind_group → ResourceMetadata.insert(Arc<Buffer>).
+	// Without this, Buffer.Release() before Submit can HAL-destroy buffers
+	// that are still referenced by a pending command buffer.
+	for _, buf := range group.boundBuffers {
+		if buf.core != nil && buf.core.Ref != nil {
+			p.trackRef(buf.core.Ref)
+		}
+	}
 	// Track bind group itself for submit-time validation (VAL-B5).
 	p.encoder.trackBindGroup(group)
 	// Track bind group resources for submit-time validation (VAL-A6).


### PR DESCRIPTION
## Summary

- `SetBindGroup` now calls `ResourceRef.Clone()` on each buffer in the bind group
- Prevents use-after-free: `Buffer.Release()` before `Submit()` no longer HAL-destroys buffers referenced by pending command buffers
- Matches Rust wgpu `merge_bind_group` → `ResourceMetadata.insert(Arc<Buffer>)` pattern
- Both `RenderPassEncoder` and `ComputePassEncoder` affected

## Root Cause

Previously only `BindGroup.ref` was Clone'd in `SetBindGroup`. Individual buffer refs were tracked in `usedBuffers` map for validation (VAL-A6), but NOT refcounted. If caller called `Release()` before `Submit()`, Phase 1 `Defer(lastSubmissionIndex)` could use a stale index, destroying the HAL buffer while GPU was still using it.

## Already Correct (no changes needed)

- `SetVertexBuffer` / `SetIndexBuffer` — already call `trackRef(buffer.core.Ref)`
- `CopyBufferToBuffer` — already calls `trackRef` on both src and dst

## Research

Full analysis: `docs/dev/research/RESEARCH-RESOURCE-LIFECYCLE-GO-VS-RUST.md`

## Test plan
- [x] Build: Windows, Linux
- [x] Tests: 15/15 pass
- [x] Lint: 0 issues
- [ ] CI
- [ ] Born ML training loop verification (separate)