### PR TITLE
feat!: unified public API + enterprise cleanup (v0.30.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.0] - 2026-06-15
+
+### Changed (BREAKING)
+
+- **Unified public API across all build targets (ADR-047)** — 6 divergences fixed
+  between native, Rust, and browser builds. Consumer code now compiles on all targets.
+- **StencilOperation → gputypes** — canonical webgpu.h spec values (uint32, 0x1-based).
+  Was: HAL uint8 iota (0-based) on native, independent uint32 (0-based) on browser.
+  Breaking: numeric values changed (Keep: 0→0x1, Zero: 1→0x2, etc.).
+- **Device.released → atomic.Bool** — fixes data race when Release() called
+  concurrently with CreateBuffer(). Was plain bool.
+- **gpucontext sentinel methods** — `*wgpu.Device` now satisfies `gpucontext.Device`
+  interface (with sentinel). Requires gpucontext v0.20.0.
+
+### Added
+
+- **MinBindGroups = 4** — WebGPU spec guaranteed minimum. Portable code should
+  use ≤4 bind groups. MaxBindGroups (8) is HAL hard cap.
+- **CommandEncoder.CopyBufferToTexture** — WebGPU spec method, was browser-only.
+  Now available on native (routes through HAL).
+- **CommandEncoder.ClearBuffer** — WebGPU spec method, was browser-only.
+  Now available on native.
+- **Browser fence stubs** — DestroyFence, ResetFence, GetFenceStatus, WaitForFence
+  (no-op on browser, matching native signatures).
+- **Browser ComputePipelineDescriptor** — added Constants and
+  ZeroInitializeWorkgroupMemory fields (were native-only).
+- **browser-compute example** — WASM WebGPU compute validation
+  (shader → dispatch → readback).
+
 ## [0.29.16] - 2026-06-15
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.29.15
+## Current State: v0.30.0
 
 ✅ **Triple-backend architecture (ADR-038)** — Native Go, Rust FFI, Browser WASM via build tags
 ✅ **All 5 Native HAL backends complete** (~127K LOC)
@@ -172,6 +172,7 @@ Target: stable, documented, conformant WebGPU implementation in Pure Go.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.30.0** | 2026-06 | **BREAKING: Unified public API (ADR-047).** StencilOperation→gputypes, Device.released→atomic.Bool, sentinel methods, MinBindGroups, CopyBufferToTexture+ClearBuffer native, browser fence stubs, browser-compute example. |
 | **v0.29.16** | 2026-06 | HAL wrapper stubs for Rust/Browser builds — public API compiles on all build targets. README updated. |
 | **v0.29.15** | 2026-06 | naga v0.17.15 (HLSL sampler fix, @georgebuilds), x/sys v0.46.0. |
 | **v0.29.14** | 2026-06 | GLES: missing vertexBuffers in Linux pipeline — one-line fix enables full gg rendering (SDF, text, widgets) on GLES Linux. @lkmavi. |

--- a/descriptor.go
+++ b/descriptor.go
@@ -240,18 +240,19 @@ type PipelineLayoutDescriptor struct {
 }
 
 // StencilOperation describes a stencil operation.
-type StencilOperation = hal.StencilOperation
+// Canonical definition in gputypes (webgpu.h spec-compliant values).
+type StencilOperation = gputypes.StencilOperation
 
-// Stencil operation constants.
+// Stencil operation constants (webgpu.h spec values).
 const (
-	StencilOperationKeep           = hal.StencilOperationKeep
-	StencilOperationZero           = hal.StencilOperationZero
-	StencilOperationReplace        = hal.StencilOperationReplace
-	StencilOperationInvert         = hal.StencilOperationInvert
-	StencilOperationIncrementClamp = hal.StencilOperationIncrementClamp
-	StencilOperationDecrementClamp = hal.StencilOperationDecrementClamp
-	StencilOperationIncrementWrap  = hal.StencilOperationIncrementWrap
-	StencilOperationDecrementWrap  = hal.StencilOperationDecrementWrap
+	StencilOperationKeep           = gputypes.StencilOperationKeep
+	StencilOperationZero           = gputypes.StencilOperationZero
+	StencilOperationReplace        = gputypes.StencilOperationReplace
+	StencilOperationInvert         = gputypes.StencilOperationInvert
+	StencilOperationIncrementClamp = gputypes.StencilOperationIncrementClamp
+	StencilOperationDecrementClamp = gputypes.StencilOperationDecrementClamp
+	StencilOperationIncrementWrap  = gputypes.StencilOperationIncrementWrap
+	StencilOperationDecrementWrap  = gputypes.StencilOperationDecrementWrap
 )
 
 // StencilFaceState describes stencil operations for a face.

--- a/descriptor_browser.go
+++ b/descriptor_browser.go
@@ -2,6 +2,8 @@
 
 package wgpu
 
+import "github.com/gogpu/gputypes"
+
 // Extent3D is a 3D size.
 type Extent3D struct {
 	Width              uint32
@@ -112,18 +114,19 @@ type PipelineLayoutDescriptor struct {
 }
 
 // StencilOperation describes a stencil operation.
-type StencilOperation uint32
+// Canonical definition in gputypes (webgpu.h spec-compliant values).
+type StencilOperation = gputypes.StencilOperation
 
-// Stencil operation constants.
+// Stencil operation constants (webgpu.h spec values).
 const (
-	StencilOperationKeep           StencilOperation = 0
-	StencilOperationZero           StencilOperation = 1
-	StencilOperationReplace        StencilOperation = 2
-	StencilOperationInvert         StencilOperation = 3
-	StencilOperationIncrementClamp StencilOperation = 4
-	StencilOperationDecrementClamp StencilOperation = 5
-	StencilOperationIncrementWrap  StencilOperation = 6
-	StencilOperationDecrementWrap  StencilOperation = 7
+	StencilOperationKeep           = gputypes.StencilOperationKeep
+	StencilOperationZero           = gputypes.StencilOperationZero
+	StencilOperationReplace        = gputypes.StencilOperationReplace
+	StencilOperationInvert         = gputypes.StencilOperationInvert
+	StencilOperationIncrementClamp = gputypes.StencilOperationIncrementClamp
+	StencilOperationDecrementClamp = gputypes.StencilOperationDecrementClamp
+	StencilOperationIncrementWrap  = gputypes.StencilOperationIncrementWrap
+	StencilOperationDecrementWrap  = gputypes.StencilOperationDecrementWrap
 )
 
 // StencilFaceState describes stencil operations for a face.
@@ -179,6 +182,14 @@ type ComputePipelineDescriptor struct {
 	Layout     *PipelineLayout
 	Module     *ShaderModule
 	EntryPoint string
+
+	// Constants are pipeline-overridable constants (WebGPU spec).
+	// Browser passes these to GPUDevice.createComputePipeline() constants dict.
+	Constants map[string]float64
+
+	// ZeroInitializeWorkgroupMemory controls workgroup memory zero-init.
+	// Browser ignores this (WebGPU spec mandates zero-init in browser).
+	ZeroInitializeWorkgroupMemory *bool
 }
 
 // RenderPassDescriptor describes a render pass.

--- a/device_browser.go
+++ b/device_browser.go
@@ -4,6 +4,7 @@ package wgpu
 
 import (
 	"syscall/js"
+	"time"
 
 	"github.com/gogpu/wgpu/internal/browser"
 )
@@ -262,6 +263,24 @@ func (d *Device) CreateFence() (*Fence, error) {
 	return &Fence{}, nil
 }
 
+// DestroyFence destroys a fence. No-op on browser — fences are JS-managed.
+func (d *Device) DestroyFence(f *Fence) {
+	if f != nil {
+		f.Release()
+	}
+}
+
+// ResetFence resets a fence. No-op on browser — fences auto-reset.
+func (d *Device) ResetFence(_ *Fence) error { return nil }
+
+// GetFenceStatus returns true (signaled). Browser fences resolve via JS Promises.
+func (d *Device) GetFenceStatus(_ *Fence) (bool, error) { return true, nil }
+
+// WaitForFence returns immediately on browser — GPU sync is handled by JS event loop.
+func (d *Device) WaitForFence(_ *Fence, _ uint64, _ time.Duration) (bool, error) {
+	return true, nil
+}
+
 // PushErrorScope pushes a new error scope onto the device's error scope stack.
 // Phase 2 — not yet implemented for browser.
 func (d *Device) PushErrorScope(filter ErrorFilter) {
@@ -483,9 +502,7 @@ func convertStencilFaceState(s *StencilFaceState) *browser.StencilFaceStateJS {
 	}
 }
 
-// stencilOpToJS converts the local StencilOperation enum to a WebGPU JS string.
-// The local enum (descriptor_browser.go) uses 0-based values while gputypes uses
-// 1-based (with Undefined=0), so we map explicitly to be correct.
+// stencilOpToJS converts StencilOperation (gputypes, webgpu.h spec values) to WebGPU JS string.
 func stencilOpToJS(op StencilOperation) string {
 	switch op {
 	case StencilOperationKeep:

--- a/device_native.go
+++ b/device_native.go
@@ -22,7 +22,7 @@ import (
 type Device struct {
 	core     *core.Device
 	queue    *Queue
-	released bool
+	released atomic.Bool
 
 	// cmdEncoderPool is the single shared encoder pool for the device.
 	// Used by both CreateCommandEncoder (user command encoders) and
@@ -59,7 +59,7 @@ func (d *Device) Limits() Limits {
 
 // CreateBuffer creates a GPU buffer.
 func (d *Device) CreateBuffer(desc *BufferDescriptor) (*Buffer, error) {
-	if d.released {
+	if d.released.Load() {
 		return nil, ErrReleased
 	}
 	if desc == nil {
@@ -102,7 +102,7 @@ func (d *Device) CreateBuffer(desc *BufferDescriptor) (*Buffer, error) {
 
 // CreateTexture creates a GPU texture.
 func (d *Device) CreateTexture(desc *TextureDescriptor) (*Texture, error) {
-	if d.released {
+	if d.released.Load() {
 		return nil, ErrReleased
 	}
 	if desc == nil {
@@ -130,7 +130,7 @@ func (d *Device) CreateTexture(desc *TextureDescriptor) (*Texture, error) {
 
 // CreateTextureView creates a view into a texture.
 func (d *Device) CreateTextureView(texture *Texture, desc *TextureViewDescriptor) (*TextureView, error) {
-	if d.released {
+	if d.released.Load() {
 		return nil, ErrReleased
 	}
 	if texture == nil {
@@ -164,7 +164,7 @@ func (d *Device) CreateTextureView(texture *Texture, desc *TextureViewDescriptor
 
 // CreateSampler creates a texture sampler.
 func (d *Device) CreateSampler(desc *SamplerDescriptor) (*Sampler, error) {
-	if d.released {
+	if d.released.Load() {
 		return nil, ErrReleased
 	}
 
@@ -202,7 +202,7 @@ func (d *Device) CreateSampler(desc *SamplerDescriptor) (*Sampler, error) {
 
 // CreateShaderModule creates a shader module.
 func (d *Device) CreateShaderModule(desc *ShaderModuleDescriptor) (*ShaderModule, error) {
-	if d.released {
+	if d.released.Load() {
 		return nil, ErrReleased
 	}
 	if desc == nil {
@@ -254,7 +254,7 @@ func (d *Device) CreateShaderModule(desc *ShaderModuleDescriptor) (*ShaderModule
 
 // CreateBindGroupLayout creates a bind group layout.
 func (d *Device) CreateBindGroupLayout(desc *BindGroupLayoutDescriptor) (*BindGroupLayout, error) {
-	if d.released {
+	if d.released.Load() {
 		return nil, ErrReleased
 	}
 	if desc == nil {
@@ -290,7 +290,7 @@ func (d *Device) CreateBindGroupLayout(desc *BindGroupLayoutDescriptor) (*BindGr
 
 // CreatePipelineLayout creates a pipeline layout.
 func (d *Device) CreatePipelineLayout(desc *PipelineLayoutDescriptor) (*PipelineLayout, error) {
-	if d.released {
+	if d.released.Load() {
 		return nil, ErrReleased
 	}
 	if desc == nil {
@@ -338,7 +338,7 @@ func (d *Device) CreatePipelineLayout(desc *PipelineLayoutDescriptor) (*Pipeline
 
 // CreateBindGroup creates a bind group.
 func (d *Device) CreateBindGroup(desc *BindGroupDescriptor) (*BindGroup, error) {
-	if d.released {
+	if d.released.Load() {
 		return nil, ErrReleased
 	}
 	if desc == nil {
@@ -471,7 +471,7 @@ func buildBindGroupEntryMap(entries []BindGroupEntry) map[uint32]*BindGroupEntry
 
 // CreateRenderPipeline creates a render pipeline.
 func (d *Device) CreateRenderPipeline(desc *RenderPipelineDescriptor) (*RenderPipeline, error) {
-	if d.released {
+	if d.released.Load() {
 		return nil, ErrReleased
 	}
 	if desc == nil {
@@ -573,7 +573,7 @@ func mergeShaderBindingSizes(
 
 // CreateComputePipeline creates a compute pipeline.
 func (d *Device) CreateComputePipeline(desc *ComputePipelineDescriptor) (*ComputePipeline, error) {
-	if d.released {
+	if d.released.Load() {
 		return nil, ErrReleased
 	}
 	if desc == nil {
@@ -702,7 +702,7 @@ func (d *Device) validateComputeWorkgroupSize(label, entryPoint string, module *
 // on every frame. After GPU completion, the encoder is reset and returned to the
 // pool for reuse. Matches Rust wgpu-core's CommandAllocator pattern (allocator.rs).
 func (d *Device) CreateCommandEncoder(desc *CommandEncoderDescriptor) (*CommandEncoder, error) {
-	if d.released {
+	if d.released.Load() {
 		return nil, ErrReleased
 	}
 
@@ -756,7 +756,7 @@ func (d *Device) CreateCommandEncoder(desc *CommandEncoderDescriptor) (*CommandE
 // Fences are primarily used by the HAL internally for synchronization.
 // Most callers should use Queue.Submit + Queue.Poll instead.
 func (d *Device) CreateFence() (*Fence, error) {
-	if d.released {
+	if d.released.Load() {
 		return nil, ErrReleased
 	}
 	halDevice := d.halDevice()
@@ -785,7 +785,7 @@ func (d *Device) DestroyFence(f *Fence) {
 // ResetFence resets a fence to the unsignaled state.
 // The fence must not be in use by the GPU.
 func (d *Device) ResetFence(f *Fence) error {
-	if d.released {
+	if d.released.Load() {
 		return ErrReleased
 	}
 	if f == nil || f.released {
@@ -801,7 +801,7 @@ func (d *Device) ResetFence(f *Fence) error {
 // GetFenceStatus returns true if the fence is signaled (non-blocking).
 // This is used for polling completion without blocking.
 func (d *Device) GetFenceStatus(f *Fence) (bool, error) {
-	if d.released {
+	if d.released.Load() {
 		return false, ErrReleased
 	}
 	if f == nil || f.released {
@@ -817,7 +817,7 @@ func (d *Device) GetFenceStatus(f *Fence) (bool, error) {
 // WaitForFence waits for a fence to reach the specified value.
 // Returns true if the fence reached the value, false if timeout expired.
 func (d *Device) WaitForFence(f *Fence, value uint64, timeout time.Duration) (bool, error) {
-	if d.released {
+	if d.released.Load() {
 		return false, ErrReleased
 	}
 	if f == nil || f.released {
@@ -834,7 +834,7 @@ func (d *Device) WaitForFence(f *Fence, value uint64, timeout time.Duration) (bo
 // This must be called after the GPU has finished using the command buffer.
 // The command buffer handle becomes invalid after this call.
 func (d *Device) FreeCommandBuffer(cb *CommandBuffer) {
-	if d.released || cb == nil {
+	if d.released.Load() || cb == nil {
 		return
 	}
 	halDevice := d.halDevice()
@@ -860,7 +860,7 @@ func (d *Device) PopErrorScope() *GPUError {
 
 // WaitIdle waits for all GPU work to complete.
 func (d *Device) WaitIdle() error {
-	if d.released {
+	if d.released.Load() {
 		return ErrReleased
 	}
 	halDevice := d.halDevice()
@@ -887,10 +887,10 @@ func (d *Device) WaitIdle() error {
 // Rust avoids this via Arc ownership + maintain loop. In Go we must
 // be explicit: WaitIdle ensures PollCompleted returns final index.
 func (d *Device) Release() {
-	if d.released {
+	if d.released.Load() {
 		return
 	}
-	d.released = true
+	d.released.Store(true)
 
 	if d.queue != nil {
 		d.queue.release()

--- a/encoder_native.go
+++ b/encoder_native.go
@@ -258,6 +258,48 @@ func (e *CommandEncoder) TransitionTextures(barriers []TextureBarrier) {
 	}
 }
 
+// CopyBufferToTexture copies data from a buffer to a texture.
+// WebGPU spec: GPUCommandEncoder.copyBufferToTexture.
+func (e *CommandEncoder) CopyBufferToTexture(src *Buffer, dst *Texture, regions []BufferTextureCopy) {
+	if e.released || src == nil || dst == nil {
+		return
+	}
+	raw := e.core.RawEncoder()
+	if raw == nil {
+		return
+	}
+	halRegions := make([]hal.BufferTextureCopy, len(regions))
+	for i, r := range regions {
+		halRegions[i] = hal.BufferTextureCopy{
+			BufferLayout: hal.ImageDataLayout{
+				Offset:       r.BufferLayout.Offset,
+				BytesPerRow:  r.BufferLayout.BytesPerRow,
+				RowsPerImage: r.BufferLayout.RowsPerImage,
+			},
+			TextureBase: hal.ImageCopyTexture{
+				Texture:  dst.hal,
+				MipLevel: r.TextureBase.MipLevel,
+				Origin:   hal.Origin3D(r.TextureBase.Origin),
+			},
+			Size: hal.Extent3D(r.Size),
+		}
+	}
+	raw.CopyBufferToTexture(src.halBuffer(), dst.hal, halRegions)
+}
+
+// ClearBuffer clears a buffer region to zero.
+// WebGPU spec: GPUCommandEncoder.clearBuffer.
+func (e *CommandEncoder) ClearBuffer(buffer *Buffer, offset, size uint64) {
+	if e.released || buffer == nil {
+		return
+	}
+	raw := e.core.RawEncoder()
+	if raw == nil {
+		return
+	}
+	raw.ClearBuffer(buffer.halBuffer(), offset, size)
+}
+
 // DiscardEncoding discards the encoder without producing a command buffer.
 // Use this to abandon an in-progress encoding when an error occurs.
 // If the encoder was acquired from the pool, it is returned for reuse.

--- a/examples/browser-compute/index.html
+++ b/examples/browser-compute/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>wgpu Browser Compute Test</title>
+    <style>
+        body { font-family: monospace; background: #1a1a2e; color: #e0e0e0; padding: 20px; }
+        h1 { color: #00d4ff; }
+        #log { white-space: pre-wrap; line-height: 1.6; }
+    </style>
+</head>
+<body>
+    <h1>wgpu Browser Compute Test</h1>
+    <p>Validates WebGPU compute pipeline: shader → dispatch → readback.</p>
+    <p>Input: [1.0, 2.0, 3.0, 4.0] × 2.0 = [2.0, 4.0, 6.0, 8.0]</p>
+    <hr>
+    <div id="log">Loading WASM...</div>
+    <script src="wasm_exec.js"></script>
+    <script>
+        const go = new Go();
+        WebAssembly.instantiateStreaming(fetch("compute.wasm"), go.importObject).then((result) => {
+            go.run(result.instance);
+        });
+    </script>
+</body>
+</html>

--- a/examples/browser-compute/main.go
+++ b/examples/browser-compute/main.go
@@ -1,0 +1,202 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"syscall/js"
+
+	"github.com/gogpu/wgpu"
+)
+
+const computeShader = `
+@group(0) @binding(0) var<storage, read> input: array<f32>;
+@group(0) @binding(1) var<storage, read_write> output: array<f32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) id: vec3u) {
+    let i = id.x;
+    if (i < arrayLength(&input)) {
+        output[i] = input[i] * 2.0;
+    }
+}
+`
+
+func main() {
+	log := func(msg string) {
+		js.Global().Get("document").Call("getElementById", "log").Set("innerHTML",
+			js.Global().Get("document").Call("getElementById", "log").Get("innerHTML").String()+msg+"<br>")
+		fmt.Println(msg)
+	}
+
+	log("wgpu browser COMPUTE test starting...")
+
+	instance, err := wgpu.CreateInstance(nil)
+	if err != nil {
+		log("FAIL: CreateInstance: " + err.Error())
+		return
+	}
+
+	adapter, err := instance.RequestAdapter(nil)
+	if err != nil {
+		log("FAIL: RequestAdapter: " + err.Error())
+		return
+	}
+	log(fmt.Sprintf("OK: Adapter — %s", adapter.Info().Name))
+
+	device, err := adapter.RequestDevice(nil)
+	if err != nil {
+		log("FAIL: RequestDevice: " + err.Error())
+		return
+	}
+	log("OK: Device created")
+
+	// Create compute shader
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+		Label: "double-shader",
+		WGSL:  computeShader,
+	})
+	if err != nil {
+		log("FAIL: CreateShaderModule: " + err.Error())
+		return
+	}
+	log("OK: Compute shader created")
+
+	// Create bind group layout
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "compute-bgl",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{Binding: 0, Visibility: wgpu.ShaderStagesCompute, Buffer: &wgpu.BufferBindingLayout{Type: wgpu.BufferBindingTypeReadOnlyStorage}},
+			{Binding: 1, Visibility: wgpu.ShaderStagesCompute, Buffer: &wgpu.BufferBindingLayout{Type: wgpu.BufferBindingTypeStorage}},
+		},
+	})
+	if err != nil {
+		log("FAIL: CreateBindGroupLayout: " + err.Error())
+		return
+	}
+
+	// Create pipeline layout
+	pipelineLayout, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{
+		Label:            "compute-layout",
+		BindGroupLayouts: []*wgpu.BindGroupLayout{bgl},
+	})
+	if err != nil {
+		log("FAIL: CreatePipelineLayout: " + err.Error())
+		return
+	}
+
+	// Create compute pipeline
+	pipeline, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Label:  "double-pipeline",
+		Layout: pipelineLayout,
+		Compute: wgpu.ProgrammableStageDescriptor{
+			Module:     shader,
+			EntryPoint: "main",
+		},
+	})
+	if err != nil {
+		log("FAIL: CreateComputePipeline: " + err.Error())
+		return
+	}
+	log("OK: Compute pipeline created")
+
+	// Input data: [1.0, 2.0, 3.0, 4.0]
+	inputData := make([]byte, 4*4)
+	for i, v := range []float32{1.0, 2.0, 3.0, 4.0} {
+		binary.LittleEndian.PutUint32(inputData[i*4:], math.Float32bits(v))
+	}
+
+	inputBuf, _ := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "input",
+		Size:  uint64(len(inputData)),
+		Usage: wgpu.BufferUsageStorage | wgpu.BufferUsageCopyDst,
+	})
+	device.Queue().WriteBuffer(inputBuf, 0, inputData)
+
+	outputBuf, _ := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "output",
+		Size:  uint64(len(inputData)),
+		Usage: wgpu.BufferUsageStorage | wgpu.BufferUsageCopySrc,
+	})
+
+	readBuf, _ := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "readback",
+		Size:  uint64(len(inputData)),
+		Usage: wgpu.BufferUsageMapRead | wgpu.BufferUsageCopyDst,
+	})
+
+	// Create bind group
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "compute-bg",
+		Layout: bgl,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: inputBuf, Size: uint64(len(inputData))},
+			{Binding: 1, Buffer: outputBuf, Size: uint64(len(inputData))},
+		},
+	})
+	if err != nil {
+		log("FAIL: CreateBindGroup: " + err.Error())
+		return
+	}
+	log("OK: Buffers + BindGroup created")
+
+	// Dispatch compute
+	encoder, _ := device.CreateCommandEncoder(nil)
+	pass := encoder.BeginComputePass(nil)
+	pass.SetPipeline(pipeline)
+	pass.SetBindGroup(0, bg, nil)
+	pass.DispatchWorkgroups(1, 1, 1)
+	pass.End()
+
+	// Copy output → readback
+	encoder.CopyBufferToBuffer(outputBuf, 0, readBuf, 0, uint64(len(inputData)))
+
+	cmdBuf, _ := encoder.Finish()
+	_, err = device.Queue().Submit(cmdBuf)
+	if err != nil {
+		log("FAIL: Submit: " + err.Error())
+		return
+	}
+	log("OK: Compute dispatched + submitted")
+
+	// Read back results
+	err = readBuf.MapAsync(wgpu.MapModeRead, 0, uint64(len(inputData)), func(status wgpu.BufferMapAsyncStatus) {
+		if status != wgpu.BufferMapAsyncStatusSuccess {
+			log(fmt.Sprintf("FAIL: MapAsync status=%d", status))
+			return
+		}
+
+		mapped := readBuf.GetMappedRange(0, uint64(len(inputData)))
+		results := make([]float32, 4)
+		for i := range results {
+			results[i] = math.Float32frombits(binary.LittleEndian.Uint32(mapped[i*4:]))
+		}
+		readBuf.Unmap()
+
+		log(fmt.Sprintf("Results: %v", results))
+
+		// Verify: input * 2.0
+		expected := []float32{2.0, 4.0, 6.0, 8.0}
+		pass := true
+		for i := range expected {
+			if results[i] != expected[i] {
+				log(fmt.Sprintf("FAIL: results[%d] = %f, expected %f", i, results[i], expected[i]))
+				pass = false
+			}
+		}
+		if pass {
+			log("")
+			log("ALL COMPUTE TESTS PASSED — browser WebGPU compute works!")
+			log("Born ML can run inference in browser via WASM + WebGPU.")
+		}
+	})
+	if err != nil {
+		log("FAIL: MapAsync: " + err.Error())
+		return
+	}
+
+	// Keep alive for async callback
+	select {}
+}

--- a/gpucontext_sentinel.go
+++ b/gpucontext_sentinel.go
@@ -1,0 +1,14 @@
+package wgpu
+
+// gpucontext sentinel methods — satisfy gpucontext.Device/Queue/Adapter/Surface/Instance
+// interfaces. These unexported methods prevent nil or arbitrary types from being
+// passed where a real GPU object is expected (compile-time safety).
+//
+// Linter flags these as "unused" because it doesn't see cross-package interface
+// satisfaction. The methods ARE used — gpucontext.Device requires gpuDevice(), etc.
+
+func (*Device) gpuDevice()     {} //nolint:unused // implements gpucontext.Device
+func (*Queue) gpuQueue()       {} //nolint:unused // implements gpucontext.Queue
+func (*Adapter) gpuAdapter()   {} //nolint:unused // implements gpucontext.Adapter
+func (*Surface) gpuSurface()   {} //nolint:unused // implements gpucontext.Surface
+func (*Instance) gpuInstance() {} //nolint:unused // implements gpucontext.Instance

--- a/hal/descriptor.go
+++ b/hal/descriptor.go
@@ -661,30 +661,16 @@ type StencilFaceState struct {
 }
 
 // StencilOperation describes a stencil operation.
-type StencilOperation uint8
+// Canonical definition in gputypes with webgpu.h spec-compliant values.
+type StencilOperation = gputypes.StencilOperation
 
 const (
-	// StencilOperationKeep keeps the current value.
-	StencilOperationKeep StencilOperation = iota
-
-	// StencilOperationZero sets the value to zero.
-	StencilOperationZero
-
-	// StencilOperationReplace replaces with the reference value.
-	StencilOperationReplace
-
-	// StencilOperationInvert inverts the bits.
-	StencilOperationInvert
-
-	// StencilOperationIncrementClamp increments and clamps.
-	StencilOperationIncrementClamp
-
-	// StencilOperationDecrementClamp decrements and clamps.
-	StencilOperationDecrementClamp
-
-	// StencilOperationIncrementWrap increments and wraps.
-	StencilOperationIncrementWrap
-
-	// StencilOperationDecrementWrap decrements and wraps.
-	StencilOperationDecrementWrap
+	StencilOperationKeep           = gputypes.StencilOperationKeep
+	StencilOperationZero           = gputypes.StencilOperationZero
+	StencilOperationReplace        = gputypes.StencilOperationReplace
+	StencilOperationInvert         = gputypes.StencilOperationInvert
+	StencilOperationIncrementClamp = gputypes.StencilOperationIncrementClamp
+	StencilOperationDecrementClamp = gputypes.StencilOperationDecrementClamp
+	StencilOperationIncrementWrap  = gputypes.StencilOperationIncrementWrap
+	StencilOperationDecrementWrap  = gputypes.StencilOperationDecrementWrap
 )

--- a/types.go
+++ b/types.go
@@ -2,9 +2,13 @@ package wgpu
 
 import "github.com/gogpu/gputypes"
 
-// MaxBindGroups is the maximum number of bind groups allowed by the WebGPU spec.
-// This is the hard cap (wgpu-hal MAX_BIND_GROUPS = 8). Actual device limits
-// may be lower (typically 4 in the WebGPU spec).
+// MinBindGroups is the minimum guaranteed number of bind groups per WebGPU spec.
+// All compliant devices support at least 4 bind groups. Portable code should
+// use no more than MinBindGroups.
+const MinBindGroups = 4
+
+// MaxBindGroups is the HAL hard cap on bind groups (wgpu-hal MAX_BIND_GROUPS = 8).
+// Devices may support up to 8, but only MinBindGroups (4) is guaranteed.
 const MaxBindGroups = 8
 
 // Backend types


### PR DESCRIPTION
BREAKING: StencilOperation→gputypes (webgpu.h spec values), Device.released→atomic.Bool, gpucontext sentinel methods. 6 API divergences fixed (ADR-047). MinBindGroups=4, CopyBufferToTexture+ClearBuffer native, browser fence stubs, browser-compute example. Requires gpucontext v0.20.0.