### PR TITLE
feat: TextureView.Texture() + SurfaceTexture.AsTexture() + blit hardening (v0.30.11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 
 ## Current Version
 
-v0.30.10 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.1
+v0.30.11 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.1
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.11] - 2026-07-09
+
+### Added
+
+- **`TextureView.Texture()`** — returns parent Texture (Rust wgpu parity:
+  `TextureView::texture()`). All 3 build targets (native, Rust FFI, browser).
+  Unblocks gg BUG-SW-002 offscreen texture upload.
+- **`SurfaceTexture.AsTexture()`** — lightweight Texture wrapper for direct
+  `Queue.WriteTexture()` to surface textures. Enables spec-compliant CPU pixmap
+  display without render pass. Configure surface with `TextureUsageCopyDst`.
+
+### Fixed
+
+- **Software: hardened `executeFullscreenBlit`** — added Skia-inspired state
+  validation (`blitStateValid`): checks blend mode, depth/stencil, write mask,
+  multisampling before allowing memcpy fast path. Previously blit bypassed these
+  checks, potentially producing incorrect results with non-trivial render state.
+
 ## [0.30.10] - 2026-07-08
 
 ### Fixed

--- a/device_browser.go
+++ b/device_browser.go
@@ -102,6 +102,7 @@ func (d *Device) CreateTextureView(texture *Texture, desc *TextureViewDescriptor
 	bv := texture.browser.CreateView(jsDesc)
 	return &TextureView{
 		browser:  bv,
+		texture:  texture,
 		released: false,
 	}, nil
 }

--- a/hal/software/draw.go
+++ b/hal/software/draw.go
@@ -79,7 +79,51 @@ func (r *RenderPassEncoder) getTargetTexture() *Texture {
 // When scissor is active, only pixels within the scissor rect are written.
 // The blit loop bounds are clamped to the scissor rect to maintain the
 // fast-path advantage (no per-pixel branch, just narrowed iteration range).
+// blitStateValid checks whether the current pipeline render state allows a
+// direct memcpy blit (Skia SkSpriteBlitter_Memcpy::Supports pattern). Returns
+// false if any active state would produce different results than a raw copy.
+func (r *RenderPassEncoder) blitStateValid() bool {
+	if r.pipeline == nil || r.pipeline.desc == nil {
+		return false
+	}
+	desc := r.pipeline.desc
+	if desc.DepthStencil != nil {
+		return false
+	}
+	if desc.Multisample.Count > 1 {
+		return false
+	}
+	if desc.Fragment == nil {
+		return true
+	}
+	for _, t := range desc.Fragment.Targets {
+		if t.WriteMask != gputypes.ColorWriteMaskAll {
+			return false
+		}
+		if !isBlitSafeBlend(t.Blend) {
+			return false
+		}
+	}
+	return true
+}
+
+// isBlitSafeBlend returns true if the blend state allows a direct memcpy blit.
+// Safe modes: no blend (replace), Src (One/Zero), SrcOver (One/OneMinusSrcAlpha).
+func isBlitSafeBlend(b *gputypes.BlendState) bool {
+	if b == nil {
+		return true
+	}
+	srcOver := b.Color.SrcFactor == gputypes.BlendFactorOne &&
+		b.Color.DstFactor == gputypes.BlendFactorOneMinusSrcAlpha
+	src := b.Color.SrcFactor == gputypes.BlendFactorOne &&
+		b.Color.DstFactor == gputypes.BlendFactorZero
+	return srcOver || src
+}
+
 func (r *RenderPassEncoder) executeFullscreenBlit(target *Texture) bool {
+	if !r.blitStateValid() {
+		return false
+	}
 	srcView := r.findBoundTexture()
 	if srcView == nil || srcView.texture == nil {
 		return false

--- a/surface_browser.go
+++ b/surface_browser.go
@@ -219,6 +219,9 @@ type SurfaceTexture struct {
 	released bool
 }
 
+// AsTexture returns the underlying Texture for direct WriteTexture access.
+func (st *SurfaceTexture) AsTexture() *Texture { return st.texture }
+
 // CreateView creates a texture view of this surface texture.
 //
 // Pass nil for desc to create a default view (all mips, all layers, same format).

--- a/surface_native.go
+++ b/surface_native.go
@@ -280,6 +280,19 @@ type SurfaceTexture struct {
 	device  *Device
 }
 
+// AsTexture returns a lightweight Texture wrapper around this surface texture,
+// enabling use with Queue.WriteTexture() for direct CPU pixel upload without a
+// render pass. The surface must be configured with TextureUsageCopyDst.
+//
+// The returned Texture shares the underlying HAL resource — do not Release() it
+// independently. Its lifetime is tied to this SurfaceTexture.
+func (st *SurfaceTexture) AsTexture() *Texture {
+	return &Texture{
+		hal:    st.hal,
+		device: st.device,
+	}
+}
+
 // CreateView creates a texture view of this surface texture.
 func (st *SurfaceTexture) CreateView(desc *TextureViewDescriptor) (*TextureView, error) {
 	halDevice := st.device.halDevice()

--- a/surface_rust.go
+++ b/surface_rust.go
@@ -164,6 +164,9 @@ type SurfaceTexture struct {
 	surface *Surface
 }
 
+// AsTexture returns the underlying Texture for direct WriteTexture access.
+func (st *SurfaceTexture) AsTexture() *Texture { return st.texture }
+
 // CreateView creates a texture view of this surface texture.
 func (st *SurfaceTexture) CreateView(desc *TextureViewDescriptor) (*TextureView, error) {
 	if st.texture == nil || st.texture.r == nil {

--- a/texture_browser.go
+++ b/texture_browser.go
@@ -28,8 +28,13 @@ func (t *Texture) Release() {
 // TextureView represents a view into a texture.
 type TextureView struct {
 	browser  *browser.TextureView
+	texture  *Texture
 	released bool
 }
+
+// Texture returns the parent Texture that this view was created from.
+// Returns nil if the view has been released.
+func (v *TextureView) Texture() *Texture { return v.texture }
 
 // Release marks the texture view for destruction.
 func (v *TextureView) Release() {

--- a/texture_native.go
+++ b/texture_native.go
@@ -52,6 +52,10 @@ type TextureView struct {
 	released bool
 }
 
+// Texture returns the parent Texture that this view was created from.
+// Returns nil if the view has been released.
+func (v *TextureView) Texture() *Texture { return v.texture }
+
 // Release marks the texture view for destruction. The underlying HAL TextureView
 // (and its descriptor heap slots) is not freed immediately — it is deferred via
 // DestroyQueue until the GPU completes any submission that may reference it.

--- a/texture_rust.go
+++ b/texture_rust.go
@@ -36,6 +36,10 @@ type TextureView struct {
 	released bool
 }
 
+// Texture returns the parent Texture that this view was created from.
+// Returns nil if the view has been released.
+func (v *TextureView) Texture() *Texture { return v.texture }
+
 // Release marks the texture view for destruction.
 func (v *TextureView) Release() {
 	if v.released {


### PR DESCRIPTION
## Summary

Three additions enabling spec-compliant CPU pixmap → screen display without render pass overhead.

### TextureView.Texture() — Rust wgpu parity
Returns parent `*Texture` from a `*TextureView`. Matches Rust `TextureView::texture() -> &Texture` (`texture_view.rs:30`). All 3 build targets (native, Rust FFI, browser). Browser target: added `texture` field + set in `CreateTextureView`.

Unblocks gg BUG-SW-002 (offscreen texture upload needs parent texture for `WriteTexture`).

### SurfaceTexture.AsTexture() — spec-compliant direct write
Lightweight `*Texture` wrapper around surface texture. Enables:
```go
surface.Configure(&Config{Usage: RenderAttachment | CopyDst})
tex, _ := surface.GetCurrentTexture()
queue.WriteTexture(&ImageCopyTexture{Texture: tex.AsTexture()}, pixmap, ...)
surface.Present(tex)
```
WebGPU spec allows `writeTexture` to any texture with `COPY_DST` usage. DX12/Metal always support COPY_DST on surfaces. Research: 4 agents verified against Rust wgpu, Dawn, Vulkan spec.

### Harden executeFullscreenBlit — Skia pattern
Added `blitStateValid()` checking blend mode, depth/stencil, write mask, multisampling before allowing memcpy fast path. Follows Skia `SkSpriteBlitter_Memcpy::Supports` pattern. Previously blit bypassed these state checks.

## Test plan

- [x] `go build ./...` — pass (Windows, macOS, Linux)
- [x] `GOOS=js GOARCH=wasm go build .` — pass (browser)
- [x] `go build -tags rust ./...` — pass (Rust FFI)
- [x] `go test ./...` — all 15 packages pass
- [x] `golangci-lint run --timeout=5m` — 0 issues
