### PR TITLE
fix(hal/software): format-aware copy + Clear (v0.30.7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 
 ## Current Version
 
-v0.30.6 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.1
+v0.30.7 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.1
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.7] - 2026-06-28
+
+### Fixed
+
+- **Software: format-aware copy commands** — `CopyBufferToTexture`, `CopyTextureToBuffer`,
+  `CopyTextureToTexture` used hardcoded 4 bytes/pixel. Now use `formatBytesPerPixel()` →
+  `BlockCopySize()`. R8 copies computed 4× too much data, RGBA16Float computed half.
+- **Software: format-aware Clear()** — texture clear used `i += 4` loop. Now handles
+  1-byte (R8), 2-byte (RG8/R16), and 4+ byte formats correctly. R8 render target
+  clear no longer writes out of format bounds.
+
 ## [0.30.6] - 2026-06-28
 
 ### Changed

--- a/hal/software/command.go
+++ b/hal/software/command.go
@@ -97,10 +97,9 @@ func (c *CommandEncoder) CopyBufferToTexture(src hal.Buffer, dst hal.Texture, re
 		srcBuf.mu.RLock()
 		dstTex.mu.Lock()
 
-		// Simple copy: just copy from buffer to texture data
-		// In a real implementation, this would respect image layout and stride
 		offset := region.BufferLayout.Offset
-		size := uint64(region.Size.Width) * uint64(region.Size.Height) * uint64(region.Size.DepthOrArrayLayers) * 4 // 4 bytes per pixel
+		bpp := formatBytesPerPixel(dstTex.format)
+		size := uint64(region.Size.Width) * uint64(region.Size.Height) * uint64(region.Size.DepthOrArrayLayers) * bpp
 
 		if offset+size <= uint64(len(srcBuf.data)) && size <= uint64(len(dstTex.data)) {
 			copy(dstTex.data, srcBuf.data[offset:offset+size])
@@ -124,9 +123,9 @@ func (c *CommandEncoder) CopyTextureToBuffer(src hal.Texture, dst hal.Buffer, re
 		srcTex.mu.RLock()
 		dstBuf.mu.Lock()
 
-		// Simple copy: just copy from texture to buffer data
 		offset := region.BufferLayout.Offset
-		size := uint64(region.Size.Width) * uint64(region.Size.Height) * uint64(region.Size.DepthOrArrayLayers) * 4 // 4 bytes per pixel
+		bpp := formatBytesPerPixel(srcTex.format)
+		size := uint64(region.Size.Width) * uint64(region.Size.Height) * uint64(region.Size.DepthOrArrayLayers) * bpp
 
 		if size <= uint64(len(srcTex.data)) && offset+size <= uint64(len(dstBuf.data)) {
 			copy(dstBuf.data[offset:offset+size], srcTex.data[:size])
@@ -150,8 +149,8 @@ func (c *CommandEncoder) CopyTextureToTexture(src, dst hal.Texture, regions []ha
 		srcTex.mu.RLock()
 		dstTex.mu.Lock()
 
-		// Simple copy: just copy texture data
-		size := uint64(region.Size.Width) * uint64(region.Size.Height) * uint64(region.Size.DepthOrArrayLayers) * 4 // 4 bytes per pixel
+		bpp := formatBytesPerPixel(srcTex.format)
+		size := uint64(region.Size.Width) * uint64(region.Size.Height) * uint64(region.Size.DepthOrArrayLayers) * bpp
 
 		if size <= uint64(len(srcTex.data)) && size <= uint64(len(dstTex.data)) {
 			copy(dstTex.data[:size], srcTex.data[:size])

--- a/hal/software/resource.go
+++ b/hal/software/resource.go
@@ -120,18 +120,29 @@ func (t *Texture) Clear(color gputypes.Color) {
 	b := uint8(color.B * 255)
 	a := uint8(color.A * 255)
 
-	// Write bytes in format-appropriate order so the data is correct
-	// for direct consumption by GDI (BGRA) or other readers.
-	c0, c1, c2, c3 := r, g, b, a
-	if t.format == gputypes.TextureFormatBGRA8Unorm || t.format == gputypes.TextureFormatBGRA8UnormSrgb {
-		c0, c2 = b, r
-	}
+	bpp := int(formatBytesPerPixel(t.format))
 
-	for i := 0; i < len(t.data); i += 4 {
-		t.data[i+0] = c0
-		t.data[i+1] = c1
-		t.data[i+2] = c2
-		t.data[i+3] = c3
+	switch bpp {
+	case 1:
+		for i := 0; i < len(t.data); i++ {
+			t.data[i] = r
+		}
+	case 2:
+		for i := 0; i+1 < len(t.data); i += 2 {
+			t.data[i] = r
+			t.data[i+1] = g
+		}
+	default:
+		c0, c1, c2, c3 := r, g, b, a
+		if t.format == gputypes.TextureFormatBGRA8Unorm || t.format == gputypes.TextureFormatBGRA8UnormSrgb {
+			c0, c2 = b, r
+		}
+		for i := 0; i+3 < len(t.data); i += bpp {
+			t.data[i+0] = c0
+			t.data[i+1] = c1
+			t.data[i+2] = c2
+			t.data[i+3] = c3
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix remaining hardcoded `* 4` (bytes/pixel) in software backend — copy commands and Clear().

### Copy commands (command.go)
- `CopyBufferToTexture`, `CopyTextureToBuffer`, `CopyTextureToTexture` all used `W * H * D * 4`
- Now use `formatBytesPerPixel(tex.format)` → `BlockCopySize()`
- R8 copies computed 4× too much data, RGBA16Float computed half

### Clear (resource.go)
- `Clear()` iterated with `i += 4`, writing 4 bytes per texel
- Now format-aware: R8 (1 byte), RG8/R16 (2 bytes), RGBA8+ (4 bytes)
- Per WebGPU spec, R8Unorm/R16Float/RGBA16Float are all valid render targets

### Not in scope
- Render pipeline pixel write/read in draw.go — the rasterizer pipeline internally produces RGBA8. Supporting non-4-byte render targets in the draw path requires format conversion (separate architectural task)

## Test plan

- [x] `go build ./...` — pass
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run --timeout=5m` — 0 issues
