### PR TITLE
fix(gles): fence sync ordering — glFenceSync before glFlush (v0.29.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.5] - 2026-06-06
+
+### Fixed
+
+- **GLES: fence sync ordering — glFenceSync before glFlush (Rust parity)** —
+  `Queue.Submit()` called `glFlush()` before `fence.Signal()` (`glFenceSync`),
+  leaving the fence in an unflushed client-side buffer. `PollCompleted()` uses
+  non-blocking `glGetSynciv` (no implicit flush), so the fence returned
+  `GL_UNSIGNALED` indefinitely — stalling deferred resource destruction in
+  headless/compute workloads. Headed rendering was unaffected (`SwapBuffers`
+  provides implicit flush). Reordered to match Rust wgpu-hal `queue.rs:1915-1921`:
+  `fence.Maintain` → `fence.Signal` → `glFlush`. Confirmed by ANGLE bug 6464
+  (Samsung deadlock in production), virglrenderer commit `21bbc9ea` (Windows/macOS
+  stalls), Mesa Gallium (internally flushes in `glFenceSync`, masking the bug on
+  Linux). Affects both Windows WGL and Linux EGL paths.
+- **GLES: remove redundant Maintain() from PollCompleted** — Rust wgpu-hal only
+  calls `get_latest()` in the poll path (`device.rs:1564`); fence cleanup happens
+  during `Submit()`. Removes double `GetLatest()` per poll cycle.
+
 ## [0.29.4] - 2026-06-06
 
 ### Fixed

--- a/hal/gles/queue.go
+++ b/hal/gles/queue.go
@@ -26,7 +26,7 @@ type Queue struct {
 
 // Submit submits command buffers to the GPU.
 // Acquires the AdapterContext lock, makes context current on hidden window DC,
-// executes all GL commands, flushes, and signals the fence.
+// executes all GL commands, signals the fence, and flushes.
 func (q *Queue) Submit(commandBuffers []hal.CommandBuffer) (uint64, error) {
 	glCtx := q.ctx.Lock()
 	defer q.ctx.Unlock()
@@ -45,23 +45,29 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer) (uint64, error) {
 		}
 	}
 
-	glCtx.Flush()
-
 	q.submissionIndex++
 
+	// Rust wgpu-hal queue.rs:1915-1921: fence.maintain → fence.signal → gl.flush.
+	// FenceSync must be inserted BEFORE Flush so the sync object tracks the
+	// commands being flushed. Flushing first would leave the fence un-flushed.
 	if q.fence != nil {
+		q.fence.Maintain()
 		q.fence.Signal(q.submissionIndex)
 	}
+
+	glCtx.Flush()
 
 	return q.submissionIndex, nil
 }
 
 // PollCompleted returns the highest submission index known to be completed.
-// When GL fence sync is available, polls pending sync objects. Otherwise,
-// assumes all work is complete after Flush (GLES is synchronous).
+// Polls pending GL sync objects via glGetSynciv (non-blocking, no flush).
+// Safe because Submit() always flushes after inserting the fence — the fence
+// is guaranteed to be in the GPU command queue by the time we poll it.
+// Maintenance (cleanup of completed sync objects) happens in Submit(), not here
+// (matches Rust wgpu-hal device.rs:1564 get_fence_value).
 func (q *Queue) PollCompleted() uint64 {
 	if q.fence != nil {
-		q.fence.Maintain()
 		return q.fence.GetLatest()
 	}
 	return q.submissionIndex

--- a/hal/gles/queue_linux.go
+++ b/hal/gles/queue_linux.go
@@ -25,8 +25,8 @@ type Queue struct {
 }
 
 // Submit submits command buffers to the GPU.
-// After executing all commands and flushing, signals the fence with a GL sync object
-// so that fence wait/poll can track actual GPU completion.
+// After executing all commands, signals the fence with a GL sync object then
+// flushes — the fence must precede flush so PollCompleted sees it.
 func (q *Queue) Submit(commandBuffers []hal.CommandBuffer) (uint64, error) {
 	for _, cb := range commandBuffers {
 		cmdBuf, ok := cb.(*CommandBuffer)
@@ -43,25 +43,29 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer) (uint64, error) {
 		}
 	}
 
-	// Flush GL commands
-	q.glCtx.Flush()
-
 	q.submissionIndex++
 
-	// Signal the fence with a GL sync object at this submission index.
+	// Rust wgpu-hal queue.rs:1915-1921: fence.maintain → fence.signal → gl.flush.
+	// FenceSync must be inserted BEFORE Flush so the sync object tracks the
+	// commands being flushed. Flushing first would leave the fence un-flushed.
 	if q.fence != nil {
+		q.fence.Maintain()
 		q.fence.Signal(q.submissionIndex)
 	}
+
+	q.glCtx.Flush()
 
 	return q.submissionIndex, nil
 }
 
 // PollCompleted returns the highest submission index known to be completed.
-// When GL fence sync is available, polls pending sync objects. Otherwise,
-// assumes all work is complete after Flush (GLES is synchronous).
+// Polls pending GL sync objects via glGetSynciv (non-blocking, no flush).
+// Safe because Submit() always flushes after inserting the fence — the fence
+// is guaranteed to be in the GPU command queue by the time we poll it.
+// Maintenance (cleanup of completed sync objects) happens in Submit(), not here
+// (matches Rust wgpu-hal device.rs:1564 get_fence_value).
 func (q *Queue) PollCompleted() uint64 {
 	if q.fence != nil {
-		q.fence.Maintain()
 		return q.fence.GetLatest()
 	}
 	return q.submissionIndex

--- a/hal/gles/resource.go
+++ b/hal/gles/resource.go
@@ -261,7 +261,8 @@ func NewFence(glCtx *gl.Context) *Fence {
 }
 
 // Signal inserts a GL fence sync object into the command stream at the given value.
-// Must be called on the GL thread after glFlush.
+// Must be called on the GL thread BEFORE glFlush — the flush sends both the
+// preceding commands and this fence to the GPU together.
 // Matches Rust wgpu-hal/src/gles/fence.rs Fence::signal.
 func (f *Fence) Signal(value uint64) {
 	if f.glCtx == nil || !f.glCtx.SupportsFenceSync() {


### PR DESCRIPTION
## Summary

- **Fix GLES fence ordering bug** — `glFenceSync` was called AFTER `glFlush`, leaving the fence unflushed. Now correctly inserts fence BEFORE flush (Rust wgpu-hal `queue.rs:1915-1921` parity)
- **Remove redundant `Maintain()` from `PollCompleted`** — Rust only calls `get_latest()` in poll path; maintenance happens in `Submit()` (Rust `device.rs:1564`)

## Bug details

`Submit()` did `glFlush()` → `fence.Signal()` (inserts `glFenceSync`). The fence ended up in an unflushed client-side command buffer. `PollCompleted()` uses `glGetSynciv` (non-blocking, no flush) — the unflushed fence returns `UNSIGNALED` forever.

**Impact:** deferred resource destruction stalls in headless/compute-only workloads (no SwapBuffers to trigger implicit flush). In headed rendering, SwapBuffers masks the bug.

**Confirmed by enterprise references:**
- ANGLE (Chromium) bug 6464 — Samsung found deadlock in World Cricket Championship 2
- Virglrenderer commit 21bbc9ea — same fix for Windows/macOS stalls
- Mesa Gallium — internally flushes in glFenceSync, masking the bug on Linux
- Rust wgpu-hal — explicit comment: "extremely important, fences may never be signaled in headless contexts"

## Test plan

- [x] `go build ./...` (Windows, Linux, macOS)
- [x] `go test ./...` — 15/15 pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [x] `gofmt -l .` — clean
