### PR TITLE
fix(core): eliminate intermediate trackedRefs copies in pass encoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Core: pre-allocate trackedRefs slices in pass encoders** — `BeginComputePass`,
-  `BeginRenderPass`, and `CreateCommandEncoder` now pre-allocate `trackedRefs` with
-  capacity 64. Previously Phase 2 tracking (v0.28.8) used bare `append()` starting
-  from nil, causing O(log N) reallocations and abandoned backing arrays for GC. With
-  10K dispatches × 4 buffers per step, each encoder accumulated 40K pointer entries via
-  17 doublings. Pre-allocation eliminates all intermediate backing arrays.
+- **Core: eliminate intermediate trackedRefs copies in pass encoders** — Pass encoders
+  now write tracked ResourceRefs directly to the parent CommandEncoder's slice, eliminating
+  per-pass intermediate slices and the copy at End(). Previously each pass had its own
+  `trackedRefs` slice copied to the encoder via `append()` at End(), creating abandoned
+  backing arrays. Encoder pre-allocates trackedRefs with capacity 64. For Born ML (10K
+  dispatches × 4 buffers): eliminates 40K pointer copies per pass + all intermediate arrays.
+  Matches Rust wgpu where trackers live in the command encoder throughout recording.
 
 ## [0.28.9] - 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.28.10] - 2026-05-26
+## [0.28.11] - 2026-05-26
 
 ### Fixed
 
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   backing arrays. Encoder pre-allocates trackedRefs with capacity 64. For Born ML (10K
   dispatches × 4 buffers): eliminates 40K pointer copies per pass + all intermediate arrays.
   Matches Rust wgpu where trackers live in the command encoder throughout recording.
+
+## [0.28.10] - 2026-05-26
+
+### Fixed
+
+- **Core: pre-allocate trackedRefs slices in pass encoders** — `BeginComputePass`,
+  `BeginRenderPass`, and `CreateCommandEncoder` now pre-allocate `trackedRefs` with
+  capacity 64.
 
 ## [0.28.9] - 2026-05-26
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.28.10
+## Current State: v0.28.11
 
 ✅ **All 5 HAL backends complete** (~127K LOC)
 ✅ **Three-layer WebGPU stack** — wgpu API → wgpu/core → wgpu/hal
@@ -151,6 +151,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.28.11** | 2026-05 | Core: direct-write trackedRefs (pass → encoder, zero intermediate copies). |
 | **v0.28.10** | 2026-05 | Core: pre-allocate trackedRefs in pass encoders (ML OOM fix). |
 | **v0.28.9** | 2026-05 | Core: refcount-driven Buffer destruction via onZero (Rust Drop parity). Eliminates Phase 1 stale index risk. |
 | **v0.28.8** | 2026-05 | Core: Clone buffer ResourceRefs in SetBindGroup — prevents use-after-free (Rust wgpu parity). |

--- a/computepass_native.go
+++ b/computepass_native.go
@@ -41,19 +41,16 @@ type ComputePassEncoder struct {
 	// binder tracks bind group assignments and validates compatibility
 	// at dispatch time, matching Rust wgpu-core's Binder pattern.
 	binder binder
-	// trackedRefs accumulates Clone'd ResourceRefs for resources used in
-	// this compute pass. Transferred to the parent CommandEncoder on End().
-	// Phase 2: per-command-buffer resource tracking.
-	trackedRefs []*core.ResourceRef
 }
 
-// trackRef Clone()'s a ResourceRef and accumulates it for later transfer
-// to the parent CommandEncoder. This keeps the resource alive until the
-// GPU completes the submission containing this compute pass.
+// trackRef Clone()'s a ResourceRef and appends directly to the parent
+// CommandEncoder's trackedRefs. Eliminates intermediate pass-level slice
+// and the copy at End(). Matches Rust where trackers live in the command
+// encoder throughout recording — no per-pass intermediate storage.
 func (p *ComputePassEncoder) trackRef(ref *core.ResourceRef) {
 	if ref != nil {
 		ref.Clone()
-		p.trackedRefs = append(p.trackedRefs, ref)
+		p.encoder.trackedRefs = append(p.encoder.trackedRefs, ref)
 	}
 }
 
