### PR TITLE
feat(gles): shared context + tiered config + CI GL test (v0.29.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.11] - 2026-06-08
+
+### Added
+
+- **GLES: shared context in CreateSurface (Windows AdapterContext parity)** —
+  When Instance has a pre-created EGL context (X11/headless), `CreateSurface`
+  shares it instead of creating a new one. Surface stores `ownsContext=false` and
+  only references the Instance context. On Wayland (no Instance context),
+  `CreateSurface` creates its own (`ownsContext=true`). Matches Windows pattern
+  where Surface is lightweight (HWND + shared AdapterContext reference).
+- **GLES: tiered EGL config selection (Rust wgpu-hal egl.rs:218-293 parity)** —
+  `chooseEGLConfig` now tries WINDOW+PBUFFER first, falls back to PBUFFER-only.
+  Ensures the chosen config supports both headless rendering (pbuffer) and later
+  window presentation.
+- **GLES: CI GL object creation test** — `TestGLObjectCreation` verifies
+  `GenBuffers`, `GenTextures`, `GenVertexArrays`, `GenFramebuffers` return non-zero
+  IDs through goffi. Catches the FFI pointer convention bug (PR #210, ADR-044)
+  that went undetected because CI previously only tested EGL init.
+
 ## [0.29.10] - 2026-06-08
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.29.4
+## Current State: v0.29.11
 
 ✅ **Triple-backend architecture (ADR-038)** — Native Go, Rust FFI, Browser WASM via build tags
 ✅ **All 5 Native HAL backends complete** (~127K LOC)
@@ -66,6 +66,11 @@
 ✅ **Software render pass instrumentation** — slog debug events + RenderPassStats for CI e2e assertions
 ✅ **Browser WebGPU backend** — complete `syscall/js` → `navigator.gpu` implementation (~6500 LOC). Instance, Adapter, Device, Resources, Pipelines, Command Recording, Queue Submit, Surface/Canvas, Buffer Mapping. Bypasses core/hal (Rust wgpu pattern). 97 TextureFormats, 31 VertexFormats, 29+ tests. Zero external dependencies.
 ✅ **GLES hidden window context (Windows)** — GL context owned by Instance on hidden 1×1 HWND, shared via mutex-protected `AdapterContext`. Adapter/Device/Queue survive Surface destruction. Follows Rust wgpu-hal `wgl.rs` `AdapterContext::lock()`/`lock_with_dc()` pattern. Surface lightweight — no context ownership.
+✅ **GLES instance-level EGL context (Linux)** — surfaceless/pbuffer context at CreateInstance (Rust wgpu-hal `egl.rs:846` parity). Tiered config selection WINDOW+PBUFFER → PBUFFER-only (Rust `egl.rs:218-293`). Shared context in CreateSurface on X11/headless, own context on Wayland.
+✅ **GLES FFI pointer convention fix (Linux)** — 30+ GL calls in `context_linux.go` fixed: pointer-type args corrected for goffi `CallFunction` (PR #210, @lkmavi). ADR-044 documents convention. CI test verifies GenBuffers/GenTextures through goffi.
+✅ **GLES fence sync ordering** — `glFenceSync` before `glFlush` (was reversed). PollCompleted uses non-blocking `glGetSynciv`. Confirmed by ANGLE bug 6464, virglrenderer commit 21bbc9ea, Mesa Gallium. `Fence.Signal` returns error (Rust parity).
+✅ **Wayland SHM presentation (enterprise quality)** — display wrapper pattern (Qt6 parity), `wl_display_roundtrip_queue`, proper proxy cleanup, triple-buffer freeze fix (bufferBusyMap pointer + roundtrip_queue dispatch). Verified on WSL2.
+✅ **Codecov OIDC** — replaced token + GPG verification with GitHub OIDC. No more intermittent CI failures from GPG keyserver.
 
 ### Remaining validation (planned)
 - **Phase C** (P2): Spec compliance edge cases, feature gates
@@ -76,8 +81,8 @@
 | Vulkan | Windows, Linux, macOS | ✅ Stable — text, compute, MSAA |
 | Metal | macOS | ✅ Stable — naga MSL 91/91 |
 | DX12 | Windows | ✅ Stable — TDR fixed, PendingWrites, deferred destruction |
-| GLES | Windows, Linux | ✅ Stable — hidden window context (Rust parity), Wayland EGL (EGL 1.5 + fallback), glFenceSync, copy commands, timestamps, real adapter capabilities, compute barriers |
-| Software | Windows, Linux, macOS | ✅ Stable — windowed presentation (GDI/X11/Wayland SHM/CG+Metal), SPIR-V interpreter. All 3 desktop platforms + Wayland. |
+| GLES | Windows, Linux | ✅ Stable — hidden window (Win), instance-level EGL (Linux), FFI pointer fix (@lkmavi), fence sync ordering, Wayland EGL (EGL 1.5 + fallback), surfaceless/pbuffer, tiered config, compute barriers |
+| Software | Windows, Linux, macOS | ✅ Stable — windowed presentation (GDI/X11/Wayland SHM/CG+Metal), SPIR-V interpreter. Wayland: display wrapper pattern, roundtrip_queue, triple-buffer. |
 
 → **See [CHANGELOG.md](CHANGELOG.md) for detailed per-version notes**
 
@@ -90,7 +95,8 @@
 - [x] GLES hidden window context (Windows) — Instance-owned GL context, Rust wgpu parity (FEAT-GLES-002)
 - [x] Wayland SHM presentation (Software backend) — triple-buffered wl_shm, release listener, partial copy, variadic ABI (ADR-042/043)
 - [x] Wayland EGL window surface (GLES backend) — wl_egl_window, EGL 1.5 eglCreatePlatformWindowSurface (ADR-042)
-- [ ] GLES hidden window context (Linux) — EGL surfaceless/pbuffer, Phase 2 of FEAT-GLES-002
+- [x] GLES instance-level EGL context (Linux) — surfaceless/pbuffer, tiered config, shared context (v0.29.10-v0.29.11)
+- [ ] GLES shared AdapterContext (Linux) — full Windows parity with Lock/LockForSurface/Unlock (FEAT-GLES-003)
 - [x] macOS software presentation — CGImage + CAMetalLayer (PR #187, @k-chimi, v0.28.4)
 - [ ] DX12 DeviceTextureTracker for proper barrier state tracking
 - [ ] GLES global UNPACK_ALIGNMENT=1 (Rust pattern — set once at device open)
@@ -154,6 +160,18 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.29.11** | 2026-06 | GLES: shared context + tiered config + CI GL test. Completes ADR-045 enterprise parity. |
+| **v0.29.10** | 2026-06 | GLES: instance-level EGL context (Linux), surfaceless fallback, FFI pointer fix (PR #210, @lkmavi). |
+| **v0.29.9** | 2026-06 | Software: Wayland SHM triple-buffer freeze fix (bufferBusyMap + roundtrip_queue). |
+| **v0.29.8** | 2026-06 | Software: Wayland display wrapper pattern — queue mismatch fix. |
+| **v0.29.7** | 2026-06 | Software: eager Wayland wl_shm init in Configure (SIGSEGV fix, gogpu#292). |
+| **v0.29.6** | 2026-06 | GLES: Fence.Signal returns error on glFenceSync failure (Rust parity). |
+| **v0.29.5** | 2026-06 | GLES: fence sync ordering — glFenceSync before glFlush. Confirmed by ANGLE/virglrenderer/Mesa. |
+| **v0.29.4** | 2026-06 | Software: dedicated wl_event_queue for SHM buffer release dispatch. |
+| **v0.29.3** | 2026-06 | Software: Wayland SHM present (enterprise). GLES: compute/instancing/topology fixes. |
+| **v0.29.2** | 2026-06 | Vulkan: VK_ERROR_SURFACE_LOST_KHR (Rust parity). goffi v0.5.3. |
+| **v0.29.1** | 2026-05 | go-webgpu/webgpu v0.5.2. |
+| **v0.29.0** | 2026-05 | ADR-038: Rust backend at public API level (browser pattern). |
 | **v0.28.11** | 2026-05 | Core: direct-write trackedRefs (pass → encoder, zero intermediate copies). |
 | **v0.28.10** | 2026-05 | Core: pre-allocate trackedRefs in pass encoders (ML OOM fix). |
 | **v0.28.9** | 2026-05 | Core: refcount-driven Buffer destruction via onZero (Rust Drop parity). Eliminates Phase 1 stale index risk. |

--- a/hal/gles/api_linux.go
+++ b/hal/gles/api_linux.go
@@ -81,45 +81,60 @@ type Instance struct {
 // On Linux: displayHandle and windowHandle are platform-specific.
 // For X11: displayHandle is X11 Display*, windowHandle is Window.
 // For Wayland: displayHandle is wl_display*, windowHandle is wl_surface*.
+//
+// When Instance has a pre-created EGL context (X11/headless), the context is
+// SHARED — Surface only creates an EGL window surface for presentation. This
+// matches the Windows pattern where Instance owns AdapterContext and Surface
+// is lightweight (just HWND + reference to shared ctx).
+//
+// When Instance has no context (Wayland — no wl_display* at init), CreateSurface
+// creates a new EGL context with the caller's displayHandle.
 func (i *Instance) CreateSurface(displayHandle, windowHandle uintptr) (hal.Surface, error) {
-	// Create EGL context with automatic platform detection.
-	// NativeDisplay must be the app's wl_display* on Wayland so EGL shares the
-	// same display connection as the wl_surface — see egl.GetEGLDisplay.
+	// Path A: share Instance context (X11/headless — context already exists).
+	if i.eglCtx != nil && i.glCtx != nil {
+		hal.Logger().Info("gles: surface sharing Instance EGL context")
+		return &Surface{
+			displayHandle: displayHandle,
+			windowHandle:  windowHandle,
+			eglCtx:        i.eglCtx,
+			glCtx:         i.glCtx,
+			ownsContext:   false, // Instance owns context, Surface only references it
+			version:       i.glCtx.GetString(gl.VERSION),
+			renderer:      i.glCtx.GetString(gl.RENDERER),
+		}, nil
+	}
+
+	// Path B: create new context (Wayland — Instance had no wl_display* at init).
 	config := egl.DefaultContextConfig()
-	config.GLES = false // Use desktop OpenGL
+	config.GLES = false
 	config.NativeDisplay = displayHandle
 	ctx, err := egl.NewContext(config)
 	if err != nil {
 		return nil, fmt.Errorf("gles: failed to create EGL context: %w", err)
 	}
 
-	// Make it current to load GL functions
 	if err := ctx.MakeCurrent(); err != nil {
 		ctx.Destroy()
 		return nil, fmt.Errorf("gles: failed to make context current: %w", err)
 	}
 
-	// Load GL function pointers
 	glCtx := &gl.Context{}
 	if err := glCtx.Load(egl.GetGLProcAddress); err != nil {
 		ctx.Destroy()
 		return nil, fmt.Errorf("gles: failed to load GL functions: %w", err)
 	}
 
-	// Query OpenGL version
 	version := glCtx.GetString(gl.VERSION)
 	renderer := glCtx.GetString(gl.RENDERER)
-
-	hal.Logger().Info("gles: surface created",
-		"version", version,
-		"renderer", renderer,
-	)
+	hal.Logger().Info("gles: surface created with new EGL context",
+		"version", version, "renderer", renderer)
 
 	return &Surface{
 		displayHandle: displayHandle,
 		windowHandle:  windowHandle,
 		eglCtx:        ctx,
 		glCtx:         glCtx,
+		ownsContext:   true, // Surface owns this context (no Instance context)
 		version:       version,
 		renderer:      renderer,
 	}, nil

--- a/hal/gles/egl/context.go
+++ b/hal/gles/egl/context.go
@@ -157,9 +157,15 @@ func chooseEGLConfig(display EGLDisplay, config ContextConfig) (EGLConfig, error
 		renderableType = OpenGLBit
 	}
 
-	// Build attribute list
-	attribs := []EGLInt{
-		SurfaceType, PbufferBit,
+	// Tiered config selection (Rust wgpu-hal egl.rs:218-293).
+	// Try from best to worst: the config must support pbuffer (for headless
+	// MakeCurrent) and ideally window (for later CreateWindowSurface).
+	tiers := []EGLInt{
+		WindowBit | PbufferBit, // Tier 1: window + pbuffer (can present later)
+		PbufferBit,             // Tier 0: pbuffer only (headless/CI fallback)
+	}
+
+	baseAttribs := []EGLInt{
 		RenderableType, renderableType,
 		RedSize, 8,
 		GreenSize, 8,
@@ -167,21 +173,25 @@ func chooseEGLConfig(display EGLDisplay, config ContextConfig) (EGLConfig, error
 		AlphaSize, 8,
 		DepthSize, 24,
 		StencilSize, 8,
-		None,
 	}
 
-	// Choose config
-	var eglConfig EGLConfig
-	var numConfigs EGLInt
-	if ChooseConfig(display, &attribs[0], &eglConfig, 1, &numConfigs) == False {
-		return 0, fmt.Errorf("eglChooseConfig failed: error 0x%x", GetError())
+	for _, surfaceType := range tiers {
+		attribs := make([]EGLInt, 0, len(baseAttribs)+3)
+		attribs = append(attribs, SurfaceType, surfaceType)
+		attribs = append(attribs, baseAttribs...)
+		attribs = append(attribs, None)
+
+		var eglConfig EGLConfig
+		var numConfigs EGLInt
+		if ChooseConfig(display, &attribs[0], &eglConfig, 1, &numConfigs) == False {
+			continue
+		}
+		if numConfigs > 0 {
+			return eglConfig, nil
+		}
 	}
 
-	if numConfigs == 0 {
-		return 0, fmt.Errorf("no suitable EGL configs found")
-	}
-
-	return eglConfig, nil
+	return 0, fmt.Errorf("no suitable EGL configs found (tried window+pbuffer and pbuffer-only)")
 }
 
 // createEGLContext creates an EGL rendering context.
@@ -224,13 +234,38 @@ func createPbufferSurface(display EGLDisplay, config EGLConfig) EGLSurface {
 	return CreatePbufferSurface(display, config, &attribs[0])
 }
 
-// MakeCurrent makes this context current for the calling thread.
+// MakeCurrent makes this context current on the pbuffer (headless rendering).
 func (c *Context) MakeCurrent() error {
 	if MakeCurrent(c.display, c.pbuffer, c.pbuffer, c.context) == False {
 		return fmt.Errorf("eglMakeCurrent failed: error 0x%x", GetError())
 	}
 	return nil
 }
+
+// MakeCurrentSurface makes this context current on a window surface (for Present).
+func (c *Context) MakeCurrentSurface(surface EGLSurface) error {
+	if MakeCurrent(c.display, surface, surface, c.context) == False {
+		return fmt.Errorf("eglMakeCurrent(surface) failed: error 0x%x", GetError())
+	}
+	return nil
+}
+
+// CreateWindowSurface creates an EGL window surface for presentation.
+// The surface shares this context's display and config.
+func (c *Context) CreateWindowSurface(nativeWindow uintptr) (EGLSurface, error) {
+	attribs := []EGLInt{None}
+	surface := CreateWindowSurface(c.display, c.config, EGLNativeWindowType(nativeWindow), &attribs[0])
+	if surface == NoSurface {
+		return NoSurface, fmt.Errorf("eglCreateWindowSurface failed: error 0x%x", GetError())
+	}
+	return surface, nil
+}
+
+// Display returns the EGL display handle.
+func (c *Context) Display() EGLDisplay { return c.display }
+
+// Config returns the EGL config handle.
+func (c *Context) Config() EGLConfig { return c.config }
 
 // Destroy releases the context and its associated resources.
 // Order matters: EGL resources first, then the native display connection.
@@ -257,16 +292,6 @@ func (c *Context) Destroy() {
 		c.displayOwner.Close()
 		c.displayOwner = nil
 	}
-}
-
-// Display returns the EGL display.
-func (c *Context) Display() EGLDisplay {
-	return c.display
-}
-
-// Config returns the EGL config.
-func (c *Context) Config() EGLConfig {
-	return c.config
 }
 
 // EGLContext returns the EGL context handle.

--- a/hal/gles/integration_test.go
+++ b/hal/gles/integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/hal"
 	"github.com/gogpu/wgpu/hal/gles/egl"
+	"github.com/gogpu/wgpu/hal/gles/gl"
 )
 
 // TestEGLInit tests basic EGL initialization.
@@ -102,6 +103,67 @@ func TestEGLContext(t *testing.T) {
 	// Destroy context
 	ctx.Destroy()
 	t.Log("Context destroyed")
+}
+
+// TestGLObjectCreation verifies that GL object creation works through goffi.
+// This catches the fundamental FFI pointer convention bug found by @lkmavi
+// (PR #210): pointer-type args must use unsafe.Pointer(&ptr), not unsafe.Pointer(&value).
+// Without this test, the bug went undetected because CI only tested EGL init.
+func TestGLObjectCreation(t *testing.T) {
+	if err := egl.Init(); err != nil {
+		t.Fatalf("egl.Init() failed: %v", err)
+	}
+
+	config := egl.DefaultContextConfig()
+	config.GLES = false
+	ctx, err := egl.NewContext(config)
+	if err != nil {
+		t.Skipf("egl.NewContext() failed: %v", err)
+	}
+	defer ctx.Destroy()
+
+	if err := ctx.MakeCurrent(); err != nil {
+		t.Fatalf("MakeCurrent failed: %v", err)
+	}
+
+	glCtx := &gl.Context{}
+	if err := glCtx.Load(egl.GetGLProcAddress); err != nil {
+		t.Fatalf("GL load failed: %v", err)
+	}
+
+	// GenBuffers — would return 0 with old FFI bug (garbage pointer to OpenGL)
+	buf := glCtx.GenBuffers(1)
+	if buf == 0 {
+		t.Fatal("GenBuffers returned 0 — FFI pointer convention bug (see ADR-044)")
+	}
+	t.Logf("GenBuffers: %d", buf)
+	glCtx.DeleteBuffers(buf)
+
+	// GenTextures
+	tex := glCtx.GenTextures(1)
+	if tex == 0 {
+		t.Fatal("GenTextures returned 0")
+	}
+	t.Logf("GenTextures: %d", tex)
+	glCtx.DeleteTextures(tex)
+
+	// GenVertexArrays
+	vao := glCtx.GenVertexArrays(1)
+	if vao == 0 {
+		t.Fatal("GenVertexArrays returned 0")
+	}
+	t.Logf("GenVertexArrays: %d", vao)
+	glCtx.DeleteVertexArrays(vao)
+
+	// GenFramebuffers
+	fbo := glCtx.GenFramebuffers(1)
+	if fbo == 0 {
+		t.Fatal("GenFramebuffers returned 0")
+	}
+	t.Logf("GenFramebuffers: %d", fbo)
+	glCtx.DeleteFramebuffers(fbo)
+
+	t.Log("All GL object creation/deletion passed — FFI pointer convention correct")
 }
 
 // TestGLESBackend tests the full GLES backend integration.

--- a/hal/gles/resource_linux.go
+++ b/hal/gles/resource_linux.go
@@ -15,6 +15,9 @@ import (
 )
 
 // Surface implements hal.Surface for OpenGL on Linux.
+// When Instance has a pre-created context (X11/headless), ownsContext=false —
+// Surface shares Instance's context (like Windows AdapterContext pattern).
+// When Instance has no context (Wayland), ownsContext=true — Surface owns its own.
 type Surface struct {
 	displayHandle uintptr
 	windowHandle  uintptr
@@ -22,6 +25,7 @@ type Surface struct {
 	eglDisplay    egl.EGLDisplay
 	eglSurface    egl.EGLSurface
 	glCtx         *gl.Context
+	ownsContext   bool // true = Surface owns context, false = shared from Instance
 	version       string
 	renderer      string
 	configured    bool
@@ -271,10 +275,13 @@ func (s *Surface) Destroy() {
 		s.eglWindow = 0
 	}
 
-	if s.eglCtx != nil {
+	// Only destroy context if Surface owns it (Wayland path).
+	// When shared from Instance (X11/headless), Instance.Destroy handles cleanup.
+	if s.ownsContext && s.eglCtx != nil {
 		s.eglCtx.Destroy()
-		s.eglCtx = nil
 	}
+	s.eglCtx = nil
+	s.glCtx = nil
 }
 
 // SurfaceTexture implements hal.SurfaceTexture for OpenGL.


### PR DESCRIPTION
## Summary

Completes ADR-045 enterprise parity (items 4-6 that v0.29.10 missed).

1. **Shared context in CreateSurface** — X11/headless: Surface shares Instance EGL context (`ownsContext=false`). Wayland: creates own context (`ownsContext=true`). Windows AdapterContext parity.
2. **Tiered EGL config selection** — WINDOW+PBUFFER → PBUFFER-only (Rust `egl.rs:218-293`). Ensures config works for both headless and window presentation.
3. **CI GL rendering test** — `TestGLObjectCreation`: GenBuffers/GenTextures/GenVertexArrays/GenFramebuffers through goffi. Catches FFI pointer convention bug (PR #210, ADR-044).
4. **ROADMAP updated** — v0.29.5–v0.29.11 releases documented, backend status current.

## Test plan

- [x] `go build ./...` (Windows, Linux, macOS, WASM)
- [x] `go test ./...` — 15/15 pass
- [x] `golangci-lint run` — 0 issues (Windows, Linux, macOS)
- [x] `gofmt -l .` — clean
