### PR TITLE
fix(vulkan): VK_ERROR_SURFACE_LOST_KHR handling + goffi v0.5.3 (v0.29.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.2] - 2026-06-05
+
+### Fixed
+
+- **Vulkan: comprehensive VK_ERROR_SURFACE_LOST_KHR handling (Rust wgpu parity)** —
+  `acquireNextImage`, `present`, and `createSwapchain` now handle
+  `VK_ERROR_SURFACE_LOST_KHR` → `hal.ErrSurfaceLost` in all code paths, matching
+  Rust wgpu-hal `native.rs` (acquire line 452, present line 584, create line 228).
+  Added defensive `sc.handle == 0` guard in `present()`. Triggered by Wayland
+  SIGSEGV investigation (gogpu#292) — two users on Intel ANV and AMD RADV confirmed
+  crash in `vkQueuePresentKHR`. While the root cause is in gogpu's Wayland surface
+  lifecycle (missing configure gate + thread safety), robust error handling in the
+  Vulkan HAL prevents future crashes from surfacing as segfaults.
+
+### Changed
+
+- **deps:** goffi v0.5.2 → v0.5.3
+
 ## [0.29.1] - 2026-05-27
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,6 @@ require (
 )
 
 require (
-	github.com/go-webgpu/goffi v0.5.2 // indirect
+	github.com/go-webgpu/goffi v0.5.3 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/go-webgpu/goffi v0.5.2 h1:Kq2llPlA6IhkkmAffkM5CtsgaXuBQC4mBI0BOREwV04=
 github.com/go-webgpu/goffi v0.5.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.5.3 h1:Ckc94SdHO42bIb0oEapRIcv+jKjhjGJfb9zPEvNKC7U=
+github.com/go-webgpu/goffi v0.5.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.0 h1:2d58oSZuOCkGMVFF2PO7YO8Dmk7BORkrlxfHESCqXT4=
 github.com/go-webgpu/webgpu v0.5.0/go.mod h1:HNIBiaMJNdPeQd6hmHdQsXg4t4R99xVQybnoDGOShe0=
 github.com/go-webgpu/webgpu v0.5.1 h1:qJ0UM6Hg6ryMGphpa9+uj6L+ExvmFMj13iUrr6HA3G8=

--- a/hal/vulkan/swapchain.go
+++ b/hal/vulkan/swapchain.go
@@ -99,6 +99,9 @@ func (s *Surface) createSwapchain(device *Device, config *hal.SurfaceConfigurati
 	var capabilities vk.SurfaceCapabilitiesKHR
 	result := vkGetPhysicalDeviceSurfaceCapabilitiesKHR(s.instance, device.physicalDevice, s.handle, &capabilities)
 	if result != vk.Success {
+		if result == vk.ErrorSurfaceLostKhr {
+			return hal.ErrSurfaceLost
+		}
 		return fmt.Errorf("vulkan: vkGetPhysicalDeviceSurfaceCapabilitiesKHR failed: %d", result)
 	}
 
@@ -200,7 +203,12 @@ func (s *Surface) createSwapchain(device *Device, config *hal.SurfaceConfigurati
 	var swapchainHandle vk.SwapchainKHR
 	result = vkCreateSwapchainKHR(device, &createInfo, nil, &swapchainHandle)
 	if result != vk.Success {
-		return fmt.Errorf("vulkan: vkCreateSwapchainKHR failed: %d", result)
+		switch result {
+		case vk.ErrorSurfaceLostKhr, vk.ErrorInitializationFailed:
+			return hal.ErrSurfaceLost
+		default:
+			return fmt.Errorf("vulkan: vkCreateSwapchainKHR failed: %d", result)
+		}
 	}
 
 	// Destroy old swapchain AFTER creating new (Vulkan requirement)
@@ -538,6 +546,10 @@ func (sc *Swapchain) acquireNextImage() (*SwapchainTexture, bool, error) {
 		// Surface needs reconfiguration
 		// (wgpu: returns Err(Outdated))
 		return nil, false, hal.ErrSurfaceOutdated
+	case vk.ErrorSurfaceLostKhr:
+		// Surface destroyed (e.g., Wayland compositor killed it).
+		// (wgpu: returns Err(Lost))
+		return nil, false, hal.ErrSurfaceLost
 	default:
 		return nil, false, fmt.Errorf("vulkan: vkAcquireNextImageKHR failed: %d", result)
 	}
@@ -587,6 +599,9 @@ func (sc *Swapchain) acquireNextImage() (*SwapchainTexture, bool, error) {
 func (sc *Swapchain) present(queue *Queue, damageRects []image.Rectangle) error {
 	if !sc.imageAcquired {
 		return fmt.Errorf("vulkan: no image acquired to present")
+	}
+	if sc.handle == 0 {
+		return hal.ErrSurfaceLost
 	}
 
 	// BUG-WGPU-VK-006: Ensure the swapchain image is in PRESENT_SRC_KHR layout
@@ -654,6 +669,8 @@ func (sc *Swapchain) present(queue *Queue, damageRects []image.Rectangle) error 
 		return nil
 	case vk.ErrorOutOfDateKhr:
 		return hal.ErrSurfaceOutdated
+	case vk.ErrorSurfaceLostKhr:
+		return hal.ErrSurfaceLost
 	default:
 		return fmt.Errorf("vulkan: vkQueuePresentKHR failed: %d", result)
 	}


### PR DESCRIPTION
## Summary

- Comprehensive `VK_ERROR_SURFACE_LOST_KHR` handling in Vulkan HAL — Rust wgpu-hal parity (`native.rs` acquire/present/createSwapchain)
- Defensive `sc.handle == 0` guard in `present()`
- goffi v0.5.2 → v0.5.3

## Context

Triggered by Wayland SIGSEGV investigation (gogpu#292). Two independent users (Intel ANV + AMD RADV) confirmed crash in `vkQueuePresentKHR`. Root cause is in gogpu's Wayland surface lifecycle, but robust error handling in the Vulkan HAL prevents future crashes from surfacing as segfaults.

## Test plan

- [x] `go build ./...` (Windows, Linux, macOS cross-compile)
- [x] `go test ./...` — all pass
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [ ] CI green