### PR TITLE
chore: bump goffi v0.5.6 — callback stack-move fix (v0.30.9)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 
 ## Current Version
 
-v0.30.8 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.1
+v0.30.9 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.1
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.9] - 2026-07-05
+
+### Dependencies
+
+- goffi v0.5.5 → v0.5.6 — fixes callback stack-move corruption. Callbacks that
+  caused goroutine stack growth could corrupt `callbackArgs` pointers because Go's
+  moving GC relocates stacks. Fix uses `sync.Pool` + `runtime.Pinner` (PR go-webgpu/goffi#59, @tie).
+
 ## [0.30.8] - 2026-06-28
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/wgpu
 go 1.25.0
 
 require (
-	github.com/go-webgpu/goffi v0.5.5
+	github.com/go-webgpu/goffi v0.5.6
 	github.com/go-webgpu/webgpu v0.5.2
 	github.com/gogpu/gpucontext v0.21.0
 	github.com/gogpu/gputypes v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.5.5 h1:xLWMhnJq+GrejlhTC3iVt3q8ozRbmYSq8kzuw6MKlgE=
-github.com/go-webgpu/goffi v0.5.5/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.5.6 h1:jAN4ciR63DcpU/qdX4A3wbNvcpZ6AdFK+H7OB/1+9Lc=
+github.com/go-webgpu/goffi v0.5.6/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
 github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
 github.com/gogpu/gpucontext v0.21.0 h1:O1SnXBiednIyVP4Zx5SASh0svYiG6g/wF1igNZVo1Pc=


### PR DESCRIPTION
## Summary

Bump goffi v0.5.5 → v0.5.6. Fixes callback stack-move corruption (go-webgpu/goffi#59, @tie).

Callbacks that cause goroutine stack growth could corrupt `callbackArgs` pointers because Go's moving GC relocates stacks. Fix: `sync.Pool` for `callbackArgs` + `runtime.Pinner`.

## Test plan

- [x] `GOWORK=off go build ./...` — pass
- [x] `go test ./...` — all 15 packages pass
- [x] `golangci-lint run --timeout=5m` — pending (background)