### PR TITLE
fix: HAL wrapper stubs for Rust and Browser builds (v0.29.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.29.16] - 2026-06-15
+
+### Fixed
+
+- **HAL wrapper stubs for Rust and Browser builds** — `NewDeviceFromHAL`,
+  `NewSurfaceFromHAL`, `NewTextureFromHAL`, `NewTextureViewFromHAL`,
+  `NewSamplerFromHAL` now have stubs in `wrap_rust.go` (error return) and
+  `wrap_browser.go` (`any` params, nil return). Previously these 5 public
+  functions disappeared with `-tags=rust` or `js/wasm`, breaking consumers
+  that reference them. Public API must compile on all build targets.
+
 ## [0.29.15] - 2026-06-15
 
 ### Dependencies

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ GOOS=js GOARCH=wasm go build -o app.wasm .
 > | (default) | Pure Go → core → HAL → Vulkan/Metal/DX12/GLES/Software | Zero deps, cross-compile |
 > | `-tags rust` | go-webgpu/webgpu → wgpu-native v29 | Battle-tested GPU drivers |
 > | `GOOS=js` | syscall/js → Browser WebGPU | Web applications |
+>
+> **API consistency:** The public API compiles on all build targets. HAL wrapper functions (`NewDeviceFromHAL`, `NewSurfaceFromHAL`, etc.) return errors or nil on Rust/Browser builds where no Go HAL layer exists. Use `RequestAdapter` → `RequestDevice` for the standard cross-backend path.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -172,6 +172,8 @@ Target: stable, documented, conformant WebGPU implementation in Pure Go.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.29.16** | 2026-06 | HAL wrapper stubs for Rust/Browser builds — public API compiles on all build targets. README updated. |
+| **v0.29.15** | 2026-06 | naga v0.17.15 (HLSL sampler fix, @georgebuilds), x/sys v0.46.0. |
 | **v0.29.14** | 2026-06 | GLES: missing vertexBuffers in Linux pipeline — one-line fix enables full gg rendering (SDF, text, widgets) on GLES Linux. @lkmavi. |
 | **v0.29.13** | 2026-06 | **GLES enterprise parity**: GLSL version propagation, runtime binding fallback (GL <4.2), MSAA validation, GLES function names, lazy VAO, compute VERTEX_ATTRIB barrier, Wayland EGL fixes. First triangle on GLES WSL2 Wayland. Credits: @lkmavi (PR #210, #215). |
 | **v0.29.12** | 2026-06 | GLES: Wayland EGL nativeDisplay=0 surfaceless fallback. CreateSurface Path A guard. |

--- a/wrap_browser.go
+++ b/wrap_browser.go
@@ -1,0 +1,37 @@
+//go:build js && wasm
+
+package wgpu
+
+import "fmt"
+
+// NewDeviceFromHAL is not supported in the browser.
+// The browser backend uses navigator.gpu (WebGPU JS API), not Go HAL.
+func NewDeviceFromHAL(
+	_ any,
+	_ any,
+	_ Features,
+	_ Limits,
+	_ string,
+) (*Device, error) {
+	return nil, fmt.Errorf("wgpu: NewDeviceFromHAL not available in browser — use RequestDevice instead")
+}
+
+// NewSurfaceFromHAL is not supported in the browser.
+func NewSurfaceFromHAL(_ any, _ string) *Surface {
+	return nil
+}
+
+// NewTextureFromHAL is not supported in the browser.
+func NewTextureFromHAL(_ any, _ *Device, _ TextureFormat) *Texture {
+	return nil
+}
+
+// NewTextureViewFromHAL is not supported in the browser.
+func NewTextureViewFromHAL(_ any, _ *Device) *TextureView {
+	return nil
+}
+
+// NewSamplerFromHAL is not supported in the browser.
+func NewSamplerFromHAL(_ any, _ *Device) *Sampler {
+	return nil
+}

--- a/wrap_rust.go
+++ b/wrap_rust.go
@@ -1,0 +1,41 @@
+//go:build rust
+
+package wgpu
+
+import (
+	"fmt"
+
+	"github.com/gogpu/wgpu/hal"
+)
+
+// NewDeviceFromHAL is not supported with the Rust FFI backend.
+// The Rust backend creates devices through wgpu-native, not through Go HAL.
+func NewDeviceFromHAL(
+	_ hal.Device,
+	_ hal.Queue,
+	_ Features,
+	_ Limits,
+	_ string,
+) (*Device, error) {
+	return nil, fmt.Errorf("wgpu: NewDeviceFromHAL not available with Rust backend — use RequestDevice instead")
+}
+
+// NewSurfaceFromHAL is not supported with the Rust FFI backend.
+func NewSurfaceFromHAL(_ hal.Surface, _ string) *Surface {
+	return nil
+}
+
+// NewTextureFromHAL is not supported with the Rust FFI backend.
+func NewTextureFromHAL(_ hal.Texture, _ *Device, _ TextureFormat) *Texture {
+	return nil
+}
+
+// NewTextureViewFromHAL is not supported with the Rust FFI backend.
+func NewTextureViewFromHAL(_ hal.TextureView, _ *Device) *TextureView {
+	return nil
+}
+
+// NewSamplerFromHAL is not supported with the Rust FFI backend.
+func NewSamplerFromHAL(_ hal.Sampler, _ *Device) *Sampler {
+	return nil
+}


### PR DESCRIPTION
5 public HAL wrapper functions now compile on all build targets. Error stubs for Rust, nil stubs for Browser. README updated with API consistency note.