### PR TITLE
fix(gles): Wayland EGL nativeDisplay=0 fallback to surfaceless (v0.29.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.12] - 2026-06-08
+
+### Fixed
+
+- **GLES: Wayland EGL nativeDisplay=0 fallback to surfaceless** — `GetEGLDisplay`
+  with `nativeDisplay=0` on Wayland tried `eglGetPlatformDisplay(WAYLAND, 0)` which
+  opens a second `wl_display` connection via `wl_display_connect(NULL)`. Surface's
+  `wl_surface*` is on the app's display → "Proxy and queue point to different
+  wl_displays" crash. Fix: skip Wayland platform when `nativeDisplay=0` (Instance
+  init), fall back to surfaceless. `CreateSurface` calls again with real `wl_display*`.
+  Also: `CreateSurface` Path A skips sharing Instance context when it used surfaceless
+  display (can't create window surface on surfaceless EGL display). Found by @lkmavi.
+
 ## [0.29.11] - 2026-06-08
 
 ### Added

--- a/hal/gles/api_linux.go
+++ b/hal/gles/api_linux.go
@@ -90,8 +90,10 @@ type Instance struct {
 // When Instance has no context (Wayland — no wl_display* at init), CreateSurface
 // creates a new EGL context with the caller's displayHandle.
 func (i *Instance) CreateSurface(displayHandle, windowHandle uintptr) (hal.Surface, error) {
-	// Path A: share Instance context (X11/headless — context already exists).
-	if i.eglCtx != nil && i.glCtx != nil {
+	// Path A: share Instance context (X11 — context matches window system).
+	// Do NOT share if Instance context is surfaceless (headless/Wayland fallback)
+	// and Surface needs a window — the EGL display won't support eglCreateWindowSurface.
+	if i.eglCtx != nil && i.glCtx != nil && i.eglCtx.WindowKind() != egl.WindowKindSurfaceless {
 		hal.Logger().Info("gles: surface sharing Instance EGL context")
 		return &Surface{
 			displayHandle: displayHandle,

--- a/hal/gles/egl/display.go
+++ b/hal/gles/egl/display.go
@@ -244,11 +244,22 @@ func GetEGLDisplay(nativeDisplay uintptr) (EGLDisplay, WindowKind, *DisplayOwner
 		return display, WindowKindX11, owner, nil
 
 	case WindowKindWayland:
-		// Use the caller's wl_display so EGL shares the same Wayland connection
-		// as the window. Passing 0 would make EGL open a second connection via
-		// wl_display_connect(NULL), causing "Proxy and queue point to different
-		// wl_displays" when eglCreatePlatformWindowSurface tries to register
-		// protocol objects on the app's wl_surface.
+		// Wayland EGL REQUIRES the app's wl_display* — passing 0 opens a second
+		// connection via wl_display_connect(NULL), causing "Proxy and queue point
+		// to different wl_displays" when eglCreateWindowSurface tries to use a
+		// wl_surface* from the app's display on EGL's separate display.
+		//
+		// If nativeDisplay==0 (Instance init, no wl_display* yet), skip Wayland
+		// platform and try surfaceless instead. CreateSurface will call again
+		// with the real wl_display*.
+		if nativeDisplay == 0 {
+			display := GetPlatformDisplay(PlatformSurfacelessMesa, 0, nil)
+			if display != NoDisplay {
+				return display, WindowKindSurfaceless, nil, nil
+			}
+			return NoDisplay, WindowKindUnknown, nil, fmt.Errorf("wayland EGL requires wl_display* (nativeDisplay=0), and surfaceless not available")
+		}
+
 		display := GetPlatformDisplay(PlatformWaylandKHR, nativeDisplay, nil)
 		if display != NoDisplay {
 			return display, WindowKindWayland, nil, nil


### PR DESCRIPTION
Fix regression found by @lkmavi: GetEGLDisplay with nativeDisplay=0 on Wayland opened second wl_display connection → crash. Now falls back to surfaceless. CreateSurface Path A skips sharing surfaceless Instance context. Validated against Rust wgpu-hal egl.rs:905-968.