### PR TITLE
chore(ci): switch Codecov to OIDC authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  id-token: write
+
 env:
   # goffi requires CGO_ENABLED=0 for pure Go FFI on Unix
   CGO_ENABLED: 0
@@ -102,11 +106,10 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v5
       with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+        use_oidc: true
         files: ./coverage.txt
         flags: unittests
         name: codecov-wgpu
-        fail_ci_if_error: true
 
   # GLES/EGL Integration Test - Linux with Mesa Surfaceless
   integration-gles:


### PR DESCRIPTION
Switch from `token: secrets.CODECOV_TOKEN` + GPG verification to `use_oidc: true`. Fixes intermittent CI failures from GPG keyserver unavailability (codecov/codecov-action#1876). Matches audio, compose, gogpu, systray, ui repos.