### PR TITLE
fix(gles): Fence.Signal returns error on glFenceSync failure (v0.29.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.6] - 2026-06-06
+
+### Fixed
+
+- **GLES: Fence.Signal returns error on glFenceSync failure (Rust parity)** —
+  `Fence.Signal()` silently fell back to marking submissions as immediately
+  complete when `glFenceSync` returned 0 (OOM). Now returns `error`, propagated
+  through `Queue.Submit()`. Matches Rust wgpu-hal `fence.rs:37-52` which returns
+  `Result<(), DeviceError::OutOfMemory>`.
+
 ## [0.29.5] - 2026-06-06
 
 ### Fixed

--- a/hal/gles/queue.go
+++ b/hal/gles/queue.go
@@ -52,7 +52,9 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer) (uint64, error) {
 	// commands being flushed. Flushing first would leave the fence un-flushed.
 	if q.fence != nil {
 		q.fence.Maintain()
-		q.fence.Signal(q.submissionIndex)
+		if err := q.fence.Signal(q.submissionIndex); err != nil {
+			return 0, err
+		}
 	}
 
 	glCtx.Flush()

--- a/hal/gles/queue_linux.go
+++ b/hal/gles/queue_linux.go
@@ -50,7 +50,9 @@ func (q *Queue) Submit(commandBuffers []hal.CommandBuffer) (uint64, error) {
 	// commands being flushed. Flushing first would leave the fence un-flushed.
 	if q.fence != nil {
 		q.fence.Maintain()
-		q.fence.Signal(q.submissionIndex)
+		if err := q.fence.Signal(q.submissionIndex); err != nil {
+			return 0, err
+		}
 	}
 
 	q.glCtx.Flush()

--- a/hal/gles/resource.go
+++ b/hal/gles/resource.go
@@ -6,6 +6,7 @@
 package gles
 
 import (
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -263,20 +264,19 @@ func NewFence(glCtx *gl.Context) *Fence {
 // Signal inserts a GL fence sync object into the command stream at the given value.
 // Must be called on the GL thread BEFORE glFlush — the flush sends both the
 // preceding commands and this fence to the GPU together.
+// Returns an error if glFenceSync fails (typically OOM).
 // Matches Rust wgpu-hal/src/gles/fence.rs Fence::signal.
-func (f *Fence) Signal(value uint64) {
+func (f *Fence) Signal(value uint64) error {
 	if f.glCtx == nil || !f.glCtx.SupportsFenceSync() {
-		// Fallback: no fence sync support, mark as immediately complete.
 		f.lastCompleted.Store(value)
-		return
+		return nil
 	}
 	sync := f.glCtx.FenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0)
 	if sync == 0 {
-		// Fence creation failed — mark as immediately complete to avoid deadlock.
-		f.lastCompleted.Store(value)
-		return
+		return fmt.Errorf("gles: glFenceSync failed (OOM)")
 	}
 	f.pending = append(f.pending, glFence{sync: sync, value: value})
+	return nil
 }
 
 // GetLatest polls pending sync objects and returns the highest completed value.


### PR DESCRIPTION
## Summary

- **Fence.Signal returns error on glFenceSync failure** — previously silently fell back to marking submissions as immediately complete when `glFenceSync` returned 0 (OOM). Now returns `error`, propagated through `Queue.Submit()`. Matches Rust wgpu-hal `fence.rs:37-52` (`Result<(), DeviceError::OutOfMemory>`).

Follow-up to v0.29.5 fence ordering fix — found during method-by-method Rust lifecycle comparison.

## Test plan

- [x] `go build ./...` (Windows, Linux, macOS)
- [x] `go test ./...` — 15/15 pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
