### PR TITLE
docs: CHANGELOG + AGENTS.md for v0.30.3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 
 ## Current Version
 
-v0.30.2 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.0
+v0.30.3 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.0
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.3] - 2026-06-24
+
+### Added
+
+- **SPIR-V interpreter: hyperbolic math** — `Sinh`/`Cosh`/`Tanh`/`Asinh`/`Acosh`/`Atanh`
+  (GLSL.std.450 opcodes 19–24). Previously returned silent zeros.
+- **SPIR-V interpreter: integer clamp** — `UClamp` (44) and `SClamp` (45) for unsigned
+  and signed integers. Only float `FClamp` was implemented before.
+- `glslTernaryUint`/`glslTernaryInt` helpers for ternary integer operations.
+
+### Contributors
+
+- **@amery** ([PR #225](https://github.com/gogpu/wgpu/pull/225)) — discovered and fixed
+  missing opcodes via Born ML's software backend path.
+
 ## [0.30.2] - 2026-06-17
 
 ### Dependencies


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.30.3 release
- Update AGENTS.md version reference

### What's in v0.30.3

**SPIR-V interpreter: missing GLSL.std.450 opcodes** (PR #225, @amery)

- Hyperbolic math: `Sinh`/`Cosh`/`Tanh`/`Asinh`/`Acosh`/`Atanh` (opcodes 19–24)
- Integer clamp: `UClamp` (44), `SClamp` (45)
- Previously these returned silent zeros — discovered via Born ML's software backend path

## Test plan

- [x] `go build ./...` — pass
- [x] `go test ./hal/software/shader/` — 31 GLSL tests pass (8 new)
- [x] `golangci-lint run --timeout=5m` — clean
- [x] Cross-platform build verified locally
