### PR TITLE
fix(gles): missing vertexBuffers in Linux RenderPipeline (v0.29.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.14] - 2026-06-11
+
+### Fixed
+
+- **GLES: missing vertexBuffers in Linux RenderPipeline** — `device_linux.go`
+  `CreateRenderPipeline` did not store `desc.Vertex.Buffers` in the pipeline
+  struct. Windows `device.go` had it. Without vertex buffer layout, vertex
+  attributes were never configured → all geometry silently discarded → blank
+  window. One-line fix enables full gg rendering (SDF shapes, text, widgets)
+  on GLES Linux. Found by @lkmavi (PR #215).
+
 ## [0.29.13] - 2026-06-11
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.29.13
+## Current State: v0.29.14
 
 ✅ **Triple-backend architecture (ADR-038)** — Native Go, Rust FFI, Browser WASM via build tags
 ✅ **All 5 Native HAL backends complete** (~127K LOC)
@@ -161,6 +161,7 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.29.14** | 2026-06 | GLES: missing vertexBuffers in Linux pipeline — one-line fix enables full gg rendering (SDF, text, widgets) on GLES Linux. @lkmavi. |
 | **v0.29.13** | 2026-06 | **GLES enterprise parity**: GLSL version propagation, runtime binding fallback (GL <4.2), MSAA validation, GLES function names, lazy VAO, compute VERTEX_ATTRIB barrier, Wayland EGL fixes. First triangle on GLES WSL2 Wayland. Credits: @lkmavi (PR #210, #215). |
 | **v0.29.12** | 2026-06 | GLES: Wayland EGL nativeDisplay=0 surfaceless fallback. CreateSurface Path A guard. |
 | **v0.29.11** | 2026-06 | GLES: shared context + tiered config + CI GL test. Completes ADR-045 enterprise parity. |

--- a/hal/gles/device_linux.go
+++ b/hal/gles/device_linux.go
@@ -523,6 +523,7 @@ func (d *Device) CreateRenderPipeline(desc *RenderPipelineDescriptor) (hal.Rende
 		multisample:       desc.Multisample,
 		blend:             blend,
 		colorWriteMask:    colorWriteMask,
+		vertexBuffers:     desc.Vertex.Buffers,
 	}
 
 	// Build SamplerBindMap from TextureMappings using pre-computed BindingMap.


### PR DESCRIPTION
One-line fix: vertexBuffers missing in device_linux.go. Enables full gg rendering on GLES Linux. Found by @lkmavi (PR #215).