### PR TITLE
fix: SurfaceTexture.CreateView() sets parent texture on TextureView

### DIFF
--- a/surface_browser.go
+++ b/surface_browser.go
@@ -245,6 +245,7 @@ func (st *SurfaceTexture) CreateView(desc *TextureViewDescriptor) (*TextureView,
 	bv := st.texture.browser.CreateView(jsDesc)
 	return &TextureView{
 		browser: bv,
+		texture: st.AsTexture(),
 	}, nil
 }
 

--- a/surface_native.go
+++ b/surface_native.go
@@ -319,5 +319,5 @@ func (st *SurfaceTexture) CreateView(desc *TextureViewDescriptor) (*TextureView,
 		return nil, fmt.Errorf("wgpu: failed to create surface texture view: %w", err)
 	}
 
-	return &TextureView{hal: halView, device: st.device}, nil
+	return &TextureView{hal: halView, device: st.device, texture: st.AsTexture()}, nil
 }

--- a/surface_rust.go
+++ b/surface_rust.go
@@ -192,7 +192,7 @@ func (st *SurfaceTexture) CreateView(desc *TextureViewDescriptor) (*TextureView,
 		return nil, fmt.Errorf("wgpu: failed to create surface texture view: %w", err)
 	}
 
-	return &TextureView{r: rv}, nil
+	return &TextureView{r: rv, device: st.surface.device, texture: st.AsTexture()}, nil
 }
 
 // Texture returns the underlying Texture.


### PR DESCRIPTION
## Summary

`SurfaceTexture.CreateView()` on all 3 build targets didn't set the `texture` field on the returned `TextureView`. Since v0.30.11 added `TextureView.Texture()` as public API, calling it on a surface texture view returned nil.

Fix: set `texture: st.AsTexture()` in native, Rust FFI, and browser `CreateView` paths.

## Test plan

- [x] All targets build (Windows, macOS, Linux, WASM, Rust FFI)
- [x] `go test ./...` — 15/15 pass
- [x] `golangci-lint run` — 0 issues