### PR TITLE
software backend: fix R8 texture sampling stride and implement DrawIndexed

### DIFF
--- a/hal/software/command.go
+++ b/hal/software/command.go
@@ -237,6 +237,12 @@ type RenderPassEncoder struct {
 	indexFormat gputypes.IndexFormat
 	indexOffset uint64
 
+	// activeIndices, when non-nil, remaps the sequential draw position to a
+	// vertex index for the current DrawIndexed call (already including
+	// baseVertex). The vertex fetch paths consult it instead of computing
+	// firstVertex+i, so indexed and non-indexed draws share one rasterizer.
+	activeIndices []uint32
+
 	// Viewport and scissor state.
 	viewport    [6]float32 // x, y, w, h, minDepth, maxDepth
 	scissorRect [4]uint32  // x, y, w, h
@@ -404,8 +410,75 @@ func (r *RenderPassEncoder) Draw(vertexCount, instanceCount, firstVertex, firstI
 	r.executeDraw(vertexCount, instanceCount, firstVertex, firstInstance)
 }
 
-// DrawIndexed is a no-op (indexed drawing not yet implemented).
-func (r *RenderPassEncoder) DrawIndexed(_, _, _ uint32, _ int32, _ uint32) {}
+// DrawIndexed executes an indexed draw call. It resolves the index buffer into
+// a list of vertex indices (applying baseVertex) and runs the same vertex-fetch
+// and rasterization path as Draw, with vertex positions remapped through the
+// resolved indices. Previously this was a no-op, so every indexed draw (glyph
+// mask text, MSDF text) rendered nothing on the software backend.
+func (r *RenderPassEncoder) DrawIndexed(indexCount, instanceCount, firstIndex uint32, baseVertex int32, firstInstance uint32) {
+	r.drawCount++
+	if indexCount == 0 || r.indexBuffer == nil {
+		return
+	}
+	indices := r.resolveIndices(indexCount, firstIndex, baseVertex)
+	if indices == nil {
+		return
+	}
+	hal.Logger().Debug("software: DrawIndexed", "indices", indexCount, "instances", instanceCount, "drawIndex", r.drawCount)
+
+	r.activeIndices = indices
+	defer func() { r.activeIndices = nil }()
+	// vertexCount == indexCount; firstVertex is unused because activeIndices
+	// supplies the per-position vertex index directly.
+	r.executeDraw(indexCount, instanceCount, 0, firstInstance)
+}
+
+// resolveIndices reads indexCount entries from the bound index buffer starting
+// at firstIndex, honoring the index format (Uint16/Uint32) and the buffer
+// offset set by SetIndexBuffer, and adds baseVertex to each. Returns nil if the
+// requested range lies outside the buffer.
+func (r *RenderPassEncoder) resolveIndices(indexCount, firstIndex uint32, baseVertex int32) []uint32 {
+	indexSize := uint64(2)
+	if r.indexFormat == gputypes.IndexFormatUint32 {
+		indexSize = 4
+	}
+
+	r.indexBuffer.mu.RLock()
+	data := r.indexBuffer.data
+	r.indexBuffer.mu.RUnlock()
+
+	start := r.indexOffset + uint64(firstIndex)*indexSize
+	end := start + uint64(indexCount)*indexSize
+	if end > uint64(len(data)) {
+		return nil
+	}
+
+	out := make([]uint32, indexCount)
+	for i := uint32(0); i < indexCount; i++ {
+		off := start + uint64(i)*indexSize
+		var idx uint32
+		if indexSize == 4 {
+			idx = uint32(data[off]) | uint32(data[off+1])<<8 | uint32(data[off+2])<<16 | uint32(data[off+3])<<24
+		} else {
+			idx = uint32(data[off]) | uint32(data[off+1])<<8
+		}
+		out[i] = uint32(int32(idx) + baseVertex) //nolint:gosec // index + baseVertex is a valid vertex index
+	}
+	return out
+}
+
+// drawVertexIndex maps a sequential draw position to the vertex index to fetch.
+// For non-indexed draws it is firstVertex+pos; for indexed draws it reads the
+// resolved index list set by DrawIndexed.
+func (r *RenderPassEncoder) drawVertexIndex(firstVertex, pos uint32) uint32 {
+	if r.activeIndices != nil {
+		if pos < uint32(len(r.activeIndices)) {
+			return r.activeIndices[pos]
+		}
+		return 0
+	}
+	return firstVertex + pos
+}
 
 // DrawIndirect is a no-op.
 func (r *RenderPassEncoder) DrawIndirect(_ hal.Buffer, _ uint64) {}

--- a/hal/software/command.go
+++ b/hal/software/command.go
@@ -462,7 +462,7 @@ func (r *RenderPassEncoder) resolveIndices(indexCount, firstIndex uint32, baseVe
 		} else {
 			idx = uint32(data[off]) | uint32(data[off+1])<<8
 		}
-		out[i] = uint32(int32(idx) + baseVertex) //nolint:gosec // index + baseVertex is a valid vertex index
+		out[i] = uint32(int32(idx) + baseVertex)
 	}
 	return out
 }

--- a/hal/software/device.go
+++ b/hal/software/device.go
@@ -75,10 +75,11 @@ func (d *Device) CreateTexture(desc *hal.TextureDescriptor) (hal.Texture, error)
 	if desc == nil {
 		return nil, fmt.Errorf("BUG: texture descriptor is nil in Software.CreateTexture — core validation gap")
 	}
-	// Calculate total size needed for texture data
-	// Simple calculation: width * height * depth * bytesPerPixel
-	// Assuming 4 bytes per pixel (RGBA8) for now
-	bytesPerPixel := uint64(4)
+	// Calculate total size needed for texture data: width * height * depth *
+	// bytesPerPixel, where bytesPerPixel is derived from the format (R8=1,
+	// RG8/R16=2, RGBA8/BGRA8=4). Hardcoding 4 here corrupted single-channel
+	// formats such as the R8 glyph atlas.
+	bytesPerPixel := formatBytesPerPixel(desc.Format)
 	totalSize := uint64(desc.Size.Width) * uint64(desc.Size.Height) * uint64(desc.Size.DepthOrArrayLayers) * bytesPerPixel
 
 	return &Texture{

--- a/hal/software/draw.go
+++ b/hal/software/draw.go
@@ -355,7 +355,7 @@ func (r *RenderPassEncoder) fetchTriangles(
 	// Read all vertices.
 	vertices := make([]raster.ScreenVertex, 0, vertexCount)
 	for i := uint32(0); i < vertexCount; i++ {
-		vi := firstVertex + i
+		vi := r.drawVertexIndex(firstVertex, i)
 		base := vb.offset + uint64(vi)*stride
 
 		// Read position.
@@ -516,7 +516,7 @@ func (r *RenderPassEncoder) fetchTrianglesSPIRV(
 
 		vertices := make([]raster.ScreenVertex, 0, vertexCount)
 		for vert := uint32(0); vert < vertexCount; vert++ {
-			vertexID := firstVertex + vert
+			vertexID := r.drawVertexIndex(firstVertex, vert)
 
 			// Build input map for this invocation.
 			inputs := make(map[uint32]shader.Value)
@@ -706,9 +706,11 @@ func (r *RenderPassEncoder) buildExecutionContext() *shader.ExecutionContext {
 				Group:   uint32(groupIdx),
 				Binding: bindingIdx,
 			}] = &shader.Texture2D{
-				Width:  tv.texture.width,
-				Height: tv.texture.height,
-				Data:   tv.texture.data,
+				Width:         tv.texture.width,
+				Height:        tv.texture.height,
+				Data:          tv.texture.data,
+				Format:        uint32(tv.texture.format),
+				BytesPerPixel: uint32(formatBytesPerPixel(tv.texture.format)),
 			}
 			tv.texture.mu.RUnlock()
 		}

--- a/hal/software/queue.go
+++ b/hal/software/queue.go
@@ -50,27 +50,31 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 		return nil
 	}
 
-	const bytesPerPixel = 4
+	// bytesPerPixel must match the texture's format, not a hardcoded 4. With a
+	// fixed 4 an R8 texture was written with a 4x row stride, spreading each
+	// source row across 4x the destination columns and corrupting sampling.
+	bytesPerPixel := formatBytesPerPixel(tex.format)
 
-	srcBytesPerRow := layout.BytesPerRow
+	srcBytesPerRow := uint64(layout.BytesPerRow)
 	if srcBytesPerRow == 0 {
-		srcBytesPerRow = size.Width * bytesPerPixel
+		srcBytesPerRow = uint64(size.Width) * bytesPerPixel
 	}
 
 	dstBytesPerRow := uint64(tex.width) * bytesPerPixel
+	rowCopyBytes := uint64(size.Width) * bytesPerPixel
 
 	tex.mu.Lock()
 	defer tex.mu.Unlock()
 
 	for row := uint32(0); row < size.Height; row++ {
-		srcStart := layout.Offset + uint64(row)*uint64(srcBytesPerRow)
-		srcEnd := srcStart + uint64(size.Width)*bytesPerPixel
+		srcStart := layout.Offset + uint64(row)*srcBytesPerRow
+		srcEnd := srcStart + rowCopyBytes
 		if srcEnd > uint64(len(data)) {
 			break
 		}
 
 		dstStart := uint64(dst.Origin.Y+row)*dstBytesPerRow + uint64(dst.Origin.X)*bytesPerPixel
-		dstEnd := dstStart + uint64(size.Width)*bytesPerPixel
+		dstEnd := dstStart + rowCopyBytes
 		if dstEnd > uint64(len(tex.data)) {
 			break
 		}

--- a/hal/software/resource.go
+++ b/hal/software/resource.go
@@ -61,6 +61,31 @@ func (b *Buffer) WriteData(offset uint64, data []byte) {
 // NativeHandle returns the buffer's unique ID for handle resolution.
 func (b *Buffer) NativeHandle() uintptr { return uintptr(b.id) }
 
+// formatBytesPerPixel returns the number of bytes per texel for the color
+// formats the software backend stores and samples. Previously the backend
+// assumed 4 bytes/pixel everywhere (RGBA8), which corrupted single- and
+// two-channel formats: an R8 texture's data was laid out and sampled with a
+// 4x horizontal stride, so a glyph atlas read at U sampled the texel at 4*U
+// (text rendered garbled/blank). Keeping this in one place ensures texture
+// allocation, WriteTexture, and the sampler agree on the layout.
+func formatBytesPerPixel(f gputypes.TextureFormat) uint64 {
+	switch f {
+	case gputypes.TextureFormatR8Unorm, gputypes.TextureFormatR8Snorm,
+		gputypes.TextureFormatR8Uint, gputypes.TextureFormatR8Sint:
+		return 1
+	case gputypes.TextureFormatRG8Unorm, gputypes.TextureFormatRG8Snorm,
+		gputypes.TextureFormatRG8Uint, gputypes.TextureFormatRG8Sint,
+		gputypes.TextureFormatR16Unorm, gputypes.TextureFormatR16Snorm,
+		gputypes.TextureFormatR16Uint, gputypes.TextureFormatR16Sint,
+		gputypes.TextureFormatR16Float:
+		return 2
+	default:
+		// RGBA8/BGRA8 and any unhandled format default to 4 bytes/pixel,
+		// preserving the previous behavior for the common color formats.
+		return 4
+	}
+}
+
 // Texture implements hal.Texture with real pixel storage.
 type Texture struct {
 	Resource

--- a/hal/software/shader/interpreter.go
+++ b/hal/software/shader/interpreter.go
@@ -1961,17 +1961,32 @@ func sampleBilinear(tex *Texture2D, u, v float32) Vec4 {
 	return result
 }
 
-// readTexel reads a single RGBA texel from the texture at pixel coordinates (x, y).
+// readTexel reads a single texel from the texture at pixel coordinates (x, y),
+// unpacking it to RGBA according to the texture's bytes-per-pixel. Single- and
+// two-channel formats follow the WebGPU convention of filling missing color
+// channels with 0 and alpha with 1. A zero BytesPerPixel means "unspecified"
+// and is treated as 4 (RGBA8) for backward compatibility.
 func readTexel(tex *Texture2D, x, y int) Vec4 {
-	idx := (y*int(tex.Width) + x) * 4
-	if idx+3 >= len(tex.Data) {
+	bpp := int(tex.BytesPerPixel)
+	if bpp == 0 {
+		bpp = 4
+	}
+	idx := (y*int(tex.Width) + x) * bpp
+	if idx+bpp > len(tex.Data) {
 		return Vec4{0, 0, 0, 0}
 	}
-	return Vec4{
-		float32(tex.Data[idx+0]) / 255.0,
-		float32(tex.Data[idx+1]) / 255.0,
-		float32(tex.Data[idx+2]) / 255.0,
-		float32(tex.Data[idx+3]) / 255.0,
+	switch bpp {
+	case 1:
+		return Vec4{float32(tex.Data[idx]) / 255.0, 0, 0, 1}
+	case 2:
+		return Vec4{float32(tex.Data[idx]) / 255.0, float32(tex.Data[idx+1]) / 255.0, 0, 1}
+	default:
+		return Vec4{
+			float32(tex.Data[idx+0]) / 255.0,
+			float32(tex.Data[idx+1]) / 255.0,
+			float32(tex.Data[idx+2]) / 255.0,
+			float32(tex.Data[idx+3]) / 255.0,
+		}
 	}
 }
 

--- a/hal/software/shader/value.go
+++ b/hal/software/shader/value.go
@@ -74,8 +74,12 @@ type Mat4 = [4]Vec4
 type Texture2D struct {
 	Width  uint32
 	Height uint32
-	Data   []byte // RGBA pixel data, row-major, 4 bytes per pixel.
+	Data   []byte // Pixel data, row-major, BytesPerPixel bytes per texel.
 	Format uint32 // Texture format identifier (0 = RGBA8).
+	// BytesPerPixel is the storage size of a single texel (1 for R8, 2 for
+	// RG8/R16, 4 for RGBA8/BGRA8). When zero, sampling assumes 4 (RGBA8) for
+	// backward compatibility. Single-channel formats unpack as (r, 0, 0, 1).
+	BytesPerPixel uint32
 }
 
 // Sampler describes texture sampling parameters.

--- a/r8sample_repro_test.go
+++ b/r8sample_repro_test.go
@@ -1,0 +1,407 @@
+//go:build !rust && !(js && wasm)
+
+package wgpu_test
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+)
+
+// sampleShader renders a single full-screen triangle that samples a texture.
+// The fragment maps gl_FragCoord.x across the output width to U in [0,1], V=0.5,
+// and writes the sampled .r value to all RGBA channels. This lets the test read
+// back the U->texel mapping directly: output column x shows the texel sampled at
+// U = x/width.
+const sampleShader = `
+struct VSOut { @builtin(position) pos: vec4<f32>, @location(0) uv: vec2<f32> };
+
+@vertex
+fn vs_main(@builtin(vertex_index) vid: u32) -> VSOut {
+    // Full-screen triangle.
+    var p = array<vec2<f32>,3>(vec2<f32>(-1.0,-1.0), vec2<f32>(3.0,-1.0), vec2<f32>(-1.0,3.0));
+    var o: VSOut;
+    o.pos = vec4<f32>(p[vid], 0.0, 1.0);
+    // Map clip space to UV: x in [-1,3]->[0,2], y similarly. We only use x here.
+    o.uv = (p[vid] + vec2<f32>(1.0,1.0)) * 0.5;
+    return o;
+}
+
+@group(0) @binding(0) var t: texture_2d<f32>;
+@group(0) @binding(1) var s: sampler;
+
+@fragment
+fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
+    let v = textureSample(t, s, vec2<f32>(in.uv.x, 0.5)).r;
+    return vec4<f32>(v, v, v, 1.0);
+}
+`
+
+// TestR8SampleCoordRepro verifies that sampling an R8Unorm texture maps the U
+// texture coordinate 1:1. It uploads a vertical-stripe pattern (one 255 stripe
+// near texel 0.75*width) and checks that sampling U=0.75 hits it.
+//
+// BUG: on the pure-Go Metal HAL, the R8 sample coordinate U was scaled ~4x,
+// so U=0.75 sampled near the texture edge and the stripe appeared at U~0.1875.
+func TestR8SampleCoordRepro(t *testing.T) {
+	runSampleCoordTest(t, gputypes.TextureFormatR8Unorm, 1)
+}
+
+// TestRGBA8SampleCoordControl is the control: RGBA8 sampling must also be 1:1.
+func TestRGBA8SampleCoordControl(t *testing.T) {
+	runSampleCoordTest(t, gputypes.TextureFormatRGBA8Unorm, 4)
+}
+
+func runSampleCoordTest(t *testing.T, format wgpu.TextureFormat, bytesPerPixel int) {
+	instance, err := wgpu.CreateInstance(&wgpu.InstanceDescriptor{Backends: wgpu.BackendsPrimary})
+	if err != nil {
+		t.Skipf("CreateInstance: %v", err)
+	}
+	defer instance.Release()
+	adapter, err := instance.RequestAdapter(&wgpu.RequestAdapterOptions{PowerPreference: wgpu.PowerPreferenceHighPerformance})
+	if err != nil {
+		t.Skipf("RequestAdapter: %v", err)
+	}
+	defer adapter.Release()
+	device, err := adapter.RequestDevice(&wgpu.DeviceDescriptor{Label: "r8repro"})
+	if err != nil {
+		t.Skipf("RequestDevice: %v", err)
+	}
+	defer device.Release()
+	q := device.Queue()
+
+	const texW, texH = 256, 4
+	const stripeTexel = 192 // 0.75 * 256
+	// Build texture data: a 255 stripe at columns [stripeTexel, stripeTexel+8).
+	data := make([]byte, texW*texH*bytesPerPixel)
+	for y := 0; y < texH; y++ {
+		for x := stripeTexel; x < stripeTexel+8; x++ {
+			o := (y*texW + x) * bytesPerPixel
+			data[o] = 255 // R channel
+			if bytesPerPixel == 4 {
+				data[o+3] = 255 // A
+			}
+		}
+	}
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "sample-coord-tex",
+		Size:          wgpu.Extent3D{Width: texW, Height: texH, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     gputypes.TextureDimension2D,
+		Format:        format,
+		Usage:         wgpu.TextureUsageTextureBinding | wgpu.TextureUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	defer tex.Release()
+	if err := q.WriteTexture(
+		&wgpu.ImageCopyTexture{Texture: tex, MipLevel: 0},
+		data,
+		&wgpu.ImageDataLayout{Offset: 0, BytesPerRow: uint32(texW * bytesPerPixel), RowsPerImage: texH},
+		&wgpu.Extent3D{Width: texW, Height: texH, DepthOrArrayLayers: 1},
+	); err != nil {
+		t.Fatalf("WriteTexture: %v", err)
+	}
+	view, err := device.CreateTextureView(tex, nil)
+	if err != nil {
+		t.Fatalf("CreateView: %v", err)
+	}
+	defer view.Release()
+
+	sampler, err := device.CreateSampler(&wgpu.SamplerDescriptor{
+		Label:        "nearest",
+		AddressModeU: gputypes.AddressModeClampToEdge,
+		AddressModeV: gputypes.AddressModeClampToEdge,
+		MagFilter:    gputypes.FilterModeNearest,
+		MinFilter:    gputypes.FilterModeNearest,
+		MipmapFilter: gputypes.FilterModeNearest,
+	})
+	if err != nil {
+		t.Fatalf("CreateSampler: %v", err)
+	}
+	defer sampler.Release()
+
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{Label: "sample", WGSL: sampleShader})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer shader.Release()
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Entries: []gputypes.BindGroupLayoutEntry{
+			{Binding: 0, Visibility: gputypes.ShaderStageFragment, Texture: &gputypes.TextureBindingLayout{SampleType: gputypes.TextureSampleTypeFloat, ViewDimension: gputypes.TextureViewDimension2D}},
+			{Binding: 1, Visibility: gputypes.ShaderStageFragment, Sampler: &gputypes.SamplerBindingLayout{Type: gputypes.SamplerBindingTypeFiltering}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+	pl, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{BindGroupLayouts: []*wgpu.BindGroupLayout{bgl}})
+	if err != nil {
+		t.Fatalf("CreatePipelineLayout: %v", err)
+	}
+	defer pl.Release()
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Layout: bgl,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, TextureView: view},
+			{Binding: 1, Sampler: sampler},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	defer bg.Release()
+
+	const outW, outH = 256, 1
+	pipeline, err := device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
+		Label:  "sample-pipe",
+		Layout: pl,
+		Vertex: wgpu.VertexState{Module: shader, EntryPoint: "vs_main"},
+		Fragment: &wgpu.FragmentState{
+			Module:     shader,
+			EntryPoint: "fs_main",
+			Targets:    []gputypes.ColorTargetState{{Format: gputypes.TextureFormatRGBA8Unorm, WriteMask: gputypes.ColorWriteMaskAll}},
+		},
+		Primitive:   gputypes.PrimitiveState{Topology: gputypes.PrimitiveTopologyTriangleList, CullMode: gputypes.CullModeNone},
+		Multisample: gputypes.MultisampleState{Count: 1, Mask: 0xFFFFFFFF},
+	})
+	if err != nil {
+		t.Fatalf("CreateRenderPipeline: %v", err)
+	}
+	defer pipeline.Release()
+
+	outTex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "out",
+		Size:          wgpu.Extent3D{Width: outW, Height: outH, DepthOrArrayLayers: 1},
+		MipLevelCount: 1, SampleCount: 1, Dimension: gputypes.TextureDimension2D,
+		Format: gputypes.TextureFormatRGBA8Unorm,
+		Usage:  gputypes.TextureUsageRenderAttachment | gputypes.TextureUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture(out): %v", err)
+	}
+	defer outTex.Release()
+	outView, err := device.CreateTextureView(outTex, nil)
+	if err != nil {
+		t.Fatalf("CreateView(out): %v", err)
+	}
+	defer outView.Release()
+
+	enc, err := device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{})
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	rp, err := enc.BeginRenderPass(&wgpu.RenderPassDescriptor{
+		ColorAttachments: []wgpu.RenderPassColorAttachment{{
+			View: outView, LoadOp: gputypes.LoadOpClear, StoreOp: gputypes.StoreOpStore,
+			ClearValue: gputypes.Color{R: 0, G: 0, B: 0, A: 1},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BeginRenderPass: %v", err)
+	}
+	rp.SetPipeline(pipeline)
+	rp.SetBindGroup(0, bg, nil)
+	rp.Draw(3, 1, 0, 0)
+	_ = rp.End()
+
+	enc.TransitionTextures([]wgpu.TextureBarrier{{Texture: outTex, Usage: wgpu.TextureUsageTransition{OldUsage: gputypes.TextureUsageRenderAttachment, NewUsage: gputypes.TextureUsageCopySrc}}})
+
+	staging, err := device.CreateBuffer(&wgpu.BufferDescriptor{Size: outW * 4, Usage: gputypes.BufferUsageMapRead | gputypes.BufferUsageCopyDst})
+	if err != nil {
+		t.Fatalf("CreateBuffer(staging): %v", err)
+	}
+	defer staging.Release()
+	enc.CopyTextureToBuffer(outTex, staging, []wgpu.BufferTextureCopy{{
+		BufferLayout: wgpu.ImageDataLayout{Offset: 0, BytesPerRow: outW * 4, RowsPerImage: outH},
+		TextureBase:  wgpu.ImageCopyTexture{Texture: outTex, MipLevel: 0},
+		Size:         wgpu.Extent3D{Width: outW, Height: outH, DepthOrArrayLayers: 1},
+	}})
+	cb, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+	if _, err := q.Submit(cb); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if err := staging.Map(context.Background(), wgpu.MapModeRead, 0, outW*4); err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	rng, err := staging.MappedRange(0, outW*4)
+	if err != nil {
+		t.Fatalf("MappedRange: %v", err)
+	}
+	px := rng.Bytes()
+
+	// Find the output column where the stripe shows up (the bright band).
+	firstBright := -1
+	for x := 0; x < outW; x++ {
+		if px[x*4] > 128 {
+			firstBright = x
+			break
+		}
+	}
+	staging.Unmap()
+
+	expected := stripeTexel // output column x maps to U=x/outW; texture texel = U*texW = x (since outW==texW)
+	t.Logf("format=%v: stripe at texel %d sampled bright at output col %d (expected ~%d)", format, stripeTexel, firstBright, expected)
+	if firstBright < 0 {
+		t.Fatalf("format=%v: stripe not found in output — U coordinate maps off-texture", format)
+	}
+	if firstBright < expected-12 || firstBright > expected+12 {
+		t.Fatalf("format=%v: stripe sampled at output col %d but expected ~%d — U coordinate is mis-scaled (ratio %.2f)",
+			format, firstBright, expected, float64(expected)/float64(firstBright+1))
+	}
+}
+
+// indexedShader draws solid green; vertex positions come from a vertex buffer
+// (location 0). It exists to verify indexed drawing actually rasterizes.
+const indexedShader = `
+@vertex
+fn vs_main(@location(0) pos: vec2<f32>) -> @builtin(position) vec4<f32> {
+    return vec4<f32>(pos, 0.0, 1.0);
+}
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+}
+`
+
+// TestDrawIndexedRenders verifies that DrawIndexed actually rasterizes geometry.
+// A full-screen quad is drawn as two triangles via a uint16 index buffer
+// (0,1,2, 2,3,0). Previously DrawIndexed was a no-op on the software backend,
+// so glyph-mask and MSDF text (the only indexed-draw tiers) rendered nothing.
+func TestDrawIndexedRenders(t *testing.T) {
+	instance, err := wgpu.CreateInstance(&wgpu.InstanceDescriptor{Backends: wgpu.BackendsPrimary})
+	if err != nil {
+		t.Skipf("CreateInstance: %v", err)
+	}
+	defer instance.Release()
+	adapter, err := instance.RequestAdapter(nil)
+	if err != nil {
+		t.Skipf("RequestAdapter: %v", err)
+	}
+	defer adapter.Release()
+	device, err := adapter.RequestDevice(nil)
+	if err != nil {
+		t.Skipf("RequestDevice: %v", err)
+	}
+	defer device.Release()
+	q := device.Queue()
+
+	// Full-screen quad: 4 vertices (vec2 NDC), 6 indices.
+	verts := []float32{-1, -1, 1, -1, 1, 1, -1, 1}
+	vbytes := make([]byte, len(verts)*4)
+	for i, f := range verts {
+		binaryLEPutFloat32(vbytes[i*4:], f)
+	}
+	indices := []uint16{0, 1, 2, 2, 3, 0}
+	ibytes := make([]byte, len(indices)*2)
+	for i, v := range indices {
+		ibytes[i*2] = byte(v)
+		ibytes[i*2+1] = byte(v >> 8)
+	}
+
+	vbuf, _ := device.CreateBuffer(&wgpu.BufferDescriptor{Size: uint64(len(vbytes)), Usage: gputypes.BufferUsageVertex | gputypes.BufferUsageCopyDst})
+	defer vbuf.Release()
+	q.WriteBuffer(vbuf, 0, vbytes)
+	ibuf, _ := device.CreateBuffer(&wgpu.BufferDescriptor{Size: uint64(len(ibytes)), Usage: gputypes.BufferUsageIndex | gputypes.BufferUsageCopyDst})
+	defer ibuf.Release()
+	q.WriteBuffer(ibuf, 0, ibytes)
+
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{WGSL: indexedShader})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer shader.Release()
+	pl, _ := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{})
+	defer pl.Release()
+
+	const W, H = 16, 16
+	pipeline, err := device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
+		Layout: pl,
+		Vertex: wgpu.VertexState{
+			Module: shader, EntryPoint: "vs_main",
+			Buffers: []gputypes.VertexBufferLayout{{
+				ArrayStride: 8, StepMode: gputypes.VertexStepModeVertex,
+				Attributes: []gputypes.VertexAttribute{{Format: gputypes.VertexFormatFloat32x2, Offset: 0, ShaderLocation: 0}},
+			}},
+		},
+		Fragment: &wgpu.FragmentState{
+			Module: shader, EntryPoint: "fs_main",
+			Targets: []gputypes.ColorTargetState{{Format: gputypes.TextureFormatRGBA8Unorm, WriteMask: gputypes.ColorWriteMaskAll}},
+		},
+		Primitive:   gputypes.PrimitiveState{Topology: gputypes.PrimitiveTopologyTriangleList, CullMode: gputypes.CullModeNone},
+		Multisample: gputypes.MultisampleState{Count: 1, Mask: 0xFFFFFFFF},
+	})
+	if err != nil {
+		t.Fatalf("CreateRenderPipeline: %v", err)
+	}
+	defer pipeline.Release()
+
+	outTex, _ := device.CreateTexture(&wgpu.TextureDescriptor{
+		Size: wgpu.Extent3D{Width: W, Height: H, DepthOrArrayLayers: 1}, MipLevelCount: 1, SampleCount: 1,
+		Dimension: gputypes.TextureDimension2D, Format: gputypes.TextureFormatRGBA8Unorm,
+		Usage: gputypes.TextureUsageRenderAttachment | gputypes.TextureUsageCopySrc,
+	})
+	defer outTex.Release()
+	outView, _ := device.CreateTextureView(outTex, nil)
+	defer outView.Release()
+
+	enc, _ := device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{})
+	rp, _ := enc.BeginRenderPass(&wgpu.RenderPassDescriptor{
+		ColorAttachments: []wgpu.RenderPassColorAttachment{{
+			View: outView, LoadOp: gputypes.LoadOpClear, StoreOp: gputypes.StoreOpStore,
+			ClearValue: gputypes.Color{R: 0, G: 0, B: 0, A: 1},
+		}},
+	})
+	rp.SetPipeline(pipeline)
+	rp.SetVertexBuffer(0, vbuf, 0)
+	rp.SetIndexBuffer(ibuf, gputypes.IndexFormatUint16, 0)
+	rp.DrawIndexed(6, 1, 0, 0, 0)
+	_ = rp.End()
+	enc.TransitionTextures([]wgpu.TextureBarrier{{Texture: outTex, Usage: wgpu.TextureUsageTransition{OldUsage: gputypes.TextureUsageRenderAttachment, NewUsage: gputypes.TextureUsageCopySrc}}})
+	staging, _ := device.CreateBuffer(&wgpu.BufferDescriptor{Size: W * H * 4, Usage: gputypes.BufferUsageMapRead | gputypes.BufferUsageCopyDst})
+	defer staging.Release()
+	enc.CopyTextureToBuffer(outTex, staging, []wgpu.BufferTextureCopy{{
+		BufferLayout: wgpu.ImageDataLayout{Offset: 0, BytesPerRow: W * 4, RowsPerImage: H},
+		TextureBase:  wgpu.ImageCopyTexture{Texture: outTex, MipLevel: 0},
+		Size:         wgpu.Extent3D{Width: W, Height: H, DepthOrArrayLayers: 1},
+	}})
+	cb, _ := enc.Finish()
+	q.Submit(cb)
+	if err := staging.Map(context.Background(), wgpu.MapModeRead, 0, W*H*4); err != nil {
+		t.Fatalf("Map: %v", err)
+	}
+	rng, _ := staging.MappedRange(0, W*H*4)
+	px := rng.Bytes()
+	// The full-screen quad fills over a black clear. A no-op DrawIndexed leaves
+	// the frame black. Count any non-black pixel (the software backend's default
+	// path fills white; backends that run the fragment shader fill green).
+	filled := 0
+	for i := 0; i < W*H; i++ {
+		if px[i*4] > 128 || px[i*4+1] > 128 || px[i*4+2] > 128 {
+			filled++
+		}
+	}
+	staging.Unmap()
+	if filled < W*H/2 {
+		t.Fatalf("DrawIndexed produced %d/%d filled pixels — indexed draw did not rasterize the quad", filled, W*H)
+	}
+}
+
+func binaryLEPutFloat32(b []byte, f float32) {
+	bits := math.Float32bits(f)
+	b[0] = byte(bits)
+	b[1] = byte(bits >> 8)
+	b[2] = byte(bits >> 16)
+	b[3] = byte(bits >> 24)
+}


### PR DESCRIPTION
## Summary

The pure-Go software HAL had two bugs that together made GPU glyph-mask / MSDF text rendering produce nothing (or garbled output). Both are fixed here, with integration regression tests.

### 1. Texture storage and sampling assumed 4 bytes per pixel everywhere

`hal/software` `CreateTexture` (allocation), `Queue.WriteTexture`, and the shader interpreter's texel fetch all hardcoded `bytesPerPixel = 4` (RGBA8). For an **R8** texture (1 byte/texel — e.g. a glyph coverage atlas) this laid the data out and sampled it with a **4× horizontal stride**: sampling at U returned the texel at `4*U`, so a glyph atlas read mostly off the populated region and text rendered garbled (first glyphs) then blank.

Fixed by deriving bytes-per-pixel from the texture format (R8=1, RG8/R16=2, RGBA8/BGRA8=4) in one helper (`formatBytesPerPixel`) used by all three sites, and unpacking single/two-channel texels to RGBA as `(r,0,0,1)` / `(r,g,0,1)` per the WebGPU convention.

### 2. `RenderPassEncoder.DrawIndexed` was a no-op

Every indexed draw rasterized nothing. The glyph-mask and MSDF text pipelines are the only tiers that use indexed drawing, so all text vanished while non-indexed tiers (SDF, convex, image, stencil) worked. Implemented `DrawIndexed` by resolving the bound index buffer (uint16/uint32, honoring offset and `baseVertex`) into a vertex-index list that the existing vertex-fetch and rasterization path consults, so indexed and non-indexed draws share one code path.

## Tests

- `TestR8SampleCoordRepro` — an R8 texture's U coordinate maps 1:1 (with an RGBA8 control).
- `TestDrawIndexedRenders` — an indexed quad actually rasterizes.

Both fail on the prior code and pass with this change. The Metal HAL was unaffected (it samples R8 via hardware and already implements `drawIndexedPrimitives`), so this is software-backend only.
