### PR TITLE
feat(gles): instance-level EGL context on Linux + surfaceless fallback (v0.29.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.10] - 2026-06-08
+
+### Added
+
+- **GLES: instance-level EGL context on Linux (Rust wgpu-hal parity)** —
+  `CreateInstance` now creates an EGL context via surfaceless/pbuffer at init time,
+  matching Rust wgpu-hal `egl.rs:846` and Windows hidden window pattern (v0.28.6).
+  `EnumerateAdapters` uses the instance context to return real GPU name/vendor/version
+  instead of placeholder "Unknown" values. On Wayland (no `wl_display*` at init),
+  gracefully degrades — `CreateSurface` provides context later (nil guard from PR #210).
+
+### Fixed
+
+- **GLES: EGL surfaceless context fallback (Rust wgpu-hal egl.rs:735-758 parity)** —
+  `NewContext` now checks for `EGL_KHR_surfaceless_context` or EGL 1.5+ before
+  creating pbuffer. When surfaceless is available, `MakeCurrent(EGL_NO_SURFACE)`
+  works without a dummy 1×1 pbuffer. Fallback to pbuffer on older drivers.
+- **GLES: FFI pointer convention in context_linux.go** (PR #210, @lkmavi) —
+  30+ GL calls fixed: `unsafe.Pointer(&value)` → `unsafe.Pointer(&pointer)` for
+  PointerType goffi arguments. See ADR-044. Fundamental fix enabling GLES rendering
+  on Linux for the first time.
+
 ## [0.29.9] - 2026-06-07
 
 ### Fixed

--- a/hal/gles/api_linux.go
+++ b/hal/gles/api_linux.go
@@ -26,18 +26,56 @@ func (Backend) Variant() gputypes.Backend {
 	return gputypes.BackendGL
 }
 
-// CreateInstance creates a new OpenGL instance.
+// CreateInstance creates a new OpenGL instance with an optional EGL context.
+// Attempts to create an EGL context at instance level (Rust wgpu-hal egl.rs:846
+// parity) for adapter enumeration without a surface. Uses surfaceless/pbuffer
+// context — same role as Windows hidden 1×1 HWND (v0.28.6).
+//
+// On Wayland, this may fail (EGL needs wl_display*) — that's OK, CreateSurface
+// provides the proper context later. On X11/headless, this succeeds.
 func (Backend) CreateInstance(_ *hal.InstanceDescriptor) (hal.Instance, error) {
-	// Initialize EGL on Linux
 	if err := egl.Init(); err != nil {
 		return nil, fmt.Errorf("gles: failed to initialize EGL: %w", err)
 	}
-	hal.Logger().Info("gles: instance created", "platform", "linux")
-	return &Instance{}, nil
+
+	// Try to create instance-level EGL context (Rust wgpu-hal parity).
+	// NativeDisplay=0 uses EGL_DEFAULT_DISPLAY or EGL_MESA_platform_surfaceless.
+	config := egl.DefaultContextConfig()
+	config.GLES = false
+	ctx, err := egl.NewContext(config)
+	if err != nil {
+		hal.Logger().Info("gles: instance context unavailable (expected on Wayland)", "err", err)
+		return &Instance{}, nil
+	}
+
+	if err := ctx.MakeCurrent(); err != nil {
+		ctx.Destroy()
+		hal.Logger().Warn("gles: instance context MakeCurrent failed", "err", err)
+		return &Instance{}, nil
+	}
+
+	glCtx := &gl.Context{}
+	if err := glCtx.Load(egl.GetGLProcAddress); err != nil {
+		ctx.Destroy()
+		hal.Logger().Warn("gles: instance GL load failed", "err", err)
+		return &Instance{}, nil
+	}
+
+	hal.Logger().Info("gles: instance created with EGL context",
+		"version", glCtx.GetString(gl.VERSION),
+		"renderer", glCtx.GetString(gl.RENDERER))
+
+	return &Instance{eglCtx: ctx, glCtx: glCtx}, nil
 }
 
 // Instance implements hal.Instance for the OpenGL backend on Linux.
-type Instance struct{}
+// eglCtx/glCtx are non-nil when an instance-level EGL context was created
+// successfully (X11/headless). On Wayland they may be nil — CreateSurface
+// provides the context when a window handle is available.
+type Instance struct {
+	eglCtx *egl.Context
+	glCtx  *gl.Context
+}
 
 // CreateSurface creates an OpenGL surface from window handles.
 // On Linux: displayHandle and windowHandle are platform-specific.
@@ -88,41 +126,68 @@ func (i *Instance) CreateSurface(displayHandle, windowHandle uintptr) (hal.Surfa
 }
 
 // EnumerateAdapters returns available OpenGL adapters.
-// For OpenGL, there's typically one adapter per display.
+// Uses surface context (preferred), instance context (X11/headless), or placeholder.
 func (i *Instance) EnumerateAdapters(surfaceHint hal.Surface) []hal.ExposedAdapter {
-	// If we have a surface, use its GL context for info
+	// Priority 1: surface provides the best context (has window handle)
 	if surface, ok := surfaceHint.(*Surface); ok {
+		return []hal.ExposedAdapter{surface.GetAdapterInfo()}
+	}
+
+	// Priority 2: instance-level context (created in CreateInstance via pbuffer/surfaceless)
+	if i.glCtx != nil {
 		return []hal.ExposedAdapter{
-			surface.GetAdapterInfo(),
+			makeAdapterFromGL(i.glCtx, i.eglCtx),
 		}
 	}
 
-	// Without a surface, we can't query OpenGL info
-	// Return a placeholder that will be updated when surface is created
+	// Priority 3: no context available (Wayland without surface hint)
+	// Return placeholder — Open() has nil guard from PR #210.
 	return []hal.ExposedAdapter{
 		{
 			Adapter: &Adapter{},
 			Info: gputypes.AdapterInfo{
 				Name:       "OpenGL Adapter",
 				Vendor:     vendorUnknown,
-				VendorID:   0,
-				DeviceID:   0,
 				DeviceType: gputypes.DeviceTypeOther,
 				Driver:     "OpenGL",
-				DriverInfo: "OpenGL 3.3+ / ES 3.0+",
+				DriverInfo: "OpenGL 3.3+ / ES 3.0+ (no context — use RequestAdapterWithSurface)",
 				Backend:    gputypes.BackendGL,
 			},
-			Features: 0,
 			Capabilities: hal.Capabilities{
 				Limits: gputypes.DefaultLimits(),
 				AlignmentsMask: hal.Alignments{
 					BufferCopyOffset: 4,
 					BufferCopyPitch:  256,
 				},
-				DownlevelCapabilities: hal.DownlevelCapabilities{
-					ShaderModel: 50, // SM5.0
-					Flags:       0,
-				},
+			},
+		},
+	}
+}
+
+// makeAdapterFromGL creates an ExposedAdapter using a live GL context.
+func makeAdapterFromGL(glCtx *gl.Context, eglCtx *egl.Context) hal.ExposedAdapter {
+	version := glCtx.GetString(gl.VERSION)
+	renderer := glCtx.GetString(gl.RENDERER)
+	vendor := glCtx.GetString(gl.VENDOR)
+
+	return hal.ExposedAdapter{
+		Adapter: &Adapter{
+			glCtx:  glCtx,
+			eglCtx: eglCtx,
+		},
+		Info: gputypes.AdapterInfo{
+			Name:       renderer,
+			Vendor:     vendor,
+			DeviceType: gputypes.DeviceTypeIntegratedGPU,
+			Driver:     "OpenGL",
+			DriverInfo: version,
+			Backend:    gputypes.BackendGL,
+		},
+		Capabilities: hal.Capabilities{
+			Limits: gputypes.DefaultLimits(),
+			AlignmentsMask: hal.Alignments{
+				BufferCopyOffset: 4,
+				BufferCopyPitch:  256,
 			},
 		},
 	}
@@ -130,5 +195,9 @@ func (i *Instance) EnumerateAdapters(surfaceHint hal.Surface) []hal.ExposedAdapt
 
 // Destroy releases the instance resources.
 func (i *Instance) Destroy() {
-	// Nothing to clean up at instance level
+	if i.eglCtx != nil {
+		i.eglCtx.Destroy()
+		i.eglCtx = nil
+		i.glCtx = nil
+	}
 }

--- a/hal/gles/egl/context.go
+++ b/hal/gles/egl/context.go
@@ -7,6 +7,7 @@ package egl
 
 import (
 	"fmt"
+	"strings"
 	"unsafe"
 )
 
@@ -106,14 +107,27 @@ func NewContext(config ContextConfig) (*Context, error) {
 		return nil, fmt.Errorf("eglCreateContext failed: error 0x%x", GetError())
 	}
 
-	// Create a pbuffer surface for the context
-	// This is needed even for surfaceless rendering on some drivers
-	pbuffer := createPbufferSurface(display, eglConfig)
-	if pbuffer == NoSurface {
-		DestroyContext(display, eglContext)
-		Terminate(display)
-		closeOwner()
-		return nil, fmt.Errorf("eglCreatePbufferSurface failed: error 0x%x", GetError())
+	// Surfaceless context: EGL 1.5+ or EGL_KHR_surfaceless_context allows
+	// MakeCurrent with EGL_NO_SURFACE. Skip pbuffer creation in that case.
+	// Fallback to 1×1 pbuffer for older drivers.
+	// Matches Rust wgpu-hal egl.rs:735-758.
+	hasSurfaceless := (major > 1 || (major == 1 && minor >= 5))
+	if !hasSurfaceless {
+		displayExts := QueryString(display, Extensions)
+		hasSurfaceless = strings.Contains(displayExts, "EGL_KHR_surfaceless_context")
+	}
+
+	var pbuffer EGLSurface
+	if hasSurfaceless {
+		pbuffer = NoSurface
+	} else {
+		pbuffer = createPbufferSurface(display, eglConfig)
+		if pbuffer == NoSurface {
+			DestroyContext(display, eglContext)
+			Terminate(display)
+			closeOwner()
+			return nil, fmt.Errorf("eglCreatePbufferSurface failed and no surfaceless support: error 0x%x", GetError())
+		}
 	}
 
 	return &Context{


### PR DESCRIPTION
## Summary

- **Instance-level EGL context on Linux** — `CreateInstance` now creates EGL context via surfaceless/pbuffer at init time, matching Rust wgpu-hal `egl.rs:846` and Windows hidden window pattern (v0.28.6). `EnumerateAdapters` returns real GPU name/vendor/version instead of placeholder.
- **EGL surfaceless context fallback** — `NewContext` checks `EGL_KHR_surfaceless_context` or EGL 1.5+ before creating pbuffer (Rust `egl.rs:735-758`). Skips dummy 1×1 pbuffer when surfaceless available.

Builds on @lkmavi's PR #210 (FFI pointer fixes + nil guard). On Wayland, gracefully degrades (no `wl_display*` at init) — `CreateSurface` provides context later.

Phase 3 (shared AdapterContext, Windows parity) tracked as FEAT-GLES-003.

## Enterprise references

| Reference | Pattern | Our implementation |
|-----------|---------|-------------------|
| Rust wgpu-hal `egl.rs:846` | EGL context at Instance::init | ✅ CreateInstance creates context |
| Rust wgpu-hal `egl.rs:735-758` | Surfaceless → pbuffer fallback | ✅ EGL 1.5+ / KHR check |
| Qt6 `QEGLPbuffer` | Surfaceless check + pbuffer | ✅ Same pattern |
| Windows `adapter_context.go` | Hidden window at Instance | ✅ Equivalent via pbuffer |

## Test plan

- [x] `go build ./...` (Windows, Linux, macOS)
- [x] `go test ./...` — 15/15 pass
- [x] `golangci-lint run` — 0 issues on all 3 platforms