@@ -374,10 +371,5 @@ func (p *ComputePassEncoder) restoreComputeState(raw hal.ComputePassEncoder) {
 
 // End ends the compute pass.
 func (p *ComputePassEncoder) End() error {
-	// Transfer tracked refs to parent CommandEncoder before ending.
-	if len(p.trackedRefs) > 0 {
-		p.encoder.trackedRefs = append(p.encoder.trackedRefs, p.trackedRefs...)
-		p.trackedRefs = nil
-	}
 	return p.core.End()
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -276,6 +276,8 @@ Backend.CreateInstance()
 
 Resources should be explicitly Released for deterministic cleanup. Buffer destruction is **refcount-driven** (Rust `Arc<Buffer>` Drop parity): `ResourceRef.Clone()` during encoding (SetBindGroup, SetVertexBuffer, CopyBufferToBuffer), `Drop()` on GPU completion via `DestroyQueue.Triage`. The `onZero` callback fires `core.Buffer.Destroy()` only when the last reference drops — safe even if `Release()` is called before `Submit()`. `runtime.AddCleanup` (Go 1.24+) provides a GC-based safety net: unreleased resources trigger `Ref.Drop()` when collected, with `slog.Warn` for leak detection (ADR-018).
 
+**Tracking architecture:** Pass encoders (ComputePassEncoder, RenderPassEncoder) write tracked ResourceRefs directly to the parent CommandEncoder's `trackedRefs` slice — no per-pass intermediate storage. At `Finish()`, the slice moves to CommandBuffer; at `Submit()`, to `DestroyQueue.TrackSubmission`. This matches Rust wgpu where trackers live in the command encoder throughout recording (zero intermediate copies, zero abandoned backing arrays).
+
 ## Pure Go Approach
 
 All backends are implemented without CGO:

--- a/encoder_native.go
+++ b/encoder_native.go
@@ -118,11 +118,7 @@ func (e *CommandEncoder) BeginRenderPass(desc *RenderPassDescriptor) (*RenderPas
 		return nil, err
 	}
 
-	return &RenderPassEncoder{
-		core:        corePass,
-		encoder:     e,
-		trackedRefs: make([]*core.ResourceRef, 0, 64),
-	}, nil
+	return &RenderPassEncoder{core: corePass, encoder: e}, nil
 }
 
 // BeginComputePass begins a compute pass.
@@ -143,11 +139,7 @@ func (e *CommandEncoder) BeginComputePass(desc *ComputePassDescriptor) (*Compute
 		return nil, err
 	}
 
-	return &ComputePassEncoder{
-		core:        corePass,
-		encoder:     e,
-		trackedRefs: make([]*core.ResourceRef, 0, 64),
-	}, nil
+	return &ComputePassEncoder{core: corePass, encoder: e}, nil
 }
 
 // CopyBufferToBuffer copies data between buffers.

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -5,6 +5,7 @@ package wgpu_test
 import (
 	"testing"
 
+	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu"
 )
 
@@ -335,6 +336,105 @@ func TestCommandBufferReleaseFull(t *testing.T) {
 	}
 }
 
+// TestComputePass_DirectWriteTrackedRefs verifies that ComputePassEncoder.trackRef
+// writes directly to the parent CommandEncoder's trackedRefs (not a pass-level
+// intermediate slice). This eliminates per-pass backing array allocations and
+// the copy at End(). Matches Rust wgpu tracker architecture.
+func TestComputePass_DirectWriteTrackedRefs(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	// Before compute pass, encoder has no tracked refs.
+	if refs := enc.TestTrackedRefs(); len(refs) != 0 {
+		t.Fatalf("encoder should have 0 tracked refs before pass, got %d", len(refs))
+	}
+
+	pass, err := enc.BeginComputePass(nil)
+	if err != nil {
+		t.Fatalf("BeginComputePass: %v", err)
+	}
+
+	// Create a bind group with a buffer to trigger trackRef in SetBindGroup.
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "direct-write-buf",
+		Size:  64,
+		Usage: wgpu.BufferUsageStorage,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	layout, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "direct-write-bgl",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{Binding: 0, Visibility: wgpu.ShaderStageCompute,
+				Buffer: &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeStorage}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer layout.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "direct-write-bg",
+		Layout: layout,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: buf, Size: 64},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	defer bg.Release()
+
+	pass.SetBindGroup(0, bg, nil)
+
+	// After SetBindGroup INSIDE the pass, encoder should already have tracked refs
+	// (direct write, no intermediate pass-level slice).
+	refsBeforeEnd := enc.TestTrackedRefs()
+	if len(refsBeforeEnd) == 0 {
+		t.Log("encoder tracked refs empty — may be mock device without ResourceRef")
+	} else {
+		t.Logf("encoder has %d tracked refs after SetBindGroup (before End)", len(refsBeforeEnd))
+	}
+
+	if err := pass.End(); err != nil {
+		t.Fatalf("End: %v", err)
+	}
+
+	// After End(), encoder refs should be the SAME count (no additional copy).
+	refsAfterEnd := enc.TestTrackedRefs()
+	if len(refsAfterEnd) != len(refsBeforeEnd) {
+		t.Errorf("encoder refs changed at End(): before=%d, after=%d (should be same — direct write)",
+			len(refsBeforeEnd), len(refsAfterEnd))
+	}
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// After Finish, encoder should be nil (transferred to CB).
+	if enc.TestTrackedRefs() != nil {
+		t.Error("encoder should have nil trackedRefs after Finish")
+	}
+
+	// CommandBuffer should carry all refs.
+	if cbRefs := cmdBuf.TestTrackedRefs(); len(refsBeforeEnd) > 0 && len(cbRefs) == 0 {
+		t.Error("command buffer should carry tracked refs")
+	}
+
+	cmdBuf.Release()
+}
+
 func TestCommandBufferReleaseNil(t *testing.T) {
 	// Release on nil CommandBuffer should not panic.
 	var cb *wgpu.CommandBuffer
@@ -510,4 +610,108 @@ func TestCopyTextureToBufferReleasedEncoder(t *testing.T) {
 
 	// CopyTextureToBuffer on released encoder is a no-op.
 	enc.CopyTextureToBuffer(nil, nil, nil)
+}
+
+// BenchmarkComputePassTrackedRefs measures allocation overhead of Phase 2
+// resource tracking in a Born ML-like workload: N dispatches per pass,
+// each SetBindGroup tracking ~2 refs (BindGroup + Buffer).
+func BenchmarkComputePassTrackedRefs(b *testing.B) {
+	inst, err := wgpu.CreateInstance(nil)
+	if err != nil {
+		b.Fatalf("CreateInstance: %v", err)
+	}
+	defer inst.Release()
+
+	adapter, err := inst.RequestAdapter(nil)
+	if err != nil {
+		b.Fatalf("RequestAdapter: %v", err)
+	}
+	defer adapter.Release()
+
+	device, err := adapter.RequestDevice(nil)
+	if err != nil {
+		b.Fatalf("RequestDevice: %v", err)
+	}
+	defer device.Release()
+
+	q := device.Queue()
+	if q == nil {
+		b.Skip("skipping: device has no HAL integration")
+	}
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "bench-buf",
+		Size:  64,
+		Usage: wgpu.BufferUsageStorage,
+	})
+	if err != nil {
+		b.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	layout, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "bench-bgl",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{Binding: 0, Visibility: wgpu.ShaderStageCompute,
+				Buffer: &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeStorage}},
+		},
+	})
+	if err != nil {
+		b.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer layout.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "bench-bg",
+		Layout: layout,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: buf, Size: 64},
+		},
+	})
+	if err != nil {
+		b.Fatalf("CreateBindGroup: %v", err)
+	}
+	defer bg.Release()
+
+	// Baseline: encoder lifecycle without SetBindGroup.
+	b.Run("baseline-no-bindgroup", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			enc, _ := device.CreateCommandEncoder(nil)
+			pass, _ := enc.BeginComputePass(nil)
+			pass.End()
+			cb, _ := enc.Finish()
+			cb.Release()
+		}
+	})
+
+	// 100 SetBindGroup calls (Born ML: ~100 dispatches per encoder).
+	b.Run("100-setbindgroup", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			enc, _ := device.CreateCommandEncoder(nil)
+			pass, _ := enc.BeginComputePass(nil)
+			for j := 0; j < 100; j++ {
+				pass.SetBindGroup(0, bg, nil)
+			}
+			pass.End()
+			cb, _ := enc.Finish()
+			cb.Release()
+		}
+	})
+
+	// 1000 SetBindGroup calls (stress test).
+	b.Run("1000-setbindgroup", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			enc, _ := device.CreateCommandEncoder(nil)
+			pass, _ := enc.BeginComputePass(nil)
+			for j := 0; j < 1000; j++ {
+				pass.SetBindGroup(0, bg, nil)
+			}
+			pass.End()
+			cb, _ := enc.Finish()
+			cb.Release()
+		}
+	})
 }

--- a/renderpass_native.go
+++ b/renderpass_native.go
@@ -52,19 +52,14 @@ type RenderPassEncoder struct {
 	// blendConstantSet tracks whether SetBlendConstant has been called.
 	// Matches Rust wgpu-core OptionalState for blend_constant.
 	blendConstantSet bool
-	// trackedRefs accumulates Clone'd ResourceRefs for resources used in
-	// this render pass. Transferred to the parent CommandEncoder on End().
-	// Phase 2: per-command-buffer resource tracking.
-	trackedRefs []*core.ResourceRef
 }
 
-// trackRef Clone()'s a ResourceRef and accumulates it for later transfer
-// to the parent CommandEncoder. This keeps the resource alive until the
-// GPU completes the submission containing this render pass.
+// trackRef Clone()'s a ResourceRef and appends directly to the parent
+// CommandEncoder's trackedRefs. No intermediate pass-level slice.
 func (p *RenderPassEncoder) trackRef(ref *core.ResourceRef) {
 	if ref != nil {
 		ref.Clone()
-		p.trackedRefs = append(p.trackedRefs, ref)
+		p.encoder.trackedRefs = append(p.encoder.trackedRefs, ref)
 	}
 }
 
@@ -341,10 +336,5 @@ func (p *RenderPassEncoder) DrawIndexedIndirect(buffer *Buffer, offset uint64) {
 // End ends the render pass.
 // After this call, the encoder cannot be used again.
 func (p *RenderPassEncoder) End() error {
-	// Transfer tracked refs to parent CommandEncoder before ending.
-	if len(p.trackedRefs) > 0 {
-		p.encoder.trackedRefs = append(p.encoder.trackedRefs, p.trackedRefs...)
-		p.trackedRefs = nil
-	}
 	return p.core.End()
 }


### PR DESCRIPTION
## Summary

Replaces v0.28.10 pre-alloc approach with proper enterprise fix: pass encoders write ResourceRefs directly to parent CommandEncoder's slice. No intermediate pass-level slices, no copy at End().

**Before:** pass.trackedRefs → append to encoder at End() → copy to CB → allRefs (3 copies, 3 abandoned backing arrays)

**After:** encoder.trackedRefs (direct write from pass) → move to CB → allRefs (1 pre-alloc, 0 intermediate arrays)

-25 lines net. Matches Rust wgpu where trackers live in the command encoder throughout recording.

## Test plan
- [x] Build + Tests: 15/15
- [x] Lint: 0 issues
- [ ] CI
- [ ] Born ML pprof