### PR TITLE
fix(hal/metal): translate stencil state into MTLDepthStencilState

### DIFF
--- a/hal/metal/conv.go
+++ b/hal/metal/conv.go
@@ -225,6 +225,31 @@ func compareFunctionToMTL(fn gputypes.CompareFunction) MTLCompareFunction {
 	}
 }
 
+// stencilOperationToMTL maps a WebGPU stencil operation to Metal. The two enums
+// use different numeric values, so an explicit switch is required.
+func stencilOperationToMTL(op gputypes.StencilOperation) MTLStencilOperation {
+	switch op {
+	case gputypes.StencilOperationKeep:
+		return MTLStencilOperationKeep
+	case gputypes.StencilOperationZero:
+		return MTLStencilOperationZero
+	case gputypes.StencilOperationReplace:
+		return MTLStencilOperationReplace
+	case gputypes.StencilOperationInvert:
+		return MTLStencilOperationInvert
+	case gputypes.StencilOperationIncrementClamp:
+		return MTLStencilOperationIncrementClamp
+	case gputypes.StencilOperationDecrementClamp:
+		return MTLStencilOperationDecrementClamp
+	case gputypes.StencilOperationIncrementWrap:
+		return MTLStencilOperationIncrementWrap
+	case gputypes.StencilOperationDecrementWrap:
+		return MTLStencilOperationDecrementWrap
+	default:
+		return MTLStencilOperationKeep
+	}
+}
+
 // primitiveTopologyToMTL converts WebGPU primitive topology to Metal primitive type.
 func primitiveTopologyToMTL(topology gputypes.PrimitiveTopology) MTLPrimitiveType {
 	switch topology {

--- a/hal/metal/conv_test.go
+++ b/hal/metal/conv_test.go
@@ -273,6 +273,37 @@ func TestCompareFunctionToMTL(t *testing.T) {
 	}
 }
 
+// TestStencilOperationToMTL guards the WebGPU→Metal stencil-op mapping. The two
+// enums use different numeric values (WebGPU Keep=1, Metal Keep=0), so this must
+// be an explicit table — a missing/incorrect entry silently disables stencil ops
+// (the macOS rounded-UI-renders-as-squares regression).
+func TestStencilOperationToMTL(t *testing.T) {
+	tests := []struct {
+		name   string
+		op     gputypes.StencilOperation
+		expect MTLStencilOperation
+	}{
+		{"Keep", gputypes.StencilOperationKeep, MTLStencilOperationKeep},
+		{"Zero", gputypes.StencilOperationZero, MTLStencilOperationZero},
+		{"Replace", gputypes.StencilOperationReplace, MTLStencilOperationReplace},
+		{"Invert", gputypes.StencilOperationInvert, MTLStencilOperationInvert},
+		{"IncrementClamp", gputypes.StencilOperationIncrementClamp, MTLStencilOperationIncrementClamp},
+		{"DecrementClamp", gputypes.StencilOperationDecrementClamp, MTLStencilOperationDecrementClamp},
+		{"IncrementWrap", gputypes.StencilOperationIncrementWrap, MTLStencilOperationIncrementWrap},
+		{"DecrementWrap", gputypes.StencilOperationDecrementWrap, MTLStencilOperationDecrementWrap},
+		{"Unknown defaults to Keep", gputypes.StencilOperation(99), MTLStencilOperationKeep},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stencilOperationToMTL(tt.op)
+			if got != tt.expect {
+				t.Errorf("stencilOperationToMTL(%v) = %v, want %v", tt.op, got, tt.expect)
+			}
+		})
+	}
+}
+
 // TestPrimitiveTopologyToMTL tests primitive topology conversions.
 func TestPrimitiveTopologyToMTL(t *testing.T) {
 	tests := []struct {

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -685,7 +685,23 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 		depthStencilDesc := MsgSend(ID(GetClass("MTLDepthStencilDescriptor")), Sel("new"))
 		_ = MsgSend(depthStencilDesc, Sel("setDepthCompareFunction:"), uintptr(compareFunctionToMTL(desc.DepthStencil.DepthCompare)))
 		msgSendVoid(depthStencilDesc, Sel("setDepthWriteEnabled:"), argBool(desc.DepthStencil.DepthWriteEnabled))
+
+		// Translate the stencil state. Without this Metal keeps its defaults
+		// (compare = Always, ops = Keep) and the stencil test is silently
+		// ignored. WebGPU masks are global, so both faces share them; the face
+		// properties copy, so each descriptor is released after assignment.
+		front := newStencilFaceDescriptor(desc.DepthStencil.StencilFront,
+			desc.DepthStencil.StencilReadMask, desc.DepthStencil.StencilWriteMask)
+		MsgSend(depthStencilDesc, Sel("setFrontFaceStencil:"), uintptr(front))
+		Release(front)
+
+		back := newStencilFaceDescriptor(desc.DepthStencil.StencilBack,
+			desc.DepthStencil.StencilReadMask, desc.DepthStencil.StencilWriteMask)
+		MsgSend(depthStencilDesc, Sel("setBackFaceStencil:"), uintptr(back))
+		Release(back)
+
 		depthStencilState = MsgSend(d.raw, Sel("newDepthStencilStateWithDescriptor:"), uintptr(depthStencilDesc))
+		Release(depthStencilDesc)
 
 		// Record bias values to set in render pass
 		depthBias = float32(desc.DepthStencil.DepthBias)
@@ -739,6 +755,20 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 		depthSlopeScale: depthSlopeScale,
 		depthClamp:      depthClamp,
 	}, nil
+}
+
+// newStencilFaceDescriptor builds an MTLStencilDescriptor for one face. The
+// returned object is owned by the caller and must be Released after it is
+// assigned to the depth-stencil descriptor (whose face properties copy it).
+func newStencilFaceDescriptor(face hal.StencilFaceState, readMask, writeMask uint32) ID {
+	sd := MsgSend(ID(GetClass("MTLStencilDescriptor")), Sel("new"))
+	MsgSend(sd, Sel("setStencilCompareFunction:"), uintptr(compareFunctionToMTL(face.Compare)))
+	MsgSend(sd, Sel("setStencilFailureOperation:"), uintptr(stencilOperationToMTL(face.FailOp)))
+	MsgSend(sd, Sel("setDepthFailureOperation:"), uintptr(stencilOperationToMTL(face.DepthFailOp)))
+	MsgSend(sd, Sel("setDepthStencilPassOperation:"), uintptr(stencilOperationToMTL(face.PassOp)))
+	MsgSend(sd, Sel("setReadMask:"), uintptr(readMask))
+	MsgSend(sd, Sel("setWriteMask:"), uintptr(writeMask))
+	return sd
 }
 
 // buildVertexDescriptor creates an MTLVertexDescriptor from WebGPU vertex buffer layouts.


### PR DESCRIPTION
### Summary
The Metal HAL never translated a pipeline's stencil state into its
`MTLDepthStencilState`. As a result the stencil test was silently inert on Metal:
any pipeline that relied on it behaved as if `stencilCompareFunction = Always`.

The most visible casualty was the **stencil-then-cover** fill path. The cover pass
draws the path's bounding quad with a `NotEqual`/ref-0 stencil test so only pixels
inside the tessellated path are painted. With the test defaulting to `Always`, the
cover pass painted the **entire bounding quad** instead. On Apple Silicon this meant
rounded UI panels rendered as **squares** and clipped / stencil-masked content
(swatches, toggle pills, slider tracks) **vanished**. Vulkan, D3D12 and GLES already
translate the full stencil state — Metal was the only backend missing it.

### Root cause
`device.go`, `CreateRenderPipeline`: the `MTLDepthStencilDescriptor` was configured
with only `setDepthCompareFunction:` and `setDepthWriteEnabled:`. The
`StencilFront` / `StencilBack` faces, the compare functions, the fail / depth-fail /
pass operations, and the read / write masks from the WebGPU `DepthStencilState` were
never applied, so the descriptor kept Metal's defaults (`Always` / `Keep`).

### Changes
- **`hal/metal/device.go`** — build front and back `MTLStencilDescriptor`s from
  `StencilFront` / `StencilBack` (compare function + fail / depth-fail / pass ops) and
  apply the global read / write masks, then set them on the depth-stencil descriptor.
  WebGPU read/write masks are global (not per-face), so both faces share them.
- **`hal/metal/conv.go`** — add `stencilOperationToMTL`. The WebGPU and Metal
  stencil-op enums use **different numeric values** (e.g. WebGPU `Keep = 1`,
  Metal `Keep = 0`; WebGPU `IncrementWrap = 7`, Metal `IncrementWrap = 6`), so an
  explicit mapping is required — a bit-for-bit reinterpret would be wrong.
- **`hal/metal/conv_test.go`** — table-driven unit test for the new mapping.
- Also `Release` the stencil descriptors (and the depth-stencil descriptor) after
  assignment — the descriptor properties copy, so this fixes a small pre-existing leak.

### Testing
Verified on Apple Silicon (M4) against a real Metal device by driving gg's
stencil-then-cover renderer with GPU→CPU pixel readback (companion regression tests
on the gg side):

- **Circle / rounded rect / even-odd ring** — each shape must mask to its path, not
  flood the cover quad's bounding box.
  - **Before:** bounding-box corners painted opaque (circle rendered as a square,
    even-odd hole filled).
  - **After:** corners transparent, rounded corners clipped, even-odd hole empty.
- `go test ./hal/metal/` passes (excluding a pre-existing, unrelated surface-test
  crash that reproduces on `main`).
- Full gg test tree passes with this change in place.

### Scope / risk
- Additive only; no change to depth-only pipelines (a default/zero stencil face maps
  to `Always` + `Keep`, i.e. pass-through, matching prior behavior).
- Brings Metal in line with the Vulkan / D3D12 / GLES HALs, which already translate
  the full stencil state.
