### PR TITLE
fix(software): eager Wayland wl_shm init in Configure — fix SIGSEGV (v0.29.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.7] - 2026-06-06
+
+### Fixed
+
+- **Software: eager Wayland wl_shm init in Configure — fix SIGSEGV (gogpu#292)** —
+  `obtainWlShm()` called `wl_display_roundtrip()` on the render thread during first
+  present, concurrent with the main thread's Wayland event dispatch. Two concurrent
+  dispatches on the same `wl_display` corrupt proxy state → SIGSEGV at offset 0x18
+  (`wl_proxy.display` field from NULL). Moved detection + wl_shm binding to
+  `Configure()` on the main thread, before the event loop starts. Enterprise
+  references unanimously do this during init: GLFW (`glfwInit`, `wl_init.c:568`),
+  SDL3 (`SDL_Init`, `SDL_waylandvideo.c:1548`), Qt6 (`QWaylandDisplay()`,
+  `qwaylanddisplay.cpp:531` — explicit comment about this exact race), winit
+  (`EventLoop::new`, `event_loop/mod.rs:92`). Affects both @lkmavi (ARM64 Fedora)
+  and @omer316 (x86_64 Pop!_OS) from gogpu#292.
+
 ## [0.29.6] - 2026-06-06
 
 ### Fixed

--- a/hal/software/blit_darwin.go
+++ b/hal/software/blit_darwin.go
@@ -84,6 +84,9 @@ func (p *platformBlit) onceInit() bool {
 	return p.isInitialized
 }
 
+// configurePlatformBlit is a no-op on macOS (no Wayland).
+func (s *Surface) configurePlatformBlit() {}
+
 // createPlatformFramebuffer returns nil — use Go heap memory.
 func (s *Surface) createPlatformFramebuffer(_, _ int32) []byte { return nil }
 

--- a/hal/software/blit_linux.go
+++ b/hal/software/blit_linux.go
@@ -194,7 +194,34 @@ func initX11() {
 // Embedded in Surface via build tags.
 type platformBlit struct {
 	gc      uintptr          // X11 GC (Graphics Context), lazy-initialized on first blit
-	wlState waylandBlitState // Wayland SHM state (lazy-initialized on first Wayland blit)
+	wlState waylandBlitState // Wayland SHM state, initialized eagerly in Configure
+}
+
+// configurePlatformBlit detects Wayland vs X11 and eagerly obtains wl_shm.
+// Called from Configure() on the MAIN thread, before the event loop or render
+// thread calls Present. This eliminates the race between wl_display_roundtrip
+// (in obtainWlShm) and concurrent wl_display_dispatch (in gogpu event loop).
+//
+// Enterprise references unanimously do this during init, not first present:
+//   - GLFW: wl_shm bound in glfwInit(), fatal error if missing (wl_init.c:568)
+//   - SDL3: wl_shm bound in SDL_Init(SDL_INIT_VIDEO) (SDL_waylandvideo.c:1548)
+//   - Qt6:  wl_shm bound in QWaylandDisplay(), before EventThread.start()
+//     (qwaylanddisplay.cpp:531 — explicit comment about this race)
+//   - winit: wl_shm bound in EventLoop::new(), before calloop (event_loop/mod.rs:92)
+//
+// See BUG-SW-WAYLAND-001: obtainWlShm lazy init → SIGSEGV on Wayland (gogpu#292).
+func (s *Surface) configurePlatformBlit() {
+	if s.displayHandle == 0 {
+		return
+	}
+	if !s.wlState.detected {
+		s.wlState.detected = true
+		s.wlState.isWayland = isWaylandDisplay()
+		if s.wlState.isWayland {
+			s.wlState.wlShm = obtainWlShm(s.displayHandle)
+			s.wlState.shmQueue = createShmQueue(s.displayHandle)
+		}
+	}
 }
 
 // createPlatformFramebuffer returns nil on Linux — we use Go heap memory
@@ -246,21 +273,7 @@ func (s *Surface) blitFramebufferToWindow(data []byte, width, height int32) {
 		return
 	}
 
-	// Detect Wayland vs X11 on first blit. Eagerly obtain wl_shm here
-	// to avoid a wl_display_roundtrip in the present hot path.
-	// NOTE: blitFramebufferToWindow is called on the render thread
-	// (from Queue.Present), not the main thread. Full thread safety
-	// requires gogpu threading model work (BUG-WL-001).
-	if !s.wlState.detected {
-		s.wlState.detected = true
-		s.wlState.isWayland = isWaylandDisplay()
-		if s.wlState.isWayland {
-			s.wlState.wlShm = obtainWlShm(s.displayHandle)
-			s.wlState.shmQueue = createShmQueue(s.displayHandle)
-		}
-	}
-
-	// Route to Wayland SHM path if display is Wayland.
+	// Wayland detected eagerly in Configure (configurePlatformBlit).
 	if s.wlState.isWayland {
 		s.waylandPresent(data, width, height)
 		return
@@ -358,17 +371,7 @@ func (s *Surface) blitDamageRectsToWindow(data []byte, width, height int32, rect
 		return
 	}
 
-	// Detect Wayland vs X11 on first blit (same eager init as blitFramebufferToWindow).
-	if !s.wlState.detected {
-		s.wlState.detected = true
-		s.wlState.isWayland = isWaylandDisplay()
-		if s.wlState.isWayland {
-			s.wlState.wlShm = obtainWlShm(s.displayHandle)
-			s.wlState.shmQueue = createShmQueue(s.displayHandle)
-		}
-	}
-
-	// Route to Wayland SHM damage path if display is Wayland.
+	// Wayland detected eagerly in Configure (configurePlatformBlit).
 	if s.wlState.isWayland {
 		s.waylandPresentDamage(data, width, height, rects)
 		return

--- a/hal/software/blit_other.go
+++ b/hal/software/blit_other.go
@@ -8,6 +8,9 @@ import "image"
 // Windows has GDI (blit_windows.go), Linux has X11 (blit_linux.go).
 type platformBlit struct{}
 
+// configurePlatformBlit is a no-op on unsupported platforms.
+func (s *Surface) configurePlatformBlit() {}
+
 // createPlatformFramebuffer returns nil — use Go heap memory.
 func (s *Surface) createPlatformFramebuffer(_, _ int32) []byte { return nil }
 

--- a/hal/software/blit_windows.go
+++ b/hal/software/blit_windows.go
@@ -50,6 +50,9 @@ type platformBlit struct {
 	oldBmp uintptr // previous bitmap (for cleanup)
 }
 
+// configurePlatformBlit is a no-op on Windows (no Wayland).
+func (s *Surface) configurePlatformBlit() {}
+
 // createPlatformFramebuffer creates a DIB section backed by GDI.
 // Returns the DIB pixel buffer as a Go []byte slice (zero-copy).
 // The returned slice is backed by kernel memory, not Go heap — no GC pressure.

--- a/hal/software/resource.go
+++ b/hal/software/resource.go
@@ -173,6 +173,11 @@ func (s *Surface) Configure(_ hal.Device, config *hal.SurfaceConfiguration) erro
 	s.presentMode = config.PresentMode
 	s.alphaMode = config.AlphaMode
 
+	// Detect Wayland and bind wl_shm eagerly on the main thread, before any
+	// render thread calls Present. See BUG-SW-WAYLAND-001: lazy init on first
+	// present called wl_display_roundtrip concurrent with event dispatch → SIGSEGV.
+	s.configurePlatformBlit()
+
 	// Allocate framebuffer. On Windows with a window handle, use CreateDIBSection
 	// (GDI-managed bitmap) for DWM-friendly presentation via BitBlt.
 	// This follows the SDL3/Qt6 enterprise pattern and avoids the DWM freeze


### PR DESCRIPTION
## Summary

- **Fix Wayland SIGSEGV (gogpu#292)** — `obtainWlShm()` called `wl_display_roundtrip()` on render thread during first present, concurrent with main thread event dispatch. Two concurrent dispatches on same `wl_display` → proxy corruption → SIGSEGV at offset 0x18 (`wl_proxy.display` NULL). Moved wl_shm init to `Configure()` on main thread.

## Root cause

`wl_display_roundtrip` internally does `prepare_read → read_events → dispatch_pending` (ALL queues). When the main thread simultaneously does `dispatch_queue_pending` (app queue), concurrent dispatch corrupts proxy state. This only happens on the first frame (lazy init), which is why subsequent frames work fine (no roundtrip).

## Enterprise validation

All 4 enterprise references bind wl_shm eagerly during init, NEVER on first present:

| Library | When | Reference |
|---------|------|-----------|
| GLFW | `glfwInit()` | `wl_init.c:568`, fatal if missing |
| SDL3 | `SDL_Init(SDL_INIT_VIDEO)` | `SDL_waylandvideo.c:1548` |
| Qt6 | `QWaylandDisplay()` constructor | `qwaylanddisplay.cpp:531` — explicit comment about this race |
| winit | `EventLoop::new()` | `event_loop/mod.rs:92` |

## Test plan

- [x] `go build ./...` (Windows, Linux, macOS, WASM)
- [x] `go test ./...` — 15/15 pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
- [ ] Visual: `GOGPU_GRAPHICS_API=software` on Wayland (needs Linux tester)
