### PR TITLE
refactor: migrate to gputypes.BlockCopySize() (v0.30.6)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 
 ## Current Version
 
-v0.30.5 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.0
+v0.30.6 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.1
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.6] - 2026-06-28
+
+### Changed
+
+- **Migrate to `gputypes.TextureFormat.BlockCopySize()`** — canonical format size
+  from gputypes v0.5.1 replaces two independent implementations:
+  - Deleted `hal/vulkan/command.go:blockCopySize()` (30 formats, private)
+  - Simplified `hal/software/resource.go:formatBytesPerPixel()` to delegate (was 8 formats)
+  - Software backend now correctly handles RGBA16Float (8 bytes), RGBA32Float (16 bytes),
+    Stencil8 (1 byte), Depth16 (2 bytes) — previously all defaulted to 4.
+
+### Dependencies
+
+- gputypes v0.5.0 → v0.5.1 (adds `BlockCopySize()` — 87 formats, Rust wgpu-types parity)
+
 ## [0.30.5] - 2026-06-27
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-webgpu/goffi v0.5.5
 	github.com/go-webgpu/webgpu v0.5.2
 	github.com/gogpu/gpucontext v0.21.0
-	github.com/gogpu/gputypes v0.5.0
+	github.com/gogpu/gputypes v0.5.1
 	github.com/gogpu/naga v0.17.15
 	golang.org/x/sys v0.46.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRb
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=
 github.com/gogpu/gpucontext v0.21.0/go.mod h1:6zwdmYXH5GQltoiHbb3WXVS/UJ5bFsCux0mXCVqGlzY=
-github.com/gogpu/gputypes v0.5.0 h1:i2ED/9w6m6yLxf8XJT69/NIMSNTLO2y5F1LqvugCKIE=
-github.com/gogpu/gputypes v0.5.0/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
+github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=
+github.com/gogpu/gputypes v0.5.1/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.15 h1:uyy4bc8wYlvDaYOpmCBYrJ+d+e7ZqP2BN36csmRVs7o=
 github.com/gogpu/naga v0.17.15/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=

--- a/hal/software/resource.go
+++ b/hal/software/resource.go
@@ -61,29 +61,15 @@ func (b *Buffer) WriteData(offset uint64, data []byte) {
 // NativeHandle returns the buffer's unique ID for handle resolution.
 func (b *Buffer) NativeHandle() uintptr { return uintptr(b.id) }
 
-// formatBytesPerPixel returns the number of bytes per texel for the color
-// formats the software backend stores and samples. Previously the backend
-// assumed 4 bytes/pixel everywhere (RGBA8), which corrupted single- and
-// two-channel formats: an R8 texture's data was laid out and sampled with a
-// 4x horizontal stride, so a glyph atlas read at U sampled the texel at 4*U
-// (text rendered garbled/blank). Keeping this in one place ensures texture
-// allocation, WriteTexture, and the sampler agree on the layout.
+// formatBytesPerPixel returns the bytes per texel for texture allocation and
+// sampling. Delegates to gputypes.TextureFormat.BlockCopySize() — the canonical
+// source of truth for all 87 WebGPU formats. Returns 4 for unknown/ambiguous
+// formats (Depth24Plus, etc.) as a safe fallback.
 func formatBytesPerPixel(f gputypes.TextureFormat) uint64 {
-	switch f {
-	case gputypes.TextureFormatR8Unorm, gputypes.TextureFormatR8Snorm,
-		gputypes.TextureFormatR8Uint, gputypes.TextureFormatR8Sint:
-		return 1
-	case gputypes.TextureFormatRG8Unorm, gputypes.TextureFormatRG8Snorm,
-		gputypes.TextureFormatRG8Uint, gputypes.TextureFormatRG8Sint,
-		gputypes.TextureFormatR16Unorm, gputypes.TextureFormatR16Snorm,
-		gputypes.TextureFormatR16Uint, gputypes.TextureFormatR16Sint,
-		gputypes.TextureFormatR16Float:
-		return 2
-	default:
-		// RGBA8/BGRA8 and any unhandled format default to 4 bytes/pixel,
-		// preserving the previous behavior for the common color formats.
-		return 4
+	if s := f.BlockCopySize(); s > 0 {
+		return uint64(s)
 	}
+	return 4
 }
 
 // Texture implements hal.Texture with real pixel storage.

--- a/hal/vulkan/command.go
+++ b/hal/vulkan/command.go
@@ -411,57 +411,15 @@ func (e *CommandEncoder) CopyBufferToBuffer(src, dst hal.Buffer, regions []hal.B
 	vkCmdCopyBuffer(e.device.cmds, e.active, srcBuf.handle, dstBuf.handle, uint32(len(vkRegions)), &vkRegions[0])
 }
 
-// blockCopySize returns the number of bytes per block for a given texture format.
-// For non-compressed formats the block is a single texel.
-// Matches wgpu-types TextureFormat::block_copy_size in the Rust reference.
-func blockCopySize(format gputypes.TextureFormat) uint32 {
-	switch format {
-	// 1 byte per texel
-	case gputypes.TextureFormatR8Unorm, gputypes.TextureFormatR8Snorm,
-		gputypes.TextureFormatR8Uint, gputypes.TextureFormatR8Sint,
-		gputypes.TextureFormatStencil8:
-		return 1
-	// 2 bytes per texel
-	case gputypes.TextureFormatR16Unorm, gputypes.TextureFormatR16Snorm,
-		gputypes.TextureFormatR16Uint, gputypes.TextureFormatR16Sint,
-		gputypes.TextureFormatR16Float,
-		gputypes.TextureFormatRG8Unorm, gputypes.TextureFormatRG8Snorm,
-		gputypes.TextureFormatRG8Uint, gputypes.TextureFormatRG8Sint,
-		gputypes.TextureFormatDepth16Unorm:
-		return 2
-	// 4 bytes per texel
-	case gputypes.TextureFormatR32Float, gputypes.TextureFormatR32Uint, gputypes.TextureFormatR32Sint,
-		gputypes.TextureFormatRG16Unorm, gputypes.TextureFormatRG16Snorm,
-		gputypes.TextureFormatRG16Uint, gputypes.TextureFormatRG16Sint,
-		gputypes.TextureFormatRG16Float,
-		gputypes.TextureFormatRGBA8Unorm, gputypes.TextureFormatRGBA8UnormSrgb,
-		gputypes.TextureFormatRGBA8Snorm, gputypes.TextureFormatRGBA8Uint, gputypes.TextureFormatRGBA8Sint,
-		gputypes.TextureFormatBGRA8Unorm, gputypes.TextureFormatBGRA8UnormSrgb,
-		gputypes.TextureFormatRGB10A2Uint, gputypes.TextureFormatRGB10A2Unorm,
-		gputypes.TextureFormatRG11B10Ufloat, gputypes.TextureFormatRGB9E5Ufloat,
-		gputypes.TextureFormatDepth32Float:
-		return 4
-	// 8 bytes per texel
-	case gputypes.TextureFormatRG32Uint, gputypes.TextureFormatRG32Sint, gputypes.TextureFormatRG32Float,
-		gputypes.TextureFormatRGBA16Unorm, gputypes.TextureFormatRGBA16Snorm,
-		gputypes.TextureFormatRGBA16Uint, gputypes.TextureFormatRGBA16Sint,
-		gputypes.TextureFormatRGBA16Float:
-		return 8
-	// 16 bytes per texel
-	case gputypes.TextureFormatRGBA32Uint, gputypes.TextureFormatRGBA32Sint, gputypes.TextureFormatRGBA32Float:
-		return 16
-	default:
-		// Fallback for unknown formats — assume 4 (RGBA8 is the most common).
-		return 4
-	}
-}
-
 // convertBufferImageCopyRegions converts HAL BufferTextureCopy regions to Vulkan BufferImageCopy.
 // The format parameter is the texture format, used to determine block copy size
 // for correct bytes-to-texels conversion of bufferRowLength.
 func convertBufferImageCopyRegions(regions []hal.BufferTextureCopy, format gputypes.TextureFormat) []vk.BufferImageCopy {
 	vkRegions := make([]vk.BufferImageCopy, len(regions))
-	blockSize := blockCopySize(format)
+	blockSize := format.BlockCopySize()
+	if blockSize == 0 {
+		blockSize = 4
+	}
 	for i, r := range regions {
 		// Vulkan bufferRowLength is in TEXELS, not bytes.
 		// Convert from WebGPU's BytesPerRow (bytes) to Vulkan's bufferRowLength (texels)


### PR DESCRIPTION
## Summary

Migrate format-size logic to canonical `gputypes.TextureFormat.BlockCopySize()` (v0.5.1).

- **Delete** `hal/vulkan/command.go:blockCopySize()` — 30-format private switch, replaced by one-liner
- **Simplify** `hal/software/resource.go:formatBytesPerPixel()` — delegates to `BlockCopySize()` with fallback
- **Bump** gputypes v0.5.0 → v0.5.1
- **Net result:** -41 lines, single source of truth for 87 WebGPU formats across ecosystem

### Context (FEAT-GPUTYPES-001)

Three repos had independent "bytes per texel" implementations with different bugs. gputypes v0.5.1 adds `BlockCopySize()` as the canonical method (Rust wgpu-types parity, 97 tests). This PR is Phase 2 — wgpu migration.

Software backend gains correct handling for RGBA16Float (8 bytes), RGBA32Float (16 bytes), Stencil8 (1 byte), Depth16Unorm (2 bytes) — all previously defaulted to 4.

## Test plan

- [x] `go build ./...` — pass (Windows, macOS, Linux)
- [x] `go test ./...` — all packages pass including R8/DrawIndexed integration tests
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] `GOWORK=off go build ./...` — verifies go.mod correctness
