### PR TITLE
fix(hal): add tanh + integer clamp to SPIR-V interpreter

### DIFF
--- a/hal/software/shader/glsl_ext.go
+++ b/hal/software/shader/glsl_ext.go
@@ -31,6 +31,13 @@ const (
 	GLSLAcos = 17
 	GLSLAtan = 18
 
+	GLSLSinh  = 19
+	GLSLCosh  = 20
+	GLSLTanh  = 21
+	GLSLAsinh = 22
+	GLSLAcosh = 23
+	GLSLAtanh = 24
+
 	GLSLPow         = 26
 	GLSLExp         = 27
 	GLSLLog         = 28
@@ -46,6 +53,8 @@ const (
 	GLSLUMax   = 41
 	GLSLSMax   = 42
 	GLSLFClamp = 43
+	GLSLUClamp = 44
+	GLSLSClamp = 45
 
 	GLSLFMix       = 46
 	GLSLStep       = 48
@@ -140,6 +149,32 @@ func (interp *interpreter) executeGLSLExtInst(instNum uint32, operands []uint32)
 			return float32(math.Atan2(float64(y), float64(x)))
 		})
 
+	// --- Hyperbolic ops ---
+	case GLSLSinh:
+		return interp.glslUnaryFloat(operands, func(x float32) float32 {
+			return float32(math.Sinh(float64(x)))
+		})
+	case GLSLCosh:
+		return interp.glslUnaryFloat(operands, func(x float32) float32 {
+			return float32(math.Cosh(float64(x)))
+		})
+	case GLSLTanh:
+		return interp.glslUnaryFloat(operands, func(x float32) float32 {
+			return float32(math.Tanh(float64(x)))
+		})
+	case GLSLAsinh:
+		return interp.glslUnaryFloat(operands, func(x float32) float32 {
+			return float32(math.Asinh(float64(x)))
+		})
+	case GLSLAcosh:
+		return interp.glslUnaryFloat(operands, func(x float32) float32 {
+			return float32(math.Acosh(float64(x)))
+		})
+	case GLSLAtanh:
+		return interp.glslUnaryFloat(operands, func(x float32) float32 {
+			return float32(math.Atanh(float64(x)))
+		})
+
 	// --- Exponential ops ---
 	case GLSLPow:
 		return interp.glslBinaryFloat(operands, func(x, y float32) float32 {
@@ -185,6 +220,26 @@ func (interp *interpreter) executeGLSLExtInst(instNum uint32, operands []uint32)
 	case GLSLFClamp:
 		return interp.glslTernaryFloat(operands, func(x, minVal, maxVal float32) float32 {
 			return float32(math.Min(math.Max(float64(x), float64(minVal)), float64(maxVal)))
+		})
+	case GLSLUClamp:
+		return interp.glslTernaryUint(operands, func(x, minVal, maxVal uint32) uint32 {
+			if x < minVal {
+				x = minVal
+			}
+			if x > maxVal {
+				x = maxVal
+			}
+			return x
+		})
+	case GLSLSClamp:
+		return interp.glslTernaryInt(operands, func(x, minVal, maxVal int32) int32 {
+			if x < minVal {
+				x = minVal
+			}
+			if x > maxVal {
+				x = maxVal
+			}
+			return x
 		})
 	case GLSLUMin:
 		return interp.glslBinaryUint(operands, func(a, b uint32) uint32 {
@@ -355,6 +410,28 @@ func (interp *interpreter) glslBinaryInt(operands []uint32, fn func(int32, int32
 	a := int32(toUint32(interp.values[operands[0]]))
 	b := int32(toUint32(interp.values[operands[1]]))
 	return ValInt(fn(a, b))
+}
+
+// glslTernaryUint applies a ternary uint function.
+func (interp *interpreter) glslTernaryUint(operands []uint32, fn func(uint32, uint32, uint32) uint32) Value {
+	if len(operands) < 3 {
+		return ValUint(0)
+	}
+	a := toUint32(interp.values[operands[0]])
+	b := toUint32(interp.values[operands[1]])
+	c := toUint32(interp.values[operands[2]])
+	return ValUint(fn(a, b, c))
+}
+
+// glslTernaryInt applies a ternary signed int function.
+func (interp *interpreter) glslTernaryInt(operands []uint32, fn func(int32, int32, int32) int32) Value {
+	if len(operands) < 3 {
+		return ValInt(0)
+	}
+	a := int32(toUint32(interp.values[operands[0]]))
+	b := int32(toUint32(interp.values[operands[1]]))
+	c := int32(toUint32(interp.values[operands[2]]))
+	return ValInt(fn(a, b, c))
 }
 
 // =============================================================================

--- a/hal/software/shader/glsl_ext_test.go
+++ b/hal/software/shader/glsl_ext_test.go
@@ -301,6 +301,14 @@ func TestGLSLUnaryIntrinsics(t *testing.T) {
 		{"atan_0", GLSLAtan, 0.0, 0.0, 1e-5},
 		{"asin_0", GLSLAsin, 0.0, 0.0, 1e-5},
 		{"acos_1", GLSLAcos, 1.0, 0.0, 1e-5},
+		{"sinh_0", GLSLSinh, 0.0, 0.0, 1e-5},
+		{"cosh_0", GLSLCosh, 0.0, 1.0, 1e-5},
+		{"tanh_0", GLSLTanh, 0.0, 0.0, 1e-5},
+		{"tanh_sat", GLSLTanh, 10.0, 1.0, 1e-4},
+		{"tanh_neg", GLSLTanh, -10.0, -1.0, 1e-4},
+		{"asinh_0", GLSLAsinh, 0.0, 0.0, 1e-5},
+		{"acosh_1", GLSLAcosh, 1.0, 0.0, 1e-5},
+		{"atanh_0", GLSLAtanh, 0.0, 0.0, 1e-5},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -458,5 +466,74 @@ func TestGLSLIntOps(t *testing.T) {
 	got = interp.executeGLSLExtInst(GLSLSSign, []uint32{12})
 	if got.Tag != TagInt32 || got.AsInt32() != 1 {
 		t.Errorf("SSign(7) = %v, want 1", got)
+	}
+}
+
+// TestGLSLSClamp verifies signed-integer clamp (SClamp).
+func TestGLSLSClamp(t *testing.T) {
+	m := &Module{
+		Types:          map[uint32]*TypeInfo{},
+		Constants:      map[uint32]Value{},
+		ExtInstImports: map[uint32]string{1: "GLSL.std.450"},
+	}
+	tests := []struct {
+		name        string
+		x, min, max int32
+		want        int32
+	}{
+		{"below_min", -5, 0, 10, 0},
+		{"in_range", 3, 0, 10, 3},
+		{"above_max", 20, 0, 10, 10},
+		{"negative_range", -7, -10, -1, -7},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interp := &interpreter{
+				module: m,
+				values: testMakeValues(map[uint32]any{
+					10: ValInt(tt.x),
+					11: ValInt(tt.min),
+					12: ValInt(tt.max),
+				}),
+			}
+			got := interp.executeGLSLExtInst(GLSLSClamp, []uint32{10, 11, 12})
+			if got.Tag != TagInt32 || got.AsInt32() != tt.want {
+				t.Errorf("SClamp(%d,%d,%d) = %v, want %d", tt.x, tt.min, tt.max, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGLSLUClamp verifies unsigned-integer clamp (UClamp).
+func TestGLSLUClamp(t *testing.T) {
+	m := &Module{
+		Types:          map[uint32]*TypeInfo{},
+		Constants:      map[uint32]Value{},
+		ExtInstImports: map[uint32]string{1: "GLSL.std.450"},
+	}
+	tests := []struct {
+		name        string
+		x, min, max uint32
+		want        uint32
+	}{
+		{"below_min", 1, 2, 10, 2},
+		{"in_range", 7, 2, 10, 7},
+		{"above_max", 50, 2, 10, 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interp := &interpreter{
+				module: m,
+				values: testMakeValues(map[uint32]any{
+					10: ValUint(tt.x),
+					11: ValUint(tt.min),
+					12: ValUint(tt.max),
+				}),
+			}
+			got := interp.executeGLSLExtInst(GLSLUClamp, []uint32{10, 11, 12})
+			if got.Tag != TagUint32 || got.AsUint32() != tt.want {
+				t.Errorf("UClamp(%d,%d,%d) = %v, want %d", tt.x, tt.min, tt.max, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

The software SPIR-V interpreter's GLSL.std.450 dispatch was missing two
common math builtins. Unknown ext-inst opcodes fall through to
`return ValUint(0)`, so shaders calling these got **silently wrong
results (zeros) rather than an error**:

- `tanh()` — `Tanh` (21) absent (all hyperbolics, 19–24, were missing)
- integer `clamp()` — `SClamp` (45) and `UClamp` (44) absent; only the
  float `FClamp` (43) was handled

## Changes

- Implement `Sinh`/`Cosh`/`Tanh`/`Asinh`/`Acosh`/`Atanh` (19–24) and
  `UClamp`/`SClamp` (44–45) in `hal/software/shader/glsl_ext.go`.
- Add `glslTernaryUint` / `glslTernaryInt` helpers, mirroring the
  existing `glslBinary*` ones.
- Interpreter tests for each: hyperbolic rows in `TestGLSLUnaryIntrinsics`,
  plus `TestGLSLSClamp` / `TestGLSLUClamp`.

## Testing

`go test ./hal/software/shader/` and `go vet ./hal/software/shader/` pass.

## Discovery

Surfaced by the born ML framework's webgpu backend on the software path,
where its `Tanh` and `Int32 Clamp` ops returned all-zeros. With these
opcodes implemented, both produce correct results.

No existing issue tracked this; still reproducible on `main`.
