### PR TITLE
fix(hal/software): Tier 1 fullscreen quad blit detection (v0.30.13, #241)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 
 ## Current Version
 
-v0.30.12 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.1
+v0.30.13 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.0, gputypes v0.5.1
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.13] - 2026-07-10
+
+### Fixed
+
+- **Software: Tier 1 fullscreen quad blit detection** (#241) — when vertex buffers
+  are bound and the resulting 2 triangles form a fullscreen axis-aligned quad covering
+  the render target, bypass SPIR-V fragment shader entirely and use direct memcpy/swizzle.
+  Restores 50+ FPS from 18 FPS for textured quad render passes on software backend.
+  Detection: `isFullscreenQuad()` (bounding box check, 1.5px tolerance) + `blitStateValid()`
+  (blend, depth/stencil, write mask, multisampling).
+
 ## [0.30.12] - 2026-07-10
 
 ### Fixed

--- a/hal/software/draw.go
+++ b/hal/software/draw.go
@@ -107,6 +107,36 @@ func (r *RenderPassEncoder) blitStateValid() bool {
 	return true
 }
 
+// isFullscreenQuad checks whether 2 triangles form an axis-aligned quad covering
+// the full render target. Tolerance of 1.5 pixels handles sub-pixel vertex positions.
+// This is the Tier 1 detection from ADR-SOFTWARE-BLIT-OPTIMIZATION.
+func isFullscreenQuad(triangles []raster.Triangle, w, h int) bool {
+	if len(triangles) != 2 {
+		return false
+	}
+	const eps = 1.5
+	fw, fh := float32(w), float32(h)
+	minX, minY := float32(fw), float32(fh)
+	maxX, maxY := float32(0), float32(0)
+	for _, tri := range triangles {
+		for _, v := range [3]raster.ScreenVertex{tri.V0, tri.V1, tri.V2} {
+			if v.X < minX {
+				minX = v.X
+			}
+			if v.Y < minY {
+				minY = v.Y
+			}
+			if v.X > maxX {
+				maxX = v.X
+			}
+			if v.Y > maxY {
+				maxY = v.Y
+			}
+		}
+	}
+	return minX < eps && minY < eps && maxX > fw-eps && maxY > fh-eps
+}
+
 // isBlitSafeBlend returns true if the blend state allows a direct memcpy blit.
 // Safe modes: no blend (replace), Src (One/Zero), SrcOver (One/OneMinusSrcAlpha).
 func isBlitSafeBlend(b *gputypes.BlendState) bool {
@@ -313,6 +343,16 @@ func (r *RenderPassEncoder) executeVertexDraw(target *Texture, vertexCount, inst
 	if triangles == nil {
 		// Fallback: raw vertex buffer fetch (non-SPIR-V path, single instance only).
 		triangles = r.fetchTriangles(layouts, vertexCount, firstVertex, w, h)
+	}
+
+	// Tier 1 fast-path: if the triangles form a fullscreen quad with a bound
+	// texture and safe render state, bypass the SPIR-V fragment shader entirely
+	// and memcpy/swizzle the texture directly. This is the critical optimization
+	// for issue #241 (18 FPS → 50+ FPS on software backend).
+	if len(triangles) == 2 && r.blitStateValid() && isFullscreenQuad(triangles, w, h) {
+		if r.executeFullscreenBlit(target) {
+			return
+		}
 	}
 
 	// Determine fragment color source: if vertices carry attributes, interpolate.


### PR DESCRIPTION
## Summary

Implements Tier 1 from ADR-SOFTWARE-BLIT-OPTIMIZATION: detect fullscreen textured quad after vertex shader, bypass SPIR-V fragment shader with direct memcpy/swizzle. Restores 50+ FPS from 18 FPS.

### Detection criteria
- Exactly 2 triangles (6 vertices, TriangleList)
- Bounding box covers full render target (1.5px tolerance)
- `blitStateValid()` passes (blend, depth/stencil, write mask, multisampling)
- Bound texture exists in bind groups

### Architecture (ADR)
```
Tier 0: No VB + bound texture + state checks → memcpy  (v0.30.11, hardened)
Tier 1: Has VB + fullscreen quad + state checks → memcpy  (THIS PR)
Tier 2: Normal rasterization  (existing)
```

Closes #241.

## Test plan
- [x] `go build ./...` — pass
- [x] `go test ./...` — 15/15 pass
- [x] `golangci-lint run` — 0 issues