### PR TITLE
chore(deps): go-webgpu/webgpu v0.5.1 → v0.5.2 (v0.29.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.1] - 2026-05-27
+
+### Changed
+
+- **deps:** go-webgpu/webgpu v0.5.1 → v0.5.2
+
 ## [0.29.0] - 2026-05-27
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/wgpu
 go 1.25.0
 
 require (
-	github.com/go-webgpu/webgpu v0.5.1
+	github.com/go-webgpu/webgpu v0.5.2
 	github.com/gogpu/gputypes v0.5.0
 	github.com/gogpu/naga v0.17.13
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/go-webgpu/webgpu v0.5.0 h1:2d58oSZuOCkGMVFF2PO7YO8Dmk7BORkrlxfHESCqXT
 github.com/go-webgpu/webgpu v0.5.0/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/go-webgpu/webgpu v0.5.1 h1:qJ0UM6Hg6ryMGphpa9+uj6L+ExvmFMj13iUrr6HA3G8=
 github.com/go-webgpu/webgpu v0.5.1/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
+github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
+github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
 github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.13 h1:VlponVgD1fEfNotx0874M4n7tnfum8YlMEB3pBdd2Ps=


### PR DESCRIPTION
Dep bump only. go-webgpu/webgpu v0.5.2 released.