### PR TITLE
chore: bump goffi v0.5.5 (v0.30.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.2] - 2026-06-17
+
+### Dependencies
+
+- goffi v0.5.3 → v0.5.5
+
 ## [0.30.1] - 2026-06-15
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/wgpu
 go 1.25.0
 
 require (
-	github.com/go-webgpu/goffi v0.5.3
+	github.com/go-webgpu/goffi v0.5.5
 	github.com/go-webgpu/webgpu v0.5.2
 	github.com/gogpu/gpucontext v0.21.0
 	github.com/gogpu/gputypes v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.5.3 h1:Ckc94SdHO42bIb0oEapRIcv+jKjhjGJfb9zPEvNKC7U=
-github.com/go-webgpu/goffi v0.5.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE=
+github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=


### PR DESCRIPTION
Dependency update: goffi v0.5.3 → v0.5.5.