### PR TITLE
fix(hal/gles): LockOSThread in integration tests

### DIFF
--- a/hal/gles/integration_test.go
+++ b/hal/gles/integration_test.go
@@ -6,6 +6,7 @@
 package gles
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/gogpu/gputypes"
@@ -19,6 +20,8 @@ import (
 // In CI, this uses the EGL_MESA_platform_surfaceless for headless testing.
 // Run with: go test -v -tags integration ./hal/gles/...
 func TestEGLInit(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	t.Log("Testing EGL initialization...")
 
 	// Initialize EGL library
@@ -76,6 +79,8 @@ func TestEGLInit(t *testing.T) {
 
 // TestEGLContext tests EGL context creation.
 func TestEGLContext(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	t.Log("Testing EGL context creation...")
 
 	// Initialize EGL
@@ -110,6 +115,8 @@ func TestEGLContext(t *testing.T) {
 // (PR #210): pointer-type args must use unsafe.Pointer(&ptr), not unsafe.Pointer(&value).
 // Without this test, the bug went undetected because CI only tested EGL init.
 func TestGLObjectCreation(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	if err := egl.Init(); err != nil {
 		t.Fatalf("egl.Init() failed: %v", err)
 	}
@@ -168,6 +175,8 @@ func TestGLObjectCreation(t *testing.T) {
 
 // TestGLESBackend tests the full GLES backend integration.
 func TestGLESBackend(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	t.Log("Testing GLES backend...")
 
 	// Create backend
@@ -197,6 +206,8 @@ func TestGLESBackend(t *testing.T) {
 
 // TestGLProcAddress tests GL function loading via EGL.
 func TestGLProcAddress(t *testing.T) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	t.Log("Testing GL function loading via EGL...")
 
 	// Initialize EGL


### PR DESCRIPTION
## Summary

Add `runtime.LockOSThread()` to all 5 GLES integration tests that use EGL contexts.

### Root cause

EGL/GL contexts are bound to the calling OS thread (`eglMakeCurrent` binds to **current thread**). Go test runner schedules goroutines on arbitrary OS threads. Without `LockOSThread`, `MakeCurrent` on thread A followed by `glGenBuffers` on thread B returns 0 — no current context on that thread.

This caused `TestGLObjectCreation` to fail intermittently in CI (run 28320103359, PR #232). Passed on re-run because Go scheduler happened to use the same thread.

### Fix

`runtime.LockOSThread()` / `defer runtime.UnlockOSThread()` in all tests that touch EGL: `TestEGLInit`, `TestEGLContext`, `TestGLObjectCreation`, `TestGLESBackend`, `TestGLProcAddress`.

Same pattern as production code (`hal/gles/adapter_context.go` Lock/Unlock).

## Test plan

- [x] `go build ./...` — pass
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [ ] CI GLES integration — will verify on this PR