### PR TITLE
fix(hal/metal): stencil pixel format + v0.30.4 docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 
 ## Current Version
 
-v0.30.3 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.0
+v0.30.4 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.0
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.4] - 2026-06-25
+
+### Fixed
+
+- **Metal: stencil state translation** — `CreateRenderPipeline` now translates
+  `StencilFront`/`StencilBack` face states (compare function, fail/depth-fail/pass ops)
+  and read/write masks into `MTLDepthStencilState`. Previously Metal kept defaults
+  (`Always` + `Keep`), silently disabling the stencil test. Visible as rounded UI
+  rendering as squares on macOS (stencil-then-cover fill path).
+- **Metal: stencil attachment pixel format** — set `stencilAttachmentPixelFormat` on
+  the render pipeline descriptor for formats with stencil aspects (`Depth24PlusStencil8`,
+  `Depth32FloatStencil8`, `Stencil8`). Matches Rust wgpu-hal Metal pattern.
+- **Metal: depth-stencil descriptor leak** — `Release(depthStencilDesc)` after
+  `newDepthStencilStateWithDescriptor:` (descriptor properties copy).
+
+### Added
+
+- `stencilOperationToMTL` — explicit WebGPU→Metal stencil operation mapping
+  (required: enum values differ, e.g. `Invert`: WebGPU=4, Metal=5).
+
+### Contributors
+
+- **@samyfodil** ([PR #227](https://github.com/gogpu/wgpu/pull/227)) — discovered and
+  fixed Metal stencil state, verified on Apple Silicon M4.
+
 ## [0.30.3] - 2026-06-24
 
 ### Added

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -678,8 +678,13 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 	var depthStencilState ID
 	var depthBias, depthSlopeScale, depthClamp float32
 	if desc.DepthStencil != nil {
-		// Set depth attachment format
-		_ = MsgSend(pipelineDesc, Sel("setDepthAttachmentPixelFormat:"), uintptr(d.adapter.mapTextureFormat(desc.DepthStencil.Format)))
+		rawFormat := uintptr(d.adapter.mapTextureFormat(desc.DepthStencil.Format))
+		if desc.DepthStencil.Format.HasDepth() {
+			_ = MsgSend(pipelineDesc, Sel("setDepthAttachmentPixelFormat:"), rawFormat)
+		}
+		if desc.DepthStencil.Format.HasStencil() {
+			_ = MsgSend(pipelineDesc, Sel("setStencilAttachmentPixelFormat:"), rawFormat)
+		}
 
 		// Create depth stencil state
 		depthStencilDesc := MsgSend(ID(GetClass("MTLDepthStencilDescriptor")), Sel("new"))


### PR DESCRIPTION
## Summary

- **Metal stencil attachment pixel format** — set `stencilAttachmentPixelFormat` on the render pipeline descriptor for formats with stencil aspects. Matches Rust wgpu-hal Metal pattern
- **Conditional depth/stencil format** — `setDepthAttachmentPixelFormat` only for `HasDepth()`, `setStencilAttachmentPixelFormat` only for `HasStencil()`. `Stencil8`-only format no longer incorrectly sets a depth attachment
- CHANGELOG + AGENTS.md for v0.30.4 (includes PR #227 @samyfodil Metal stencil state)

### Context

Follow-up to PR #227 (@samyfodil). During Rust wgpu reference review we found that Rust sets `stencilAttachmentPixelFormat` separately (device.rs:1457-1458) — our Metal HAL never did.

## Test plan

- [x] `go build ./...` — pass
- [x] `GOOS=darwin GOARCH=arm64 go build ./...` — pass
- [x] `go test ./...` — all 14 packages pass
- [x] `golangci-lint run --timeout=5m` — clean
