### PR TITLE
fix(vk-gen): C array params + deterministic output (v0.30.18)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 
 ## Current Version
 
-v0.30.17 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.1, gputypes v0.5.1, goffi v0.6.0
+v0.30.18 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.1, gputypes v0.5.1, goffi v0.6.0
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.18] - 2026-07-12
+
+### Fixed
+
+- **Vulkan crash: C array params in vk-gen** — `vkCmdSetBlendConstants(const float[4])`
+  was generated with scalar float CIF (`SigVoidHandleF32`) instead of pointer CIF
+  (`SigVoidHandlePtr`). C array function parameters decay to pointers in C ABI.
+  Generator now detects `[` in vk.xml RawXML and classifies as `ptr` with
+  double-pointer arg pattern (ADR-044). Also fixes `CmdSetFragmentShadingRateKHR`
+  and `CmdSetFragmentShadingRateEnumNV` (`combinerOps[2]`).
+- **vk-gen deterministic output** — extension enum map keys sorted before iteration.
+  Go map order is random; without sorting, `const_gen.go` changed on every
+  regeneration (1780+ line noise diffs). Now fully idempotent.
+
 ## [0.30.17] - 2026-07-12
 
 ### Changed

--- a/cmd/vk-gen/main.go
+++ b/cmd/vk-gen/main.go
@@ -17,6 +17,7 @@ import (
 	"go/format"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -322,9 +323,16 @@ func generateConstants(registry *Registry, outDir string) error {
 		}
 	}
 
-	// Generate extension enum values grouped by the type they extend
+	// Generate extension enum values grouped by the type they extend.
+	// Sort keys for deterministic output (Go map iteration is random).
 	extensionEnums := collectExtensionEnums(registry)
-	for extendsType, enums := range extensionEnums {
+	extendedTypes := make([]string, 0, len(extensionEnums))
+	for k := range extensionEnums {
+		extendedTypes = append(extendedTypes, k)
+	}
+	sort.Strings(extendedTypes)
+	for _, extendsType := range extendedTypes {
+		enums := extensionEnums[extendsType]
 		goTypeName := vkToGoType(extendsType)
 
 		// Filter out duplicates
@@ -936,10 +944,11 @@ func filterParams(params []Param) []Param {
 // classifyParamType classifies a parameter into a simplified category
 func classifyParamType(param Param) string {
 	isPointer := strings.Contains(param.RawXML, "*")
+	isArray := strings.Contains(param.RawXML, "[")
 	baseType := param.Type
 
-	// Pointer types first
-	if isPointer {
+	// In C ABI, array parameters decay to pointers (e.g., const float[4] → const float*).
+	if isPointer || isArray {
 		return "ptr"
 	}
 
@@ -1138,14 +1147,29 @@ func generateCommandMethod(f *os.File, cmd Command) error {
 		}
 	}
 
-	// Build args array
+	// Build args array.
+	// goffi convention (ADR-044): args[i] = unsafe.Pointer to VALUE.
+	// For pointer args: args[i] = unsafe.Pointer(&ptr) — pointer to pointer.
+	// C array params (e.g., const float[4]) decay to pointers in C ABI,
+	// so they need the same double-pointer treatment.
 	argCount := len(params)
+
+	// Emit local pointer vars for array params (C arrays decay to pointers).
+	for _, param := range params {
+		if strings.Contains(param.RawXML, "[") && !strings.Contains(param.RawXML, "*") {
+			fmt.Fprintf(f, "\t%sPtr := unsafe.Pointer(&%s)\n", param.Name, param.Name)
+		}
+	}
+
 	fmt.Fprintf(f, "\targs := [%d]unsafe.Pointer{\n", argCount)
 	for _, param := range params {
 		paramName := param.Name
-		// goffi API requires pointer TO value for all arguments
-		// (the args slice contains pointers to where argument values are stored)
-		fmt.Fprintf(f, "\t\tunsafe.Pointer(&%s),\n", paramName)
+		if strings.Contains(param.RawXML, "[") && !strings.Contains(param.RawXML, "*") {
+			// Array param: pass pointer-to-pointer (C array decays to pointer)
+			fmt.Fprintf(f, "\t\tunsafe.Pointer(&%sPtr),\n", paramName)
+		} else {
+			fmt.Fprintf(f, "\t\tunsafe.Pointer(&%s),\n", paramName)
+		}
 	}
 	fmt.Fprintln(f, "\t}")
 

--- a/hal/vulkan/vk/commands_gen.go
+++ b/hal/vulkan/vk/commands_gen.go
@@ -2114,14 +2114,15 @@ func (c *Commands) CmdSetLineWidth(commandBuffer CommandBuffer, lineWidth float3
 
 // CmdSetBlendConstants wraps vkCmdSetBlendConstants.
 func (c *Commands) CmdSetBlendConstants(commandBuffer CommandBuffer, blendConstants [4]float32) {
+	blendConstantsPtr := unsafe.Pointer(&blendConstants)
 	args := [2]unsafe.Pointer{
 		unsafe.Pointer(&commandBuffer),
-		unsafe.Pointer(&blendConstants),
+		unsafe.Pointer(&blendConstantsPtr),
 	}
 	if c.cmdSetBlendConstants == nil {
 		return
 	}
-	_, _ = ffi.CallFunction(&SigVoidHandleF32, c.cmdSetBlendConstants, nil, args[:])
+	_, _ = ffi.CallFunction(&SigVoidHandlePtr, c.cmdSetBlendConstants, nil, args[:])
 }
 
 // TODO: CmdSetDepthBounds - signature not yet supported: void(handle, f32, f32)
@@ -6509,7 +6510,19 @@ func (c *Commands) GetPhysicalDeviceRefreshableObjectTypesKHR(physicalDevice Phy
 	return Result(result)
 }
 
-// TODO: CmdSetFragmentShadingRateKHR - signature not yet supported: void(handle, ptr, handle)
+// CmdSetFragmentShadingRateKHR wraps vkCmdSetFragmentShadingRateKHR.
+func (c *Commands) CmdSetFragmentShadingRateKHR(commandBuffer CommandBuffer, pFragmentSize *Extent2D, combinerOps [2]FragmentShadingRateCombinerOpKHR) {
+	combinerOpsPtr := unsafe.Pointer(&combinerOps)
+	args := [3]unsafe.Pointer{
+		unsafe.Pointer(&commandBuffer),
+		unsafe.Pointer(&pFragmentSize),
+		unsafe.Pointer(&combinerOpsPtr),
+	}
+	if c.cmdSetFragmentShadingRateKHR == nil {
+		return
+	}
+	_, _ = ffi.CallFunction(&SigVoidHandlePtrPtr, c.cmdSetFragmentShadingRateKHR, nil, args[:])
+}
 
 // GetPhysicalDeviceFragmentShadingRatesKHR wraps vkGetPhysicalDeviceFragmentShadingRatesKHR.
 func (c *Commands) GetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice PhysicalDevice, pFragmentShadingRateCount *uint32, pFragmentShadingRates *PhysicalDeviceFragmentShadingRateKHR) Result {
@@ -6527,15 +6540,16 @@ func (c *Commands) GetPhysicalDeviceFragmentShadingRatesKHR(physicalDevice Physi
 
 // CmdSetFragmentShadingRateEnumNV wraps vkCmdSetFragmentShadingRateEnumNV.
 func (c *Commands) CmdSetFragmentShadingRateEnumNV(commandBuffer CommandBuffer, shadingRate FragmentShadingRateNV, combinerOps [2]FragmentShadingRateCombinerOpKHR) {
+	combinerOpsPtr := unsafe.Pointer(&combinerOps)
 	args := [3]unsafe.Pointer{
 		unsafe.Pointer(&commandBuffer),
 		unsafe.Pointer(&shadingRate),
-		unsafe.Pointer(&combinerOps),
+		unsafe.Pointer(&combinerOpsPtr),
 	}
 	if c.cmdSetFragmentShadingRateEnumNV == nil {
 		return
 	}
-	_, _ = ffi.CallFunction(&SigVoidHandleHandleHandle, c.cmdSetFragmentShadingRateEnumNV, nil, args[:])
+	_, _ = ffi.CallFunction(&SigVoidHandleHandlePtr, c.cmdSetFragmentShadingRateEnumNV, nil, args[:])
 }
 
 // TODO: GetAccelerationStructureBuildSizesKHR - signature not yet supported: void(handle, handle, ptr, ptr, ptr)

--- a/hal/vulkan/vk/const_gen.go
+++ b/hal/vulkan/vk/const_gen.go
@@ -3476,419 +3476,63 @@ const (
 	SwapchainImageUsageSharedBitOhos SwapchainImageUsageFlagBitsOHOS = 1 << 0
 )
 
-// VkPolygonMode extension values
-const (
-	PolygonModeFillRectangleNv PolygonMode = 1000153000
-)
-
-// VkImageTiling extension values
-const (
-	ImageTilingDrmFormatModifierExt ImageTiling = 1000158000
-)
-
-// VkObjectType extension values
-const (
-	ObjectTypeSurfaceKhr                    ObjectType = 1000000000
-	ObjectTypeSwapchainKhr                  ObjectType = 1000001000
-	ObjectTypeDisplayKhr                    ObjectType = 1000002000
-	ObjectTypeDisplayModeKhr                ObjectType = 1000002001
-	ObjectTypeDebugReportCallbackExt        ObjectType = 1000011000
-	ObjectTypeVideoSessionKhr               ObjectType = 1000023000
-	ObjectTypeVideoSessionParametersKhr     ObjectType = 1000023001
-	ObjectTypeCuModuleNvx                   ObjectType = 1000029000
-	ObjectTypeCuFunctionNvx                 ObjectType = 1000029001
-	ObjectTypeDebugUtilsMessengerExt        ObjectType = 1000128000
-	ObjectTypeAccelerationStructureKhr      ObjectType = 1000150000
-	ObjectTypeValidationCacheExt            ObjectType = 1000160000
-	ObjectTypeAccelerationStructureNv       ObjectType = 1000165000
-	ObjectTypePerformanceConfigurationIntel ObjectType = 1000210000
-	ObjectTypeDeferredOperationKhr          ObjectType = 1000268000
-	ObjectTypeIndirectCommandsLayoutNv      ObjectType = 1000277000
-	ObjectTypeCudaModuleNv                  ObjectType = 1000307000
-	ObjectTypeCudaFunctionNv                ObjectType = 1000307001
-	ObjectTypeBufferCollectionFuchsia       ObjectType = 1000366000
-	ObjectTypeMicromapExt                   ObjectType = 1000396000
-	ObjectTypeTensorArm                     ObjectType = 1000460000
-	ObjectTypeTensorViewArm                 ObjectType = 1000460001
-	ObjectTypeOpticalFlowSessionNv          ObjectType = 1000464000
-	ObjectTypeShaderExt                     ObjectType = 1000482000
-	ObjectTypePipelineBinaryKhr             ObjectType = 1000483000
-	ObjectTypeSemaphoreSciSyncPoolNv        ObjectType = 1000489000
-	ObjectTypeDataGraphPipelineSessionArm   ObjectType = 1000507000
-	ObjectTypeExternalComputeQueueNv        ObjectType = 1000556000
-	ObjectTypeIndirectCommandsLayoutExt     ObjectType = 1000572000
-	ObjectTypeIndirectExecutionSetExt       ObjectType = 1000572001
-)
-
-// VkColorSpaceKHR extension values
-const (
-	ColorSpaceDisplayP3NonlinearExt    ColorSpaceKHR = 1000104001
-	ColorSpaceExtendedSrgbLinearExt    ColorSpaceKHR = 1000104002
-	ColorSpaceDisplayP3LinearExt       ColorSpaceKHR = 1000104003
-	ColorSpaceDciP3NonlinearExt        ColorSpaceKHR = 1000104004
-	ColorSpaceBt709LinearExt           ColorSpaceKHR = 1000104005
-	ColorSpaceBt709NonlinearExt        ColorSpaceKHR = 1000104006
-	ColorSpaceBt2020LinearExt          ColorSpaceKHR = 1000104007
-	ColorSpaceHdr10St2084Ext           ColorSpaceKHR = 1000104008
-	ColorSpaceDolbyvisionExt           ColorSpaceKHR = 1000104009
-	ColorSpaceHdr10HlgExt              ColorSpaceKHR = 1000104010
-	ColorSpaceAdobergbLinearExt        ColorSpaceKHR = 1000104011
-	ColorSpaceAdobergbNonlinearExt     ColorSpaceKHR = 1000104012
-	ColorSpacePassThroughExt           ColorSpaceKHR = 1000104013
-	ColorSpaceExtendedSrgbNonlinearExt ColorSpaceKHR = 1000104014
-	ColorSpaceDisplayNativeAmd         ColorSpaceKHR = 1000213000
-)
-
-// VkSubgroupFeatureFlagBits extension values
-const (
-	SubgroupFeaturePartitionedBitNv SubgroupFeatureFlagBits = 256
-)
-
-// VkBorderColor extension values
-const (
-	BorderColorFloatCustomExt BorderColor = 1000287003
-	BorderColorIntCustomExt   BorderColor = 1000287004
-)
-
-// VkVideoSessionCreateFlagBitsKHR extension values
-const (
-	VideoSessionCreateAllowEncodeParameterOptimizationsBitKhr VideoSessionCreateFlagBitsKHR = 2
-	VideoSessionCreateInlineQueriesBitKhr                     VideoSessionCreateFlagBitsKHR = 4
-	VideoSessionCreateAllowEncodeQuantizationDeltaMapBitKhr   VideoSessionCreateFlagBitsKHR = 8
-	VideoSessionCreateAllowEncodeEmphasisMapBitKhr            VideoSessionCreateFlagBitsKHR = 16
-	VideoSessionCreateInlineSessionParametersBitKhr           VideoSessionCreateFlagBitsKHR = 32
-)
-
 // VkAccelerationStructureCreateFlagBitsKHR extension values
 const (
 	AccelerationStructureCreateDescriptorBufferCaptureReplayBitExt AccelerationStructureCreateFlagBitsKHR = 8
 	AccelerationStructureCreateMotionBitNv                         AccelerationStructureCreateFlagBitsKHR = 4
 )
 
-// VkExternalFenceHandleTypeFlagBits extension values
+// VkAccessFlagBits extension values
 const (
-	ExternalFenceHandleTypeSciSyncObjBitNv   ExternalFenceHandleTypeFlagBits = 16
-	ExternalFenceHandleTypeSciSyncFenceBitNv ExternalFenceHandleTypeFlagBits = 32
+	AccessTransformFeedbackWriteBitExt            AccessFlagBits = 33554432
+	AccessTransformFeedbackCounterReadBitExt      AccessFlagBits = 67108864
+	AccessTransformFeedbackCounterWriteBitExt     AccessFlagBits = 134217728
+	AccessConditionalRenderingReadBitExt          AccessFlagBits = 1048576
+	AccessColorAttachmentReadNoncoherentBitExt    AccessFlagBits = 524288
+	AccessAccelerationStructureReadBitKhr         AccessFlagBits = 2097152
+	AccessAccelerationStructureWriteBitKhr        AccessFlagBits = 4194304
+	AccessFragmentDensityMapReadBitExt            AccessFlagBits = 16777216
+	AccessFragmentShadingRateAttachmentReadBitKhr AccessFlagBits = 8388608
+	AccessCommandPreprocessReadBitExt             AccessFlagBits = 131072
+	AccessCommandPreprocessWriteBitExt            AccessFlagBits = 262144
 )
 
-// VkMicromapTypeEXT extension values
+// VkAccessFlagBits2 extension values
 const (
-	MicromapTypeDisplacementMicromapNv MicromapTypeEXT = 1000397000
-)
-
-// VkPipelineStageFlagBits extension values
-const (
-	PipelineStageTransformFeedbackBitExt             PipelineStageFlagBits = 16777216
-	PipelineStageConditionalRenderingBitExt          PipelineStageFlagBits = 262144
-	PipelineStageAccelerationStructureBuildBitKhr    PipelineStageFlagBits = 33554432
-	PipelineStageRayTracingShaderBitKhr              PipelineStageFlagBits = 2097152
-	PipelineStageFragmentDensityProcessBitExt        PipelineStageFlagBits = 8388608
-	PipelineStageFragmentShadingRateAttachmentBitKhr PipelineStageFlagBits = 4194304
-	PipelineStageTaskShaderBitExt                    PipelineStageFlagBits = 524288
-	PipelineStageMeshShaderBitExt                    PipelineStageFlagBits = 1048576
-	PipelineStageCommandPreprocessBitExt             PipelineStageFlagBits = 131072
-)
-
-// VkCopyAccelerationStructureModeKHR extension values
-const (
-	CopyAccelerationStructureModeSerializeKhr   CopyAccelerationStructureModeKHR = 2
-	CopyAccelerationStructureModeDeserializeKhr CopyAccelerationStructureModeKHR = 3
-)
-
-// VkMemoryMapFlagBits extension values
-const (
-	MemoryMapPlacedBitExt MemoryMapFlagBits = 1
-)
-
-// VkQueryPipelineStatisticFlagBits extension values
-const (
-	QueryPipelineStatisticTaskShaderInvocationsBitExt              QueryPipelineStatisticFlagBits = 2048
-	QueryPipelineStatisticMeshShaderInvocationsBitExt              QueryPipelineStatisticFlagBits = 4096
-	QueryPipelineStatisticClusterCullingShaderInvocationsBitHuawei QueryPipelineStatisticFlagBits = 8192
-)
-
-// VkGeometryTypeKHR extension values
-const (
-	GeometryTypeSpheresNv                        GeometryTypeKHR = 1000429004
-	GeometryTypeLinearSweptSpheresNv             GeometryTypeKHR = 1000429005
-	GeometryTypeDenseGeometryFormatTrianglesAmdx GeometryTypeKHR = 1000478000
-)
-
-// VkTensorCreateFlagBitsARM extension values
-const (
-	TensorCreateDescriptorBufferCaptureReplayBitArm TensorCreateFlagBitsARM = 4
-)
-
-// VkVideoEncodeH265CapabilityFlagBitsKHR extension values
-const (
-	VideoEncodeH265CapabilityBPictureIntraRefreshBitKhr VideoEncodeH265CapabilityFlagBitsKHR = 2048
-	VideoEncodeH265CapabilityCuQpDiffWraparoundBitKhr   VideoEncodeH265CapabilityFlagBitsKHR = 1024
-)
-
-// VkSubpassContents extension values
-const (
-	SubpassContentsInlineAndSecondaryCommandBuffersKhr SubpassContents = 1000562000
-)
-
-// VkQueryResultFlagBits extension values
-const (
-	QueryResultWithStatusBitKhr QueryResultFlagBits = 16
-)
-
-// VkVideoCodecOperationFlagBitsKHR extension values
-const (
-	VideoCodecOperationEncodeH264BitKhr VideoCodecOperationFlagBitsKHR = 65536
-	VideoCodecOperationEncodeH265BitKhr VideoCodecOperationFlagBitsKHR = 131072
-	VideoCodecOperationDecodeH264BitKhr VideoCodecOperationFlagBitsKHR = 1
-	VideoCodecOperationDecodeH265BitKhr VideoCodecOperationFlagBitsKHR = 2
-	VideoCodecOperationDecodeAv1BitKhr  VideoCodecOperationFlagBitsKHR = 4
-	VideoCodecOperationEncodeAv1BitKhr  VideoCodecOperationFlagBitsKHR = 262144
-	VideoCodecOperationDecodeVp9BitKhr  VideoCodecOperationFlagBitsKHR = 8
-)
-
-// VkComponentTypeKHR extension values
-const (
-	ComponentTypeBfloat16Khr   ComponentTypeKHR = 1000141000
-	ComponentTypeSint8PackedNv ComponentTypeKHR = 1000491000
-	ComponentTypeUint8PackedNv ComponentTypeKHR = 1000491001
-	ComponentTypeFloat8E4m3Ext ComponentTypeKHR = 1000567002
-	ComponentTypeFloat8E5m2Ext ComponentTypeKHR = 1000567003
-)
-
-// VkIndirectCommandsTokenTypeEXT extension values
-const (
-	IndirectCommandsTokenTypeDrawMeshTasksNvExt      IndirectCommandsTokenTypeEXT = 1000202002
-	IndirectCommandsTokenTypeDrawMeshTasksCountNvExt IndirectCommandsTokenTypeEXT = 1000202003
-	IndirectCommandsTokenTypeDrawMeshTasksExt        IndirectCommandsTokenTypeEXT = 1000328000
-	IndirectCommandsTokenTypeDrawMeshTasksCountExt   IndirectCommandsTokenTypeEXT = 1000328001
-	IndirectCommandsTokenTypeTraceRays2Ext           IndirectCommandsTokenTypeEXT = 1000386004
-)
-
-// VkTimeDomainKHR extension values
-const (
-	TimeDomainPresentStageLocalExt TimeDomainKHR = 1000208000
-	TimeDomainSwapchainLocalExt    TimeDomainKHR = 1000208001
-)
-
-// VkSamplerCreateFlagBits extension values
-const (
-	SamplerCreateSubsampledBitExt                     SamplerCreateFlagBits = 1
-	SamplerCreateSubsampledCoarseReconstructionBitExt SamplerCreateFlagBits = 2
-	SamplerCreateDescriptorBufferCaptureReplayBitExt  SamplerCreateFlagBits = 8
-	SamplerCreateNonSeamlessCubeMapBitExt             SamplerCreateFlagBits = 4
-	SamplerCreateImageProcessingBitQcom               SamplerCreateFlagBits = 16
-)
-
-// VkPipelineColorBlendStateCreateFlagBits extension values
-const (
-	PipelineColorBlendStateCreateRasterizationOrderAttachmentAccessBitExt PipelineColorBlendStateCreateFlagBits = 1
-)
-
-// VkVideoEncodeFlagBitsKHR extension values
-const (
-	VideoEncodeIntraRefreshBitKhr             VideoEncodeFlagBitsKHR = 4
-	VideoEncodeWithQuantizationDeltaMapBitKhr VideoEncodeFlagBitsKHR = 1
-	VideoEncodeWithEmphasisMapBitKhr          VideoEncodeFlagBitsKHR = 2
-)
-
-// VkMemoryPropertyFlagBits extension values
-const (
-	MemoryPropertyDeviceCoherentBitAmd MemoryPropertyFlagBits = 64
-	MemoryPropertyDeviceUncachedBitAmd MemoryPropertyFlagBits = 128
-	MemoryPropertyRdmaCapableBitNv     MemoryPropertyFlagBits = 256
-)
-
-// VkRenderingFlagBits extension values
-const (
-	RenderingEnableLegacyDitheringBitExt            RenderingFlagBits = 8
-	RenderingContentsInlineBitKhr                   RenderingFlagBits = 16
-	RenderingPerLayerFragmentDensityBitValve        RenderingFlagBits = 32
-	RenderingFragmentRegionBitExt                   RenderingFlagBits = 64
-	RenderingCustomResolveBitExt                    RenderingFlagBits = 128
-	RenderingLocalReadConcurrentAccessControlBitKhr RenderingFlagBits = 256
-)
-
-// VkVideoEncodeAV1CapabilityFlagBitsKHR extension values
-const (
-	VideoEncodeAv1CapabilityCompoundPredictionIntraRefreshBitKhr VideoEncodeAV1CapabilityFlagBitsKHR = 32
-)
-
-// VkPipelineCacheCreateFlagBits extension values
-const (
-	PipelineCacheCreateInternallySynchronizedMergeBitKhr PipelineCacheCreateFlagBits = 8
-)
-
-// VkResolveImageFlagBitsKHR extension values
-const (
-	ResolveImageSkipTransferFunctionBitKhr   ResolveImageFlagBitsKHR = 1
-	ResolveImageEnableTransferFunctionBitKhr ResolveImageFlagBitsKHR = 2
-)
-
-// VkSwapchainCreateFlagBitsKHR extension values
-const (
-	SwapchainCreateSplitInstanceBindRegionsBitKhr SwapchainCreateFlagBitsKHR = 1
-	SwapchainCreateProtectedBitKhr                SwapchainCreateFlagBitsKHR = 2
-	SwapchainCreateMutableFormatBitKhr            SwapchainCreateFlagBitsKHR = 4
-	SwapchainCreatePresentTimingBitExt            SwapchainCreateFlagBitsKHR = 512
-	SwapchainCreatePresentId2BitKhr               SwapchainCreateFlagBitsKHR = 64
-	SwapchainCreatePresentWait2BitKhr             SwapchainCreateFlagBitsKHR = 128
-	SwapchainCreateDeferredMemoryAllocationBitKhr SwapchainCreateFlagBitsKHR = 8
-)
-
-// VkBufferUsageFlagBits extension values
-const (
-	BufferUsageVideoDecodeSrcBitKhr                          BufferUsageFlagBits = 8192
-	BufferUsageVideoDecodeDstBitKhr                          BufferUsageFlagBits = 16384
-	BufferUsageTransformFeedbackBufferBitExt                 BufferUsageFlagBits = 2048
-	BufferUsageTransformFeedbackCounterBufferBitExt          BufferUsageFlagBits = 4096
-	BufferUsageConditionalRenderingBitExt                    BufferUsageFlagBits = 512
-	BufferUsageExecutionGraphScratchBitAmdx                  BufferUsageFlagBits = 33554432
-	BufferUsageAccelerationStructureBuildInputReadOnlyBitKhr BufferUsageFlagBits = 524288
-	BufferUsageAccelerationStructureStorageBitKhr            BufferUsageFlagBits = 1048576
-	BufferUsageShaderBindingTableBitKhr                      BufferUsageFlagBits = 1024
-	BufferUsageVideoEncodeDstBitKhr                          BufferUsageFlagBits = 32768
-	BufferUsageVideoEncodeSrcBitKhr                          BufferUsageFlagBits = 65536
-	BufferUsageSamplerDescriptorBufferBitExt                 BufferUsageFlagBits = 2097152
-	BufferUsageResourceDescriptorBufferBitExt                BufferUsageFlagBits = 4194304
-	BufferUsagePushDescriptorsDescriptorBufferBitExt         BufferUsageFlagBits = 67108864
-	BufferUsageMicromapBuildInputReadOnlyBitExt              BufferUsageFlagBits = 8388608
-	BufferUsageMicromapStorageBitExt                         BufferUsageFlagBits = 16777216
-	BufferUsageTileMemoryBitQcom                             BufferUsageFlagBits = 134217728
-)
-
-// VkFormatFeatureFlagBits2 extension values
-const (
-	FormatFeature2VideoDecodeOutputBitKhr                 FormatFeatureFlagBits2 = 33554432
-	FormatFeature2VideoDecodeDpbBitKhr                    FormatFeatureFlagBits2 = 67108864
-	FormatFeature2AccelerationStructureVertexBufferBitKhr FormatFeatureFlagBits2 = 536870912
-	FormatFeature2FragmentDensityMapBitExt                FormatFeatureFlagBits2 = 16777216
-	FormatFeature2FragmentShadingRateAttachmentBitKhr     FormatFeatureFlagBits2 = 1073741824
-	FormatFeature2VideoEncodeInputBitKhr                  FormatFeatureFlagBits2 = 134217728
-	FormatFeature2VideoEncodeDpbBitKhr                    FormatFeatureFlagBits2 = 268435456
-	FormatFeature2AccelerationStructureRadiusBufferBitNv  FormatFeatureFlagBits2 = 2251799813685248
-	FormatFeature2LinearColorAttachmentBitNv              FormatFeatureFlagBits2 = 274877906944
-	FormatFeature2WeightImageBitQcom                      FormatFeatureFlagBits2 = 17179869184
-	FormatFeature2WeightSampledImageBitQcom               FormatFeatureFlagBits2 = 34359738368
-	FormatFeature2BlockMatchingBitQcom                    FormatFeatureFlagBits2 = 68719476736
-	FormatFeature2BoxFilterSampledBitQcom                 FormatFeatureFlagBits2 = 137438953472
-	FormatFeature2TensorShaderBitArm                      FormatFeatureFlagBits2 = 549755813888
-	FormatFeature2TensorImageAliasingBitArm               FormatFeatureFlagBits2 = 8796093022208
-	FormatFeature2OpticalFlowImageBitNv                   FormatFeatureFlagBits2 = 1099511627776
-	FormatFeature2OpticalFlowVectorBitNv                  FormatFeatureFlagBits2 = 2199023255552
-	FormatFeature2OpticalFlowCostBitNv                    FormatFeatureFlagBits2 = 4398046511104
-	FormatFeature2TensorDataGraphBitArm                   FormatFeatureFlagBits2 = 281474976710656
-	FormatFeature2CopyImageIndirectDstBitKhr              FormatFeatureFlagBits2 = 576460752303423488
-	FormatFeature2VideoEncodeQuantizationDeltaMapBitKhr   FormatFeatureFlagBits2 = 562949953421312
-	FormatFeature2VideoEncodeEmphasisMapBitKhr            FormatFeatureFlagBits2 = 1125899906842624
-	FormatFeature2DepthCopyOnComputeQueueBitKhr           FormatFeatureFlagBits2 = 4503599627370496
-	FormatFeature2DepthCopyOnTransferQueueBitKhr          FormatFeatureFlagBits2 = 9007199254740992
-	FormatFeature2StencilCopyOnComputeQueueBitKhr         FormatFeatureFlagBits2 = 18014398509481984
-	FormatFeature2StencilCopyOnTransferQueueBitKhr        FormatFeatureFlagBits2 = 36028797018963968
-)
-
-// VkPipelineLayoutCreateFlagBits extension values
-const (
-	PipelineLayoutCreateIndependentSetsBitExt PipelineLayoutCreateFlagBits = 2
-)
-
-// VkPipelineDepthStencilStateCreateFlagBits extension values
-const (
-	PipelineDepthStencilStateCreateRasterizationOrderAttachmentDepthAccessBitExt   PipelineDepthStencilStateCreateFlagBits = 1
-	PipelineDepthStencilStateCreateRasterizationOrderAttachmentStencilAccessBitExt PipelineDepthStencilStateCreateFlagBits = 2
-)
-
-// VkDescriptorPoolCreateFlagBits extension values
-const (
-	DescriptorPoolCreateHostOnlyBitExt                DescriptorPoolCreateFlagBits = 4
-	DescriptorPoolCreateAllowOverallocationSetsBitNv  DescriptorPoolCreateFlagBits = 8
-	DescriptorPoolCreateAllowOverallocationPoolsBitNv DescriptorPoolCreateFlagBits = 16
-)
-
-// VkMemoryHeapFlagBits extension values
-const (
-	MemoryHeapTileMemoryBitQcom MemoryHeapFlagBits = 8
-)
-
-// VkShaderStageFlagBits extension values
-const (
-	ShaderStageRaygenBitKhr            ShaderStageFlagBits = 256
-	ShaderStageAnyHitBitKhr            ShaderStageFlagBits = 512
-	ShaderStageClosestHitBitKhr        ShaderStageFlagBits = 1024
-	ShaderStageMissBitKhr              ShaderStageFlagBits = 2048
-	ShaderStageIntersectionBitKhr      ShaderStageFlagBits = 4096
-	ShaderStageCallableBitKhr          ShaderStageFlagBits = 8192
-	ShaderStageTaskBitExt              ShaderStageFlagBits = 64
-	ShaderStageMeshBitExt              ShaderStageFlagBits = 128
-	ShaderStageSubpassShadingBitHuawei ShaderStageFlagBits = 16384
-	ShaderStageClusterCullingBitHuawei ShaderStageFlagBits = 524288
-)
-
-// VkMemoryUnmapFlagBits extension values
-const (
-	MemoryUnmapReserveBitExt MemoryUnmapFlagBits = 1
-)
-
-// VkMemoryAllocateFlagBits extension values
-const (
-	MemoryAllocateZeroInitializeBitExt MemoryAllocateFlagBits = 8
+	Access2VideoDecodeReadBitKhr                   AccessFlagBits2 = 34359738368
+	Access2VideoDecodeWriteBitKhr                  AccessFlagBits2 = 68719476736
+	Access2VideoEncodeReadBitKhr                   AccessFlagBits2 = 137438953472
+	Access2VideoEncodeWriteBitKhr                  AccessFlagBits2 = 274877906944
+	Access2ShaderTileAttachmentReadBitQcom         AccessFlagBits2 = 2251799813685248
+	Access2ShaderTileAttachmentWriteBitQcom        AccessFlagBits2 = 4503599627370496
+	Access2TransformFeedbackWriteBitExt            AccessFlagBits2 = 33554432
+	Access2TransformFeedbackCounterReadBitExt      AccessFlagBits2 = 67108864
+	Access2TransformFeedbackCounterWriteBitExt     AccessFlagBits2 = 134217728
+	Access2ConditionalRenderingReadBitExt          AccessFlagBits2 = 1048576
+	Access2CommandPreprocessReadBitExt             AccessFlagBits2 = 131072
+	Access2CommandPreprocessWriteBitExt            AccessFlagBits2 = 262144
+	Access2FragmentShadingRateAttachmentReadBitKhr AccessFlagBits2 = 8388608
+	Access2AccelerationStructureReadBitKhr         AccessFlagBits2 = 2097152
+	Access2AccelerationStructureWriteBitKhr        AccessFlagBits2 = 4194304
+	Access2FragmentDensityMapReadBitExt            AccessFlagBits2 = 16777216
+	Access2ColorAttachmentReadNoncoherentBitExt    AccessFlagBits2 = 524288
+	Access2DescriptorBufferReadBitExt              AccessFlagBits2 = 2199023255552
+	Access2InvocationMaskReadBitHuawei             AccessFlagBits2 = 549755813888
+	Access2ShaderBindingTableReadBitKhr            AccessFlagBits2 = 1099511627776
+	Access2MicromapReadBitExt                      AccessFlagBits2 = 17592186044416
+	Access2MicromapWriteBitExt                     AccessFlagBits2 = 35184372088832
+	Access2OpticalFlowReadBitNv                    AccessFlagBits2 = 4398046511104
+	Access2OpticalFlowWriteBitNv                   AccessFlagBits2 = 8796093022208
+	Access2DataGraphReadBitArm                     AccessFlagBits2 = 140737488355328
+	Access2DataGraphWriteBitArm                    AccessFlagBits2 = 281474976710656
+	Access2MemoryDecompressionReadBitExt           AccessFlagBits2 = 36028797018963968
+	Access2MemoryDecompressionWriteBitExt          AccessFlagBits2 = 72057594037927936
 )
 
 // VkAttachmentDescriptionFlagBits extension values
 const (
 	AttachmentDescriptionResolveSkipTransferFunctionBitKhr   AttachmentDescriptionFlagBits = 2
 	AttachmentDescriptionResolveEnableTransferFunctionBitKhr AttachmentDescriptionFlagBits = 4
-)
-
-// VkTensorUsageFlagBitsARM extension values
-const (
-	TensorUsageDataGraphBitArm TensorUsageFlagBitsARM = 32
-)
-
-// VkToolPurposeFlagBits extension values
-const (
-	ToolPurposeDebugReportingBitExt ToolPurposeFlagBits = 32
-	ToolPurposeDebugMarkersBitExt   ToolPurposeFlagBits = 64
-)
-
-// VkPipelineBindPoint extension values
-const (
-	PipelineBindPointExecutionGraphAmdx   PipelineBindPoint = 1000134000
-	PipelineBindPointRayTracingKhr        PipelineBindPoint = 1000347000
-	PipelineBindPointSubpassShadingHuawei PipelineBindPoint = 1000369003
-	PipelineBindPointDataGraphArm         PipelineBindPoint = 1000507000
-)
-
-// VkImageUsageFlagBits extension values
-const (
-	ImageUsageVideoDecodeDstBitKhr                  ImageUsageFlagBits = 1024
-	ImageUsageVideoDecodeSrcBitKhr                  ImageUsageFlagBits = 2048
-	ImageUsageVideoDecodeDpbBitKhr                  ImageUsageFlagBits = 4096
-	ImageUsageFragmentDensityMapBitExt              ImageUsageFlagBits = 512
-	ImageUsageFragmentShadingRateAttachmentBitKhr   ImageUsageFlagBits = 256
-	ImageUsageVideoEncodeDstBitKhr                  ImageUsageFlagBits = 8192
-	ImageUsageVideoEncodeSrcBitKhr                  ImageUsageFlagBits = 16384
-	ImageUsageVideoEncodeDpbBitKhr                  ImageUsageFlagBits = 32768
-	ImageUsageAttachmentFeedbackLoopBitExt          ImageUsageFlagBits = 524288
-	ImageUsageInvocationMaskBitHuawei               ImageUsageFlagBits = 262144
-	ImageUsageSampleWeightBitQcom                   ImageUsageFlagBits = 1048576
-	ImageUsageSampleBlockMatchBitQcom               ImageUsageFlagBits = 2097152
-	ImageUsageTensorAliasingBitArm                  ImageUsageFlagBits = 8388608
-	ImageUsageTileMemoryBitQcom                     ImageUsageFlagBits = 134217728
-	ImageUsageVideoEncodeQuantizationDeltaMapBitKhr ImageUsageFlagBits = 33554432
-	ImageUsageVideoEncodeEmphasisMapBitKhr          ImageUsageFlagBits = 67108864
-)
-
-// VkSubpassDescriptionFlagBits extension values
-const (
-	SubpassDescriptionPerViewAttributesBitNvx                         SubpassDescriptionFlagBits = 1
-	SubpassDescriptionPerViewPositionXOnlyBitNvx                      SubpassDescriptionFlagBits = 2
-	SubpassDescriptionTileShadingApronBitQcom                         SubpassDescriptionFlagBits = 256
-	SubpassDescriptionRasterizationOrderAttachmentColorAccessBitExt   SubpassDescriptionFlagBits = 16
-	SubpassDescriptionRasterizationOrderAttachmentDepthAccessBitExt   SubpassDescriptionFlagBits = 32
-	SubpassDescriptionRasterizationOrderAttachmentStencilAccessBitExt SubpassDescriptionFlagBits = 64
-	SubpassDescriptionEnableLegacyDitheringBitExt                     SubpassDescriptionFlagBits = 128
-	SubpassDescriptionFragmentRegionBitExt                            SubpassDescriptionFlagBits = 4
-	SubpassDescriptionCustomResolveBitExt                             SubpassDescriptionFlagBits = 8
 )
 
 // VkBlendOp extension values
@@ -3941,29 +3585,139 @@ const (
 	BlendOpBlueExt             BlendOp = 1000148045
 )
 
-// VkFilter extension values
+// VkBorderColor extension values
 const (
-	FilterCubicExt Filter = 1000170000
+	BorderColorFloatCustomExt BorderColor = 1000287003
+	BorderColorIntCustomExt   BorderColor = 1000287004
 )
 
-// VkImageViewCreateFlagBits extension values
+// VkBufferCreateFlagBits extension values
 const (
-	ImageViewCreateFragmentDensityMapDynamicBitExt     ImageViewCreateFlagBits = 1
-	ImageViewCreateDescriptorBufferCaptureReplayBitExt ImageViewCreateFlagBits = 4
-	ImageViewCreateFragmentDensityMapDeferredBitExt    ImageViewCreateFlagBits = 2
+	BufferCreateDescriptorBufferCaptureReplayBitExt BufferCreateFlagBits = 32
+	BufferCreateVideoProfileIndependentBitKhr       BufferCreateFlagBits = 64
 )
 
-// VkTensorViewCreateFlagBitsARM extension values
+// VkBufferUsageFlagBits extension values
 const (
-	TensorViewCreateDescriptorBufferCaptureReplayBitArm TensorViewCreateFlagBitsARM = 1
+	BufferUsageVideoDecodeSrcBitKhr                          BufferUsageFlagBits = 8192
+	BufferUsageVideoDecodeDstBitKhr                          BufferUsageFlagBits = 16384
+	BufferUsageTransformFeedbackBufferBitExt                 BufferUsageFlagBits = 2048
+	BufferUsageTransformFeedbackCounterBufferBitExt          BufferUsageFlagBits = 4096
+	BufferUsageConditionalRenderingBitExt                    BufferUsageFlagBits = 512
+	BufferUsageExecutionGraphScratchBitAmdx                  BufferUsageFlagBits = 33554432
+	BufferUsageAccelerationStructureBuildInputReadOnlyBitKhr BufferUsageFlagBits = 524288
+	BufferUsageAccelerationStructureStorageBitKhr            BufferUsageFlagBits = 1048576
+	BufferUsageShaderBindingTableBitKhr                      BufferUsageFlagBits = 1024
+	BufferUsageVideoEncodeDstBitKhr                          BufferUsageFlagBits = 32768
+	BufferUsageVideoEncodeSrcBitKhr                          BufferUsageFlagBits = 65536
+	BufferUsageSamplerDescriptorBufferBitExt                 BufferUsageFlagBits = 2097152
+	BufferUsageResourceDescriptorBufferBitExt                BufferUsageFlagBits = 4194304
+	BufferUsagePushDescriptorsDescriptorBufferBitExt         BufferUsageFlagBits = 67108864
+	BufferUsageMicromapBuildInputReadOnlyBitExt              BufferUsageFlagBits = 8388608
+	BufferUsageMicromapStorageBitExt                         BufferUsageFlagBits = 16777216
+	BufferUsageTileMemoryBitQcom                             BufferUsageFlagBits = 134217728
 )
 
-// VkQueueFlagBits extension values
+// VkBufferUsageFlagBits2 extension values
 const (
-	QueueVideoDecodeBitKhr QueueFlagBits = 32
-	QueueVideoEncodeBitKhr QueueFlagBits = 64
-	QueueOpticalFlowBitNv  QueueFlagBits = 256
-	QueueDataGraphBitArm   QueueFlagBits = 1024
+	BufferUsage2ExecutionGraphScratchBitAmdx                  BufferUsageFlagBits2 = 33554432
+	BufferUsage2ConditionalRenderingBitExt                    BufferUsageFlagBits2 = 512
+	BufferUsage2ShaderBindingTableBitKhr                      BufferUsageFlagBits2 = 1024
+	BufferUsage2TransformFeedbackBufferBitExt                 BufferUsageFlagBits2 = 2048
+	BufferUsage2TransformFeedbackCounterBufferBitExt          BufferUsageFlagBits2 = 4096
+	BufferUsage2VideoDecodeSrcBitKhr                          BufferUsageFlagBits2 = 8192
+	BufferUsage2VideoDecodeDstBitKhr                          BufferUsageFlagBits2 = 16384
+	BufferUsage2VideoEncodeDstBitKhr                          BufferUsageFlagBits2 = 32768
+	BufferUsage2VideoEncodeSrcBitKhr                          BufferUsageFlagBits2 = 65536
+	BufferUsage2AccelerationStructureBuildInputReadOnlyBitKhr BufferUsageFlagBits2 = 524288
+	BufferUsage2AccelerationStructureStorageBitKhr            BufferUsageFlagBits2 = 1048576
+	BufferUsage2SamplerDescriptorBufferBitExt                 BufferUsageFlagBits2 = 2097152
+	BufferUsage2ResourceDescriptorBufferBitExt                BufferUsageFlagBits2 = 4194304
+	BufferUsage2PushDescriptorsDescriptorBufferBitExt         BufferUsageFlagBits2 = 67108864
+	BufferUsage2MicromapBuildInputReadOnlyBitExt              BufferUsageFlagBits2 = 8388608
+	BufferUsage2MicromapStorageBitExt                         BufferUsageFlagBits2 = 16777216
+	BufferUsage2CompressedDataDgf1BitAmdx                     BufferUsageFlagBits2 = 8589934592
+	BufferUsage2DataGraphForeignDescriptorBitArm              BufferUsageFlagBits2 = 536870912
+	BufferUsage2TileMemoryBitQcom                             BufferUsageFlagBits2 = 134217728
+	BufferUsage2MemoryDecompressionBitExt                     BufferUsageFlagBits2 = 4294967296
+	BufferUsage2PreprocessBufferBitExt                        BufferUsageFlagBits2 = 2147483648
+)
+
+// VkBuildAccelerationStructureFlagBitsKHR extension values
+const (
+	BuildAccelerationStructureMotionBitNv                          BuildAccelerationStructureFlagBitsKHR = 32
+	BuildAccelerationStructureAllowOpacityMicromapUpdateBitExt     BuildAccelerationStructureFlagBitsKHR = 64
+	BuildAccelerationStructureAllowDisableOpacityMicromapsBitExt   BuildAccelerationStructureFlagBitsKHR = 128
+	BuildAccelerationStructureAllowOpacityMicromapDataUpdateBitExt BuildAccelerationStructureFlagBitsKHR = 256
+	BuildAccelerationStructureAllowDisplacementMicromapUpdateBitNv BuildAccelerationStructureFlagBitsKHR = 512
+	BuildAccelerationStructureAllowDataAccessBitKhr                BuildAccelerationStructureFlagBitsKHR = 2048
+	BuildAccelerationStructureAllowClusterOpacityMicromapsBitNv    BuildAccelerationStructureFlagBitsKHR = 4096
+)
+
+// VkColorSpaceKHR extension values
+const (
+	ColorSpaceDisplayP3NonlinearExt    ColorSpaceKHR = 1000104001
+	ColorSpaceExtendedSrgbLinearExt    ColorSpaceKHR = 1000104002
+	ColorSpaceDisplayP3LinearExt       ColorSpaceKHR = 1000104003
+	ColorSpaceDciP3NonlinearExt        ColorSpaceKHR = 1000104004
+	ColorSpaceBt709LinearExt           ColorSpaceKHR = 1000104005
+	ColorSpaceBt709NonlinearExt        ColorSpaceKHR = 1000104006
+	ColorSpaceBt2020LinearExt          ColorSpaceKHR = 1000104007
+	ColorSpaceHdr10St2084Ext           ColorSpaceKHR = 1000104008
+	ColorSpaceDolbyvisionExt           ColorSpaceKHR = 1000104009
+	ColorSpaceHdr10HlgExt              ColorSpaceKHR = 1000104010
+	ColorSpaceAdobergbLinearExt        ColorSpaceKHR = 1000104011
+	ColorSpaceAdobergbNonlinearExt     ColorSpaceKHR = 1000104012
+	ColorSpacePassThroughExt           ColorSpaceKHR = 1000104013
+	ColorSpaceExtendedSrgbNonlinearExt ColorSpaceKHR = 1000104014
+	ColorSpaceDisplayNativeAmd         ColorSpaceKHR = 1000213000
+)
+
+// VkComponentTypeKHR extension values
+const (
+	ComponentTypeBfloat16Khr   ComponentTypeKHR = 1000141000
+	ComponentTypeSint8PackedNv ComponentTypeKHR = 1000491000
+	ComponentTypeUint8PackedNv ComponentTypeKHR = 1000491001
+	ComponentTypeFloat8E4m3Ext ComponentTypeKHR = 1000567002
+	ComponentTypeFloat8E5m2Ext ComponentTypeKHR = 1000567003
+)
+
+// VkCopyAccelerationStructureModeKHR extension values
+const (
+	CopyAccelerationStructureModeSerializeKhr   CopyAccelerationStructureModeKHR = 2
+	CopyAccelerationStructureModeDeserializeKhr CopyAccelerationStructureModeKHR = 3
+)
+
+// VkDebugReportObjectTypeEXT extension values
+const (
+	DebugReportObjectTypeSamplerYcbcrConversionExt   DebugReportObjectTypeEXT = 1000011000
+	DebugReportObjectTypeDescriptorUpdateTemplateExt DebugReportObjectTypeEXT = 1000011000
+	DebugReportObjectTypeCuModuleNvxExt              DebugReportObjectTypeEXT = 1000029000
+	DebugReportObjectTypeCuFunctionNvxExt            DebugReportObjectTypeEXT = 1000029001
+	DebugReportObjectTypeAccelerationStructureKhrExt DebugReportObjectTypeEXT = 1000150000
+	DebugReportObjectTypeAccelerationStructureNvExt  DebugReportObjectTypeEXT = 1000165000
+	DebugReportObjectTypeCudaModuleNvExt             DebugReportObjectTypeEXT = 1000307000
+	DebugReportObjectTypeCudaFunctionNvExt           DebugReportObjectTypeEXT = 1000307001
+	DebugReportObjectTypeBufferCollectionFuchsiaExt  DebugReportObjectTypeEXT = 1000366000
+)
+
+// VkDebugUtilsMessageTypeFlagBitsEXT extension values
+const (
+	DebugUtilsMessageTypeDeviceAddressBindingBitExt DebugUtilsMessageTypeFlagBitsEXT = 8
+)
+
+// VkDependencyFlagBits extension values
+const (
+	DependencyFeedbackLoopBitExt                             DependencyFlagBits = 8
+	DependencyQueueFamilyOwnershipTransferUseAllStagesBitKhr DependencyFlagBits = 32
+	DependencyAsymmetricEventBitKhr                          DependencyFlagBits = 64
+)
+
+// VkDescriptorPoolCreateFlagBits extension values
+const (
+	DescriptorPoolCreateHostOnlyBitExt                DescriptorPoolCreateFlagBits = 4
+	DescriptorPoolCreateAllowOverallocationSetsBitNv  DescriptorPoolCreateFlagBits = 8
+	DescriptorPoolCreateAllowOverallocationPoolsBitNv DescriptorPoolCreateFlagBits = 16
 )
 
 // VkDescriptorSetLayoutCreateFlagBits extension values
@@ -3975,134 +3729,15 @@ const (
 	DescriptorSetLayoutCreatePerStageBitNv                   DescriptorSetLayoutCreateFlagBits = 64
 )
 
-// VkImageCreateFlagBits extension values
+// VkDescriptorType extension values
 const (
-	ImageCreateCornerSampledBitNv                      ImageCreateFlagBits = 8192
-	ImageCreateSampleLocationsCompatibleDepthBitExt    ImageCreateFlagBits = 4096
-	ImageCreateSubsampledBitExt                        ImageCreateFlagBits = 16384
-	ImageCreateDescriptorBufferCaptureReplayBitExt     ImageCreateFlagBits = 65536
-	ImageCreateMultisampledRenderToSingleSampledBitExt ImageCreateFlagBits = 262144
-	ImageCreate2dViewCompatibleBitExt                  ImageCreateFlagBits = 131072
-	ImageCreateVideoProfileIndependentBitKhr           ImageCreateFlagBits = 1048576
-	ImageCreateFragmentDensityMapOffsetBitExt          ImageCreateFlagBits = 32768
-)
-
-// VkFormat extension values
-const (
-	FormatPvrtc12bppUnormBlockImg                 Format = 1000054000
-	FormatPvrtc14bppUnormBlockImg                 Format = 1000054001
-	FormatPvrtc22bppUnormBlockImg                 Format = 1000054002
-	FormatPvrtc24bppUnormBlockImg                 Format = 1000054003
-	FormatPvrtc12bppSrgbBlockImg                  Format = 1000054004
-	FormatPvrtc14bppSrgbBlockImg                  Format = 1000054005
-	FormatPvrtc22bppSrgbBlockImg                  Format = 1000054006
-	FormatPvrtc24bppSrgbBlockImg                  Format = 1000054007
-	FormatR8BoolArm                               Format = 1000460000
-	FormatR16g16Sfixed5Nv                         Format = 1000464000
-	FormatR10x6UintPack16Arm                      Format = 1000609000
-	FormatR10x6g10x6Uint2pack16Arm                Format = 1000609001
-	FormatR10x6g10x6b10x6a10x6Uint4pack16Arm      Format = 1000609002
-	FormatR12x4UintPack16Arm                      Format = 1000609003
-	FormatR12x4g12x4Uint2pack16Arm                Format = 1000609004
-	FormatR12x4g12x4b12x4a12x4Uint4pack16Arm      Format = 1000609005
-	FormatR14x2UintPack16Arm                      Format = 1000609006
-	FormatR14x2g14x2Uint2pack16Arm                Format = 1000609007
-	FormatR14x2g14x2b14x2a14x2Uint4pack16Arm      Format = 1000609008
-	FormatR14x2UnormPack16Arm                     Format = 1000609009
-	FormatR14x2g14x2Unorm2pack16Arm               Format = 1000609010
-	FormatR14x2g14x2b14x2a14x2Unorm4pack16Arm     Format = 1000609011
-	FormatG14x2B14x2r14x22plane420Unorm3pack16Arm Format = 1000609012
-	FormatG14x2B14x2r14x22plane422Unorm3pack16Arm Format = 1000609013
-)
-
-// VkDependencyFlagBits extension values
-const (
-	DependencyFeedbackLoopBitExt                             DependencyFlagBits = 8
-	DependencyQueueFamilyOwnershipTransferUseAllStagesBitKhr DependencyFlagBits = 32
-	DependencyAsymmetricEventBitKhr                          DependencyFlagBits = 64
-)
-
-// VkGeometryInstanceFlagBitsKHR extension values
-const (
-	GeometryInstanceForceOpacityMicromap2StateBitExt GeometryInstanceFlagBitsKHR = 16
-	GeometryInstanceDisableOpacityMicromapsBitExt    GeometryInstanceFlagBitsKHR = 32
-)
-
-// VkPipelineCacheHeaderVersion extension values
-const (
-	PipelineCacheHeaderVersionDataGraphQcom PipelineCacheHeaderVersion = 1000629000
-)
-
-// VkExternalMemoryHandleTypeFlagBits extension values
-const (
-	ExternalMemoryHandleTypeDmaBufBitExt                    ExternalMemoryHandleTypeFlagBits = 512
-	ExternalMemoryHandleTypeAndroidHardwareBufferBitAndroid ExternalMemoryHandleTypeFlagBits = 1024
-	ExternalMemoryHandleTypeHostAllocationBitExt            ExternalMemoryHandleTypeFlagBits = 128
-	ExternalMemoryHandleTypeHostMappedForeignMemoryBitExt   ExternalMemoryHandleTypeFlagBits = 256
-	ExternalMemoryHandleTypeZirconVmoBitFuchsia             ExternalMemoryHandleTypeFlagBits = 2048
-	ExternalMemoryHandleTypeRdmaAddressBitNv                ExternalMemoryHandleTypeFlagBits = 4096
-	ExternalMemoryHandleTypeSciBufBitNv                     ExternalMemoryHandleTypeFlagBits = 8192
-	ExternalMemoryHandleTypeOhNativeBufferBitOhos           ExternalMemoryHandleTypeFlagBits = 32768
-	ExternalMemoryHandleTypeScreenBufferBitQnx              ExternalMemoryHandleTypeFlagBits = 16384
-	ExternalMemoryHandleTypeMtlbufferBitExt                 ExternalMemoryHandleTypeFlagBits = 65536
-	ExternalMemoryHandleTypeMtltextureBitExt                ExternalMemoryHandleTypeFlagBits = 131072
-	ExternalMemoryHandleTypeMtlheapBitExt                   ExternalMemoryHandleTypeFlagBits = 262144
-)
-
-// VkPipelineCreateFlagBits2 extension values
-const (
-	PipelineCreate2ExecutionGraphBitAmdx                            PipelineCreateFlagBits2 = 4294967296
-	PipelineCreate2RayTracingAllowSpheresAndLinearSweptSpheresBitNv PipelineCreateFlagBits2 = 8589934592
-	PipelineCreate2EnableLegacyDitheringBitExt                      PipelineCreateFlagBits2 = 17179869184
-	PipelineCreate2DeferCompileBitNv                                PipelineCreateFlagBits2 = 32
-	PipelineCreate2CaptureStatisticsBitKhr                          PipelineCreateFlagBits2 = 64
-	PipelineCreate2CaptureInternalRepresentationsBitKhr             PipelineCreateFlagBits2 = 128
-	PipelineCreate2LinkTimeOptimizationBitExt                       PipelineCreateFlagBits2 = 1024
-	PipelineCreate2RetainLinkTimeOptimizationInfoBitExt             PipelineCreateFlagBits2 = 8388608
-	PipelineCreate2LibraryBitKhr                                    PipelineCreateFlagBits2 = 2048
-	PipelineCreate2RayTracingSkipTrianglesBitKhr                    PipelineCreateFlagBits2 = 4096
-	PipelineCreate2RayTracingSkipAabbsBitKhr                        PipelineCreateFlagBits2 = 8192
-	PipelineCreate2RayTracingNoNullAnyHitShadersBitKhr              PipelineCreateFlagBits2 = 16384
-	PipelineCreate2RayTracingNoNullClosestHitShadersBitKhr          PipelineCreateFlagBits2 = 32768
-	PipelineCreate2RayTracingNoNullMissShadersBitKhr                PipelineCreateFlagBits2 = 65536
-	PipelineCreate2RayTracingNoNullIntersectionShadersBitKhr        PipelineCreateFlagBits2 = 131072
-	PipelineCreate2RayTracingShaderGroupHandleCaptureReplayBitKhr   PipelineCreateFlagBits2 = 524288
-	PipelineCreate2IndirectBindableBitNv                            PipelineCreateFlagBits2 = 262144
-	PipelineCreate2RayTracingAllowMotionBitNv                       PipelineCreateFlagBits2 = 1048576
-	PipelineCreate2RenderingFragmentShadingRateAttachmentBitKhr     PipelineCreateFlagBits2 = 2097152
-	PipelineCreate2RenderingFragmentDensityMapAttachmentBitExt      PipelineCreateFlagBits2 = 4194304
-	PipelineCreate2RayTracingOpacityMicromapBitExt                  PipelineCreateFlagBits2 = 16777216
-	PipelineCreate2ColorAttachmentFeedbackLoopBitExt                PipelineCreateFlagBits2 = 33554432
-	PipelineCreate2DepthStencilAttachmentFeedbackLoopBitExt         PipelineCreateFlagBits2 = 67108864
-	PipelineCreate2RayTracingDisplacementMicromapBitNv              PipelineCreateFlagBits2 = 268435456
-	PipelineCreate2DescriptorBufferBitExt                           PipelineCreateFlagBits2 = 536870912
-	PipelineCreate2DisallowOpacityMicromapBitArm                    PipelineCreateFlagBits2 = 137438953472
-	PipelineCreate2CaptureDataBitKhr                                PipelineCreateFlagBits2 = 2147483648
-	PipelineCreate2IndirectBindableBitExt                           PipelineCreateFlagBits2 = 274877906944
-	PipelineCreate2PerLayerFragmentDensityBitValve                  PipelineCreateFlagBits2 = 1099511627776
-	PipelineCreate264BitIndexingBitExt                              PipelineCreateFlagBits2 = 8796093022208
-)
-
-// VkBufferCreateFlagBits extension values
-const (
-	BufferCreateDescriptorBufferCaptureReplayBitExt BufferCreateFlagBits = 32
-	BufferCreateVideoProfileIndependentBitKhr       BufferCreateFlagBits = 64
-)
-
-// VkSamplerReductionMode extension values
-const (
-	SamplerReductionModeWeightedAverageRangeclampQcom SamplerReductionMode = 1000521000
-)
-
-// VkPhysicalDeviceDataGraphOperationTypeARM extension values
-const (
-	PhysicalDeviceDataGraphOperationTypeNeuralModelQcom  PhysicalDeviceDataGraphOperationTypeARM = 1000629000
-	PhysicalDeviceDataGraphOperationTypeBuiltinModelQcom PhysicalDeviceDataGraphOperationTypeARM = 1000629001
-)
-
-// VkSamplerAddressMode extension values
-const (
-	SamplerAddressModeMirrorClampToEdge SamplerAddressMode = 4
+	DescriptorTypeAccelerationStructureKhr           DescriptorType = 1000150000
+	DescriptorTypeAccelerationStructureNv            DescriptorType = 1000165000
+	DescriptorTypeSampleWeightImageQcom              DescriptorType = 1000440000
+	DescriptorTypeBlockMatchImageQcom                DescriptorType = 1000440001
+	DescriptorTypeTensorArm                          DescriptorType = 1000460000
+	DescriptorTypeMutableExt                         DescriptorType = 1000494000
+	DescriptorTypePartitionedAccelerationStructureNv DescriptorType = 1000570000
 )
 
 // VkDynamicState extension values
@@ -4157,58 +3792,65 @@ const (
 	DynamicStateDepthClampRangeExt                  DynamicState = 1000582000
 )
 
-// VkRenderPassCreateFlagBits extension values
+// VkExternalFenceHandleTypeFlagBits extension values
 const (
-	RenderPassCreateTransformBitQcom                RenderPassCreateFlagBits = 2
-	RenderPassCreatePerLayerFragmentDensityBitValve RenderPassCreateFlagBits = 4
+	ExternalFenceHandleTypeSciSyncObjBitNv   ExternalFenceHandleTypeFlagBits = 16
+	ExternalFenceHandleTypeSciSyncFenceBitNv ExternalFenceHandleTypeFlagBits = 32
 )
 
-// VkQueryResultStatusKHR extension values
+// VkExternalMemoryHandleTypeFlagBits extension values
 const (
-	QueryResultStatusInsufficientBitstreamBufferRangeKhr QueryResultStatusKHR = -1000299000
+	ExternalMemoryHandleTypeDmaBufBitExt                    ExternalMemoryHandleTypeFlagBits = 512
+	ExternalMemoryHandleTypeAndroidHardwareBufferBitAndroid ExternalMemoryHandleTypeFlagBits = 1024
+	ExternalMemoryHandleTypeHostAllocationBitExt            ExternalMemoryHandleTypeFlagBits = 128
+	ExternalMemoryHandleTypeHostMappedForeignMemoryBitExt   ExternalMemoryHandleTypeFlagBits = 256
+	ExternalMemoryHandleTypeZirconVmoBitFuchsia             ExternalMemoryHandleTypeFlagBits = 2048
+	ExternalMemoryHandleTypeRdmaAddressBitNv                ExternalMemoryHandleTypeFlagBits = 4096
+	ExternalMemoryHandleTypeSciBufBitNv                     ExternalMemoryHandleTypeFlagBits = 8192
+	ExternalMemoryHandleTypeOhNativeBufferBitOhos           ExternalMemoryHandleTypeFlagBits = 32768
+	ExternalMemoryHandleTypeScreenBufferBitQnx              ExternalMemoryHandleTypeFlagBits = 16384
+	ExternalMemoryHandleTypeMtlbufferBitExt                 ExternalMemoryHandleTypeFlagBits = 65536
+	ExternalMemoryHandleTypeMtltextureBitExt                ExternalMemoryHandleTypeFlagBits = 131072
+	ExternalMemoryHandleTypeMtlheapBitExt                   ExternalMemoryHandleTypeFlagBits = 262144
 )
 
-// VkVideoEncodeH264CapabilityFlagBitsKHR extension values
+// VkExternalSemaphoreHandleTypeFlagBits extension values
 const (
-	VideoEncodeH264CapabilityBPictureIntraRefreshBitKhr VideoEncodeH264CapabilityFlagBitsKHR = 1024
-	VideoEncodeH264CapabilityMbQpDiffWraparoundBitKhr   VideoEncodeH264CapabilityFlagBitsKHR = 512
+	ExternalSemaphoreHandleTypeZirconEventBitFuchsia ExternalSemaphoreHandleTypeFlagBits = 128
+	ExternalSemaphoreHandleTypeSciSyncObjBitNv       ExternalSemaphoreHandleTypeFlagBits = 32
 )
 
-// VkQueryPoolCreateFlagBits extension values
+// VkFilter extension values
 const (
-	QueryPoolCreateResetBitKhr QueryPoolCreateFlagBits = 1
+	FilterCubicExt Filter = 1000170000
 )
 
-// VkAccessFlagBits2 extension values
+// VkFormat extension values
 const (
-	Access2VideoDecodeReadBitKhr                   AccessFlagBits2 = 34359738368
-	Access2VideoDecodeWriteBitKhr                  AccessFlagBits2 = 68719476736
-	Access2VideoEncodeReadBitKhr                   AccessFlagBits2 = 137438953472
-	Access2VideoEncodeWriteBitKhr                  AccessFlagBits2 = 274877906944
-	Access2ShaderTileAttachmentReadBitQcom         AccessFlagBits2 = 2251799813685248
-	Access2ShaderTileAttachmentWriteBitQcom        AccessFlagBits2 = 4503599627370496
-	Access2TransformFeedbackWriteBitExt            AccessFlagBits2 = 33554432
-	Access2TransformFeedbackCounterReadBitExt      AccessFlagBits2 = 67108864
-	Access2TransformFeedbackCounterWriteBitExt     AccessFlagBits2 = 134217728
-	Access2ConditionalRenderingReadBitExt          AccessFlagBits2 = 1048576
-	Access2CommandPreprocessReadBitExt             AccessFlagBits2 = 131072
-	Access2CommandPreprocessWriteBitExt            AccessFlagBits2 = 262144
-	Access2FragmentShadingRateAttachmentReadBitKhr AccessFlagBits2 = 8388608
-	Access2AccelerationStructureReadBitKhr         AccessFlagBits2 = 2097152
-	Access2AccelerationStructureWriteBitKhr        AccessFlagBits2 = 4194304
-	Access2FragmentDensityMapReadBitExt            AccessFlagBits2 = 16777216
-	Access2ColorAttachmentReadNoncoherentBitExt    AccessFlagBits2 = 524288
-	Access2DescriptorBufferReadBitExt              AccessFlagBits2 = 2199023255552
-	Access2InvocationMaskReadBitHuawei             AccessFlagBits2 = 549755813888
-	Access2ShaderBindingTableReadBitKhr            AccessFlagBits2 = 1099511627776
-	Access2MicromapReadBitExt                      AccessFlagBits2 = 17592186044416
-	Access2MicromapWriteBitExt                     AccessFlagBits2 = 35184372088832
-	Access2OpticalFlowReadBitNv                    AccessFlagBits2 = 4398046511104
-	Access2OpticalFlowWriteBitNv                   AccessFlagBits2 = 8796093022208
-	Access2DataGraphReadBitArm                     AccessFlagBits2 = 140737488355328
-	Access2DataGraphWriteBitArm                    AccessFlagBits2 = 281474976710656
-	Access2MemoryDecompressionReadBitExt           AccessFlagBits2 = 36028797018963968
-	Access2MemoryDecompressionWriteBitExt          AccessFlagBits2 = 72057594037927936
+	FormatPvrtc12bppUnormBlockImg                 Format = 1000054000
+	FormatPvrtc14bppUnormBlockImg                 Format = 1000054001
+	FormatPvrtc22bppUnormBlockImg                 Format = 1000054002
+	FormatPvrtc24bppUnormBlockImg                 Format = 1000054003
+	FormatPvrtc12bppSrgbBlockImg                  Format = 1000054004
+	FormatPvrtc14bppSrgbBlockImg                  Format = 1000054005
+	FormatPvrtc22bppSrgbBlockImg                  Format = 1000054006
+	FormatPvrtc24bppSrgbBlockImg                  Format = 1000054007
+	FormatR8BoolArm                               Format = 1000460000
+	FormatR16g16Sfixed5Nv                         Format = 1000464000
+	FormatR10x6UintPack16Arm                      Format = 1000609000
+	FormatR10x6g10x6Uint2pack16Arm                Format = 1000609001
+	FormatR10x6g10x6b10x6a10x6Uint4pack16Arm      Format = 1000609002
+	FormatR12x4UintPack16Arm                      Format = 1000609003
+	FormatR12x4g12x4Uint2pack16Arm                Format = 1000609004
+	FormatR12x4g12x4b12x4a12x4Uint4pack16Arm      Format = 1000609005
+	FormatR14x2UintPack16Arm                      Format = 1000609006
+	FormatR14x2g14x2Uint2pack16Arm                Format = 1000609007
+	FormatR14x2g14x2b14x2a14x2Uint4pack16Arm      Format = 1000609008
+	FormatR14x2UnormPack16Arm                     Format = 1000609009
+	FormatR14x2g14x2Unorm2pack16Arm               Format = 1000609010
+	FormatR14x2g14x2b14x2a14x2Unorm4pack16Arm     Format = 1000609011
+	FormatG14x2B14x2r14x22plane420Unorm3pack16Arm Format = 1000609012
+	FormatG14x2B14x2r14x22plane422Unorm3pack16Arm Format = 1000609013
 )
 
 // VkFormatFeatureFlagBits extension values
@@ -4223,6 +3865,49 @@ const (
 	FormatFeatureVideoEncodeDpbBitKhr                    FormatFeatureFlagBits = 268435456
 )
 
+// VkFormatFeatureFlagBits2 extension values
+const (
+	FormatFeature2VideoDecodeOutputBitKhr                 FormatFeatureFlagBits2 = 33554432
+	FormatFeature2VideoDecodeDpbBitKhr                    FormatFeatureFlagBits2 = 67108864
+	FormatFeature2AccelerationStructureVertexBufferBitKhr FormatFeatureFlagBits2 = 536870912
+	FormatFeature2FragmentDensityMapBitExt                FormatFeatureFlagBits2 = 16777216
+	FormatFeature2FragmentShadingRateAttachmentBitKhr     FormatFeatureFlagBits2 = 1073741824
+	FormatFeature2VideoEncodeInputBitKhr                  FormatFeatureFlagBits2 = 134217728
+	FormatFeature2VideoEncodeDpbBitKhr                    FormatFeatureFlagBits2 = 268435456
+	FormatFeature2AccelerationStructureRadiusBufferBitNv  FormatFeatureFlagBits2 = 2251799813685248
+	FormatFeature2LinearColorAttachmentBitNv              FormatFeatureFlagBits2 = 274877906944
+	FormatFeature2WeightImageBitQcom                      FormatFeatureFlagBits2 = 17179869184
+	FormatFeature2WeightSampledImageBitQcom               FormatFeatureFlagBits2 = 34359738368
+	FormatFeature2BlockMatchingBitQcom                    FormatFeatureFlagBits2 = 68719476736
+	FormatFeature2BoxFilterSampledBitQcom                 FormatFeatureFlagBits2 = 137438953472
+	FormatFeature2TensorShaderBitArm                      FormatFeatureFlagBits2 = 549755813888
+	FormatFeature2TensorImageAliasingBitArm               FormatFeatureFlagBits2 = 8796093022208
+	FormatFeature2OpticalFlowImageBitNv                   FormatFeatureFlagBits2 = 1099511627776
+	FormatFeature2OpticalFlowVectorBitNv                  FormatFeatureFlagBits2 = 2199023255552
+	FormatFeature2OpticalFlowCostBitNv                    FormatFeatureFlagBits2 = 4398046511104
+	FormatFeature2TensorDataGraphBitArm                   FormatFeatureFlagBits2 = 281474976710656
+	FormatFeature2CopyImageIndirectDstBitKhr              FormatFeatureFlagBits2 = 576460752303423488
+	FormatFeature2VideoEncodeQuantizationDeltaMapBitKhr   FormatFeatureFlagBits2 = 562949953421312
+	FormatFeature2VideoEncodeEmphasisMapBitKhr            FormatFeatureFlagBits2 = 1125899906842624
+	FormatFeature2DepthCopyOnComputeQueueBitKhr           FormatFeatureFlagBits2 = 4503599627370496
+	FormatFeature2DepthCopyOnTransferQueueBitKhr          FormatFeatureFlagBits2 = 9007199254740992
+	FormatFeature2StencilCopyOnComputeQueueBitKhr         FormatFeatureFlagBits2 = 18014398509481984
+	FormatFeature2StencilCopyOnTransferQueueBitKhr        FormatFeatureFlagBits2 = 36028797018963968
+)
+
+// VkGeometryInstanceFlagBitsKHR extension values
+const (
+	GeometryInstanceForceOpacityMicromap2StateBitExt GeometryInstanceFlagBitsKHR = 16
+	GeometryInstanceDisableOpacityMicromapsBitExt    GeometryInstanceFlagBitsKHR = 32
+)
+
+// VkGeometryTypeKHR extension values
+const (
+	GeometryTypeSpheresNv                        GeometryTypeKHR = 1000429004
+	GeometryTypeLinearSweptSpheresNv             GeometryTypeKHR = 1000429005
+	GeometryTypeDenseGeometryFormatTrianglesAmdx GeometryTypeKHR = 1000478000
+)
+
 // VkImageAspectFlagBits extension values
 const (
 	ImageAspectMemoryPlane0BitExt ImageAspectFlagBits = 128
@@ -4231,26 +3916,402 @@ const (
 	ImageAspectMemoryPlane3BitExt ImageAspectFlagBits = 1024
 )
 
-// VkDebugUtilsMessageTypeFlagBitsEXT extension values
+// VkImageCreateFlagBits extension values
 const (
-	DebugUtilsMessageTypeDeviceAddressBindingBitExt DebugUtilsMessageTypeFlagBitsEXT = 8
+	ImageCreateCornerSampledBitNv                      ImageCreateFlagBits = 8192
+	ImageCreateSampleLocationsCompatibleDepthBitExt    ImageCreateFlagBits = 4096
+	ImageCreateSubsampledBitExt                        ImageCreateFlagBits = 16384
+	ImageCreateDescriptorBufferCaptureReplayBitExt     ImageCreateFlagBits = 65536
+	ImageCreateMultisampledRenderToSingleSampledBitExt ImageCreateFlagBits = 262144
+	ImageCreate2dViewCompatibleBitExt                  ImageCreateFlagBits = 131072
+	ImageCreateVideoProfileIndependentBitKhr           ImageCreateFlagBits = 1048576
+	ImageCreateFragmentDensityMapOffsetBitExt          ImageCreateFlagBits = 32768
 )
 
-// VkExternalSemaphoreHandleTypeFlagBits extension values
+// VkImageLayout extension values
 const (
-	ExternalSemaphoreHandleTypeZirconEventBitFuchsia ExternalSemaphoreHandleTypeFlagBits = 128
-	ExternalSemaphoreHandleTypeSciSyncObjBitNv       ExternalSemaphoreHandleTypeFlagBits = 32
+	ImageLayoutPresentSrcKhr                           ImageLayout = 1000001002
+	ImageLayoutVideoDecodeDstKhr                       ImageLayout = 1000024000
+	ImageLayoutVideoDecodeSrcKhr                       ImageLayout = 1000024001
+	ImageLayoutVideoDecodeDpbKhr                       ImageLayout = 1000024002
+	ImageLayoutSharedPresentKhr                        ImageLayout = 1000111000
+	ImageLayoutFragmentDensityMapOptimalExt            ImageLayout = 1000218000
+	ImageLayoutFragmentShadingRateAttachmentOptimalKhr ImageLayout = 1000226003
+	ImageLayoutVideoEncodeDstKhr                       ImageLayout = 1000299000
+	ImageLayoutVideoEncodeSrcKhr                       ImageLayout = 1000299001
+	ImageLayoutVideoEncodeDpbKhr                       ImageLayout = 1000299002
+	ImageLayoutAttachmentFeedbackLoopOptimalExt        ImageLayout = 1000339000
+	ImageLayoutTensorAliasingArm                       ImageLayout = 1000460000
+	ImageLayoutVideoEncodeQuantizationMapKhr           ImageLayout = 1000553000
+	ImageLayoutZeroInitializedExt                      ImageLayout = 1000620000
 )
 
-// VkVideoEncodeCapabilityFlagBitsKHR extension values
+// VkImageTiling extension values
 const (
-	VideoEncodeCapabilityQuantizationDeltaMapBitKhr VideoEncodeCapabilityFlagBitsKHR = 4
-	VideoEncodeCapabilityEmphasisMapBitKhr          VideoEncodeCapabilityFlagBitsKHR = 8
+	ImageTilingDrmFormatModifierExt ImageTiling = 1000158000
+)
+
+// VkImageUsageFlagBits extension values
+const (
+	ImageUsageVideoDecodeDstBitKhr                  ImageUsageFlagBits = 1024
+	ImageUsageVideoDecodeSrcBitKhr                  ImageUsageFlagBits = 2048
+	ImageUsageVideoDecodeDpbBitKhr                  ImageUsageFlagBits = 4096
+	ImageUsageFragmentDensityMapBitExt              ImageUsageFlagBits = 512
+	ImageUsageFragmentShadingRateAttachmentBitKhr   ImageUsageFlagBits = 256
+	ImageUsageVideoEncodeDstBitKhr                  ImageUsageFlagBits = 8192
+	ImageUsageVideoEncodeSrcBitKhr                  ImageUsageFlagBits = 16384
+	ImageUsageVideoEncodeDpbBitKhr                  ImageUsageFlagBits = 32768
+	ImageUsageAttachmentFeedbackLoopBitExt          ImageUsageFlagBits = 524288
+	ImageUsageInvocationMaskBitHuawei               ImageUsageFlagBits = 262144
+	ImageUsageSampleWeightBitQcom                   ImageUsageFlagBits = 1048576
+	ImageUsageSampleBlockMatchBitQcom               ImageUsageFlagBits = 2097152
+	ImageUsageTensorAliasingBitArm                  ImageUsageFlagBits = 8388608
+	ImageUsageTileMemoryBitQcom                     ImageUsageFlagBits = 134217728
+	ImageUsageVideoEncodeQuantizationDeltaMapBitKhr ImageUsageFlagBits = 33554432
+	ImageUsageVideoEncodeEmphasisMapBitKhr          ImageUsageFlagBits = 67108864
+)
+
+// VkImageViewCreateFlagBits extension values
+const (
+	ImageViewCreateFragmentDensityMapDynamicBitExt     ImageViewCreateFlagBits = 1
+	ImageViewCreateDescriptorBufferCaptureReplayBitExt ImageViewCreateFlagBits = 4
+	ImageViewCreateFragmentDensityMapDeferredBitExt    ImageViewCreateFlagBits = 2
+)
+
+// VkIndexType extension values
+const (
+	IndexTypeNoneKhr IndexType = 1000150000
+)
+
+// VkIndirectCommandsTokenTypeEXT extension values
+const (
+	IndirectCommandsTokenTypeDrawMeshTasksNvExt      IndirectCommandsTokenTypeEXT = 1000202002
+	IndirectCommandsTokenTypeDrawMeshTasksCountNvExt IndirectCommandsTokenTypeEXT = 1000202003
+	IndirectCommandsTokenTypeDrawMeshTasksExt        IndirectCommandsTokenTypeEXT = 1000328000
+	IndirectCommandsTokenTypeDrawMeshTasksCountExt   IndirectCommandsTokenTypeEXT = 1000328001
+	IndirectCommandsTokenTypeTraceRays2Ext           IndirectCommandsTokenTypeEXT = 1000386004
+)
+
+// VkIndirectCommandsTokenTypeNV extension values
+const (
+	IndirectCommandsTokenTypeDrawMeshTasksNv IndirectCommandsTokenTypeNV = 1000328000
+	IndirectCommandsTokenTypePipelineNv      IndirectCommandsTokenTypeNV = 1000428003
+	IndirectCommandsTokenTypeDispatchNv      IndirectCommandsTokenTypeNV = 1000428004
+)
+
+// VkInstanceCreateFlagBits extension values
+const (
+	InstanceCreateEnumeratePortabilityBitKhr InstanceCreateFlagBits = 1
+)
+
+// VkMemoryAllocateFlagBits extension values
+const (
+	MemoryAllocateZeroInitializeBitExt MemoryAllocateFlagBits = 8
+)
+
+// VkMemoryHeapFlagBits extension values
+const (
+	MemoryHeapTileMemoryBitQcom MemoryHeapFlagBits = 8
+)
+
+// VkMemoryMapFlagBits extension values
+const (
+	MemoryMapPlacedBitExt MemoryMapFlagBits = 1
+)
+
+// VkMemoryPropertyFlagBits extension values
+const (
+	MemoryPropertyDeviceCoherentBitAmd MemoryPropertyFlagBits = 64
+	MemoryPropertyDeviceUncachedBitAmd MemoryPropertyFlagBits = 128
+	MemoryPropertyRdmaCapableBitNv     MemoryPropertyFlagBits = 256
+)
+
+// VkMemoryUnmapFlagBits extension values
+const (
+	MemoryUnmapReserveBitExt MemoryUnmapFlagBits = 1
+)
+
+// VkMicromapTypeEXT extension values
+const (
+	MicromapTypeDisplacementMicromapNv MicromapTypeEXT = 1000397000
+)
+
+// VkObjectType extension values
+const (
+	ObjectTypeSurfaceKhr                    ObjectType = 1000000000
+	ObjectTypeSwapchainKhr                  ObjectType = 1000001000
+	ObjectTypeDisplayKhr                    ObjectType = 1000002000
+	ObjectTypeDisplayModeKhr                ObjectType = 1000002001
+	ObjectTypeDebugReportCallbackExt        ObjectType = 1000011000
+	ObjectTypeVideoSessionKhr               ObjectType = 1000023000
+	ObjectTypeVideoSessionParametersKhr     ObjectType = 1000023001
+	ObjectTypeCuModuleNvx                   ObjectType = 1000029000
+	ObjectTypeCuFunctionNvx                 ObjectType = 1000029001
+	ObjectTypeDebugUtilsMessengerExt        ObjectType = 1000128000
+	ObjectTypeAccelerationStructureKhr      ObjectType = 1000150000
+	ObjectTypeValidationCacheExt            ObjectType = 1000160000
+	ObjectTypeAccelerationStructureNv       ObjectType = 1000165000
+	ObjectTypePerformanceConfigurationIntel ObjectType = 1000210000
+	ObjectTypeDeferredOperationKhr          ObjectType = 1000268000
+	ObjectTypeIndirectCommandsLayoutNv      ObjectType = 1000277000
+	ObjectTypeCudaModuleNv                  ObjectType = 1000307000
+	ObjectTypeCudaFunctionNv                ObjectType = 1000307001
+	ObjectTypeBufferCollectionFuchsia       ObjectType = 1000366000
+	ObjectTypeMicromapExt                   ObjectType = 1000396000
+	ObjectTypeTensorArm                     ObjectType = 1000460000
+	ObjectTypeTensorViewArm                 ObjectType = 1000460001
+	ObjectTypeOpticalFlowSessionNv          ObjectType = 1000464000
+	ObjectTypeShaderExt                     ObjectType = 1000482000
+	ObjectTypePipelineBinaryKhr             ObjectType = 1000483000
+	ObjectTypeSemaphoreSciSyncPoolNv        ObjectType = 1000489000
+	ObjectTypeDataGraphPipelineSessionArm   ObjectType = 1000507000
+	ObjectTypeExternalComputeQueueNv        ObjectType = 1000556000
+	ObjectTypeIndirectCommandsLayoutExt     ObjectType = 1000572000
+	ObjectTypeIndirectExecutionSetExt       ObjectType = 1000572001
 )
 
 // VkOpacityMicromapSpecialIndexEXT extension values
 const (
 	OpacityMicromapSpecialIndexClusterGeometryDisableOpacityMicromapNv OpacityMicromapSpecialIndexEXT = -5
+)
+
+// VkPhysicalDeviceDataGraphOperationTypeARM extension values
+const (
+	PhysicalDeviceDataGraphOperationTypeNeuralModelQcom  PhysicalDeviceDataGraphOperationTypeARM = 1000629000
+	PhysicalDeviceDataGraphOperationTypeBuiltinModelQcom PhysicalDeviceDataGraphOperationTypeARM = 1000629001
+)
+
+// VkPhysicalDeviceDataGraphProcessingEngineTypeARM extension values
+const (
+	PhysicalDeviceDataGraphProcessingEngineTypeNeuralQcom  PhysicalDeviceDataGraphProcessingEngineTypeARM = 1000629000
+	PhysicalDeviceDataGraphProcessingEngineTypeComputeQcom PhysicalDeviceDataGraphProcessingEngineTypeARM = 1000629001
+)
+
+// VkPipelineBindPoint extension values
+const (
+	PipelineBindPointExecutionGraphAmdx   PipelineBindPoint = 1000134000
+	PipelineBindPointRayTracingKhr        PipelineBindPoint = 1000347000
+	PipelineBindPointSubpassShadingHuawei PipelineBindPoint = 1000369003
+	PipelineBindPointDataGraphArm         PipelineBindPoint = 1000507000
+)
+
+// VkPipelineCacheCreateFlagBits extension values
+const (
+	PipelineCacheCreateInternallySynchronizedMergeBitKhr PipelineCacheCreateFlagBits = 8
+)
+
+// VkPipelineCacheHeaderVersion extension values
+const (
+	PipelineCacheHeaderVersionDataGraphQcom PipelineCacheHeaderVersion = 1000629000
+)
+
+// VkPipelineColorBlendStateCreateFlagBits extension values
+const (
+	PipelineColorBlendStateCreateRasterizationOrderAttachmentAccessBitExt PipelineColorBlendStateCreateFlagBits = 1
+)
+
+// VkPipelineCreateFlagBits extension values
+const (
+	PipelineCreateRayTracingNoNullAnyHitShadersBitKhr            PipelineCreateFlagBits = 16384
+	PipelineCreateRayTracingNoNullClosestHitShadersBitKhr        PipelineCreateFlagBits = 32768
+	PipelineCreateRayTracingNoNullMissShadersBitKhr              PipelineCreateFlagBits = 65536
+	PipelineCreateRayTracingNoNullIntersectionShadersBitKhr      PipelineCreateFlagBits = 131072
+	PipelineCreateRayTracingSkipTrianglesBitKhr                  PipelineCreateFlagBits = 4096
+	PipelineCreateRayTracingSkipAabbsBitKhr                      PipelineCreateFlagBits = 8192
+	PipelineCreateRayTracingShaderGroupHandleCaptureReplayBitKhr PipelineCreateFlagBits = 524288
+	PipelineCreateDeferCompileBitNv                              PipelineCreateFlagBits = 32
+	PipelineCreateRenderingFragmentDensityMapAttachmentBitExt    PipelineCreateFlagBits = 4194304
+	PipelineCreateRenderingFragmentShadingRateAttachmentBitKhr   PipelineCreateFlagBits = 2097152
+	PipelineCreateCaptureStatisticsBitKhr                        PipelineCreateFlagBits = 64
+	PipelineCreateCaptureInternalRepresentationsBitKhr           PipelineCreateFlagBits = 128
+	PipelineCreateIndirectBindableBitNv                          PipelineCreateFlagBits = 262144
+	PipelineCreateLibraryBitKhr                                  PipelineCreateFlagBits = 2048
+	PipelineCreateDescriptorBufferBitExt                         PipelineCreateFlagBits = 536870912
+	PipelineCreateRetainLinkTimeOptimizationInfoBitExt           PipelineCreateFlagBits = 8388608
+	PipelineCreateLinkTimeOptimizationBitExt                     PipelineCreateFlagBits = 1024
+	PipelineCreateRayTracingAllowMotionBitNv                     PipelineCreateFlagBits = 1048576
+	PipelineCreateColorAttachmentFeedbackLoopBitExt              PipelineCreateFlagBits = 33554432
+	PipelineCreateDepthStencilAttachmentFeedbackLoopBitExt       PipelineCreateFlagBits = 67108864
+	PipelineCreateRayTracingOpacityMicromapBitExt                PipelineCreateFlagBits = 16777216
+	PipelineCreateRayTracingDisplacementMicromapBitNv            PipelineCreateFlagBits = 268435456
+)
+
+// VkPipelineCreateFlagBits2 extension values
+const (
+	PipelineCreate2ExecutionGraphBitAmdx                            PipelineCreateFlagBits2 = 4294967296
+	PipelineCreate2RayTracingAllowSpheresAndLinearSweptSpheresBitNv PipelineCreateFlagBits2 = 8589934592
+	PipelineCreate2EnableLegacyDitheringBitExt                      PipelineCreateFlagBits2 = 17179869184
+	PipelineCreate2DeferCompileBitNv                                PipelineCreateFlagBits2 = 32
+	PipelineCreate2CaptureStatisticsBitKhr                          PipelineCreateFlagBits2 = 64
+	PipelineCreate2CaptureInternalRepresentationsBitKhr             PipelineCreateFlagBits2 = 128
+	PipelineCreate2LinkTimeOptimizationBitExt                       PipelineCreateFlagBits2 = 1024
+	PipelineCreate2RetainLinkTimeOptimizationInfoBitExt             PipelineCreateFlagBits2 = 8388608
+	PipelineCreate2LibraryBitKhr                                    PipelineCreateFlagBits2 = 2048
+	PipelineCreate2RayTracingSkipTrianglesBitKhr                    PipelineCreateFlagBits2 = 4096
+	PipelineCreate2RayTracingSkipAabbsBitKhr                        PipelineCreateFlagBits2 = 8192
+	PipelineCreate2RayTracingNoNullAnyHitShadersBitKhr              PipelineCreateFlagBits2 = 16384
+	PipelineCreate2RayTracingNoNullClosestHitShadersBitKhr          PipelineCreateFlagBits2 = 32768
+	PipelineCreate2RayTracingNoNullMissShadersBitKhr                PipelineCreateFlagBits2 = 65536
+	PipelineCreate2RayTracingNoNullIntersectionShadersBitKhr        PipelineCreateFlagBits2 = 131072
+	PipelineCreate2RayTracingShaderGroupHandleCaptureReplayBitKhr   PipelineCreateFlagBits2 = 524288
+	PipelineCreate2IndirectBindableBitNv                            PipelineCreateFlagBits2 = 262144
+	PipelineCreate2RayTracingAllowMotionBitNv                       PipelineCreateFlagBits2 = 1048576
+	PipelineCreate2RenderingFragmentShadingRateAttachmentBitKhr     PipelineCreateFlagBits2 = 2097152
+	PipelineCreate2RenderingFragmentDensityMapAttachmentBitExt      PipelineCreateFlagBits2 = 4194304
+	PipelineCreate2RayTracingOpacityMicromapBitExt                  PipelineCreateFlagBits2 = 16777216
+	PipelineCreate2ColorAttachmentFeedbackLoopBitExt                PipelineCreateFlagBits2 = 33554432
+	PipelineCreate2DepthStencilAttachmentFeedbackLoopBitExt         PipelineCreateFlagBits2 = 67108864
+	PipelineCreate2RayTracingDisplacementMicromapBitNv              PipelineCreateFlagBits2 = 268435456
+	PipelineCreate2DescriptorBufferBitExt                           PipelineCreateFlagBits2 = 536870912
+	PipelineCreate2DisallowOpacityMicromapBitArm                    PipelineCreateFlagBits2 = 137438953472
+	PipelineCreate2CaptureDataBitKhr                                PipelineCreateFlagBits2 = 2147483648
+	PipelineCreate2IndirectBindableBitExt                           PipelineCreateFlagBits2 = 274877906944
+	PipelineCreate2PerLayerFragmentDensityBitValve                  PipelineCreateFlagBits2 = 1099511627776
+	PipelineCreate264BitIndexingBitExt                              PipelineCreateFlagBits2 = 8796093022208
+)
+
+// VkPipelineDepthStencilStateCreateFlagBits extension values
+const (
+	PipelineDepthStencilStateCreateRasterizationOrderAttachmentDepthAccessBitExt   PipelineDepthStencilStateCreateFlagBits = 1
+	PipelineDepthStencilStateCreateRasterizationOrderAttachmentStencilAccessBitExt PipelineDepthStencilStateCreateFlagBits = 2
+)
+
+// VkPipelineLayoutCreateFlagBits extension values
+const (
+	PipelineLayoutCreateIndependentSetsBitExt PipelineLayoutCreateFlagBits = 2
+)
+
+// VkPipelineStageFlagBits extension values
+const (
+	PipelineStageTransformFeedbackBitExt             PipelineStageFlagBits = 16777216
+	PipelineStageConditionalRenderingBitExt          PipelineStageFlagBits = 262144
+	PipelineStageAccelerationStructureBuildBitKhr    PipelineStageFlagBits = 33554432
+	PipelineStageRayTracingShaderBitKhr              PipelineStageFlagBits = 2097152
+	PipelineStageFragmentDensityProcessBitExt        PipelineStageFlagBits = 8388608
+	PipelineStageFragmentShadingRateAttachmentBitKhr PipelineStageFlagBits = 4194304
+	PipelineStageTaskShaderBitExt                    PipelineStageFlagBits = 524288
+	PipelineStageMeshShaderBitExt                    PipelineStageFlagBits = 1048576
+	PipelineStageCommandPreprocessBitExt             PipelineStageFlagBits = 131072
+)
+
+// VkPipelineStageFlagBits2 extension values
+const (
+	PipelineStage2VideoDecodeBitKhr                   PipelineStageFlagBits2 = 67108864
+	PipelineStage2VideoEncodeBitKhr                   PipelineStageFlagBits2 = 134217728
+	PipelineStage2TransformFeedbackBitExt             PipelineStageFlagBits2 = 16777216
+	PipelineStage2ConditionalRenderingBitExt          PipelineStageFlagBits2 = 262144
+	PipelineStage2CommandPreprocessBitExt             PipelineStageFlagBits2 = 131072
+	PipelineStage2FragmentShadingRateAttachmentBitKhr PipelineStageFlagBits2 = 4194304
+	PipelineStage2AccelerationStructureBuildBitKhr    PipelineStageFlagBits2 = 33554432
+	PipelineStage2RayTracingShaderBitKhr              PipelineStageFlagBits2 = 2097152
+	PipelineStage2FragmentDensityProcessBitExt        PipelineStageFlagBits2 = 8388608
+	PipelineStage2TaskShaderBitExt                    PipelineStageFlagBits2 = 524288
+	PipelineStage2MeshShaderBitExt                    PipelineStageFlagBits2 = 1048576
+	PipelineStage2SubpassShaderBitHuawei              PipelineStageFlagBits2 = 549755813888
+	PipelineStage2InvocationMaskBitHuawei             PipelineStageFlagBits2 = 1099511627776
+	PipelineStage2AccelerationStructureCopyBitKhr     PipelineStageFlagBits2 = 268435456
+	PipelineStage2MicromapBuildBitExt                 PipelineStageFlagBits2 = 1073741824
+	PipelineStage2ClusterCullingShaderBitHuawei       PipelineStageFlagBits2 = 2199023255552
+	PipelineStage2OpticalFlowBitNv                    PipelineStageFlagBits2 = 536870912
+	PipelineStage2ConvertCooperativeVectorMatrixBitNv PipelineStageFlagBits2 = 17592186044416
+	PipelineStage2DataGraphBitArm                     PipelineStageFlagBits2 = 4398046511104
+	PipelineStage2CopyIndirectBitKhr                  PipelineStageFlagBits2 = 70368744177664
+	PipelineStage2MemoryDecompressionBitExt           PipelineStageFlagBits2 = 35184372088832
+)
+
+// VkPolygonMode extension values
+const (
+	PolygonModeFillRectangleNv PolygonMode = 1000153000
+)
+
+// VkPresentModeKHR extension values
+const (
+	PresentModeSharedDemandRefreshKhr     PresentModeKHR = 1000111000
+	PresentModeSharedContinuousRefreshKhr PresentModeKHR = 1000111001
+	PresentModeFifoLatestReadyKhr         PresentModeKHR = 1000621000
+)
+
+// VkQueryPipelineStatisticFlagBits extension values
+const (
+	QueryPipelineStatisticTaskShaderInvocationsBitExt              QueryPipelineStatisticFlagBits = 2048
+	QueryPipelineStatisticMeshShaderInvocationsBitExt              QueryPipelineStatisticFlagBits = 4096
+	QueryPipelineStatisticClusterCullingShaderInvocationsBitHuawei QueryPipelineStatisticFlagBits = 8192
+)
+
+// VkQueryPoolCreateFlagBits extension values
+const (
+	QueryPoolCreateResetBitKhr QueryPoolCreateFlagBits = 1
+)
+
+// VkQueryResultFlagBits extension values
+const (
+	QueryResultWithStatusBitKhr QueryResultFlagBits = 16
+)
+
+// VkQueryResultStatusKHR extension values
+const (
+	QueryResultStatusInsufficientBitstreamBufferRangeKhr QueryResultStatusKHR = -1000299000
+)
+
+// VkQueryType extension values
+const (
+	QueryTypeResultStatusOnlyKhr                                      QueryType = 1000023000
+	QueryTypeTransformFeedbackStreamExt                               QueryType = 1000028004
+	QueryTypePerformanceQueryKhr                                      QueryType = 1000116000
+	QueryTypeAccelerationStructureCompactedSizeKhr                    QueryType = 1000150000
+	QueryTypeAccelerationStructureSerializationSizeKhr                QueryType = 1000150001
+	QueryTypeAccelerationStructureCompactedSizeNv                     QueryType = 1000165000
+	QueryTypePerformanceQueryIntel                                    QueryType = 1000210000
+	QueryTypeVideoEncodeFeedbackKhr                                   QueryType = 1000299000
+	QueryTypeMeshPrimitivesGeneratedExt                               QueryType = 1000328000
+	QueryTypePrimitivesGeneratedExt                                   QueryType = 1000382000
+	QueryTypeAccelerationStructureSerializationBottomLevelPointersKhr QueryType = 1000386000
+	QueryTypeAccelerationStructureSizeKhr                             QueryType = 1000386001
+	QueryTypeMicromapSerializationSizeExt                             QueryType = 1000396000
+	QueryTypeMicromapCompactedSizeExt                                 QueryType = 1000396001
+)
+
+// VkQueueFlagBits extension values
+const (
+	QueueVideoDecodeBitKhr QueueFlagBits = 32
+	QueueVideoEncodeBitKhr QueueFlagBits = 64
+	QueueOpticalFlowBitNv  QueueFlagBits = 256
+	QueueDataGraphBitArm   QueueFlagBits = 1024
+)
+
+// VkRenderPassCreateFlagBits extension values
+const (
+	RenderPassCreateTransformBitQcom                RenderPassCreateFlagBits = 2
+	RenderPassCreatePerLayerFragmentDensityBitValve RenderPassCreateFlagBits = 4
+)
+
+// VkRenderingAttachmentFlagBitsKHR extension values
+const (
+	RenderingAttachmentInputAttachmentFeedbackBitKhr       RenderingAttachmentFlagBitsKHR = 1
+	RenderingAttachmentResolveSkipTransferFunctionBitKhr   RenderingAttachmentFlagBitsKHR = 2
+	RenderingAttachmentResolveEnableTransferFunctionBitKhr RenderingAttachmentFlagBitsKHR = 4
+)
+
+// VkRenderingFlagBits extension values
+const (
+	RenderingEnableLegacyDitheringBitExt            RenderingFlagBits = 8
+	RenderingContentsInlineBitKhr                   RenderingFlagBits = 16
+	RenderingPerLayerFragmentDensityBitValve        RenderingFlagBits = 32
+	RenderingFragmentRegionBitExt                   RenderingFlagBits = 64
+	RenderingCustomResolveBitExt                    RenderingFlagBits = 128
+	RenderingLocalReadConcurrentAccessControlBitKhr RenderingFlagBits = 256
+)
+
+// VkResolveImageFlagBitsKHR extension values
+const (
+	ResolveImageSkipTransferFunctionBitKhr   ResolveImageFlagBitsKHR = 1
+	ResolveImageEnableTransferFunctionBitKhr ResolveImageFlagBitsKHR = 2
+)
+
+// VkResolveModeFlagBits extension values
+const (
+	ResolveModeExternalFormatDownsampleBitAndroid ResolveModeFlagBits = 16
+	ResolveModeCustomBitExt                       ResolveModeFlagBits = 32
 )
 
 // VkResult extension values
@@ -4279,6 +4340,51 @@ const (
 	IncompatibleShaderBinaryExt                 Result = 1000482000
 	PipelineBinaryMissingKhr                    Result = 1000483000
 	ErrorNotEnoughSpaceKhr                      Result = -1000483000
+)
+
+// VkSamplerAddressMode extension values
+const (
+	SamplerAddressModeMirrorClampToEdge SamplerAddressMode = 4
+)
+
+// VkSamplerCreateFlagBits extension values
+const (
+	SamplerCreateSubsampledBitExt                     SamplerCreateFlagBits = 1
+	SamplerCreateSubsampledCoarseReconstructionBitExt SamplerCreateFlagBits = 2
+	SamplerCreateDescriptorBufferCaptureReplayBitExt  SamplerCreateFlagBits = 8
+	SamplerCreateNonSeamlessCubeMapBitExt             SamplerCreateFlagBits = 4
+	SamplerCreateImageProcessingBitQcom               SamplerCreateFlagBits = 16
+)
+
+// VkSamplerReductionMode extension values
+const (
+	SamplerReductionModeWeightedAverageRangeclampQcom SamplerReductionMode = 1000521000
+)
+
+// VkShaderCreateFlagBitsEXT extension values
+const (
+	ShaderCreateAllowVaryingSubgroupSizeBitExt      ShaderCreateFlagBitsEXT = 2
+	ShaderCreateRequireFullSubgroupsBitExt          ShaderCreateFlagBitsEXT = 4
+	ShaderCreateNoTaskShaderBitExt                  ShaderCreateFlagBitsEXT = 8
+	ShaderCreateDispatchBaseBitExt                  ShaderCreateFlagBitsEXT = 16
+	ShaderCreateFragmentShadingRateAttachmentBitExt ShaderCreateFlagBitsEXT = 32
+	ShaderCreateFragmentDensityMapAttachmentBitExt  ShaderCreateFlagBitsEXT = 64
+	ShaderCreateIndirectBindableBitExt              ShaderCreateFlagBitsEXT = 128
+	ShaderCreate64BitIndexingBitExt                 ShaderCreateFlagBitsEXT = 32768
+)
+
+// VkShaderStageFlagBits extension values
+const (
+	ShaderStageRaygenBitKhr            ShaderStageFlagBits = 256
+	ShaderStageAnyHitBitKhr            ShaderStageFlagBits = 512
+	ShaderStageClosestHitBitKhr        ShaderStageFlagBits = 1024
+	ShaderStageMissBitKhr              ShaderStageFlagBits = 2048
+	ShaderStageIntersectionBitKhr      ShaderStageFlagBits = 4096
+	ShaderStageCallableBitKhr          ShaderStageFlagBits = 8192
+	ShaderStageTaskBitExt              ShaderStageFlagBits = 64
+	ShaderStageMeshBitExt              ShaderStageFlagBits = 128
+	ShaderStageSubpassShadingBitHuawei ShaderStageFlagBits = 16384
+	ShaderStageClusterCullingBitHuawei ShaderStageFlagBits = 524288
 )
 
 // VkStructureType extension values
@@ -5181,76 +5287,76 @@ const (
 	StructureTypePhysicalDeviceShaderUniformBufferUnsizedArrayFeaturesExt     StructureType = 1000642000
 )
 
-// VkQueryType extension values
+// VkSubgroupFeatureFlagBits extension values
 const (
-	QueryTypeResultStatusOnlyKhr                                      QueryType = 1000023000
-	QueryTypeTransformFeedbackStreamExt                               QueryType = 1000028004
-	QueryTypePerformanceQueryKhr                                      QueryType = 1000116000
-	QueryTypeAccelerationStructureCompactedSizeKhr                    QueryType = 1000150000
-	QueryTypeAccelerationStructureSerializationSizeKhr                QueryType = 1000150001
-	QueryTypeAccelerationStructureCompactedSizeNv                     QueryType = 1000165000
-	QueryTypePerformanceQueryIntel                                    QueryType = 1000210000
-	QueryTypeVideoEncodeFeedbackKhr                                   QueryType = 1000299000
-	QueryTypeMeshPrimitivesGeneratedExt                               QueryType = 1000328000
-	QueryTypePrimitivesGeneratedExt                                   QueryType = 1000382000
-	QueryTypeAccelerationStructureSerializationBottomLevelPointersKhr QueryType = 1000386000
-	QueryTypeAccelerationStructureSizeKhr                             QueryType = 1000386001
-	QueryTypeMicromapSerializationSizeExt                             QueryType = 1000396000
-	QueryTypeMicromapCompactedSizeExt                                 QueryType = 1000396001
+	SubgroupFeaturePartitionedBitNv SubgroupFeatureFlagBits = 256
 )
 
-// VkPipelineStageFlagBits2 extension values
+// VkSubpassContents extension values
 const (
-	PipelineStage2VideoDecodeBitKhr                   PipelineStageFlagBits2 = 67108864
-	PipelineStage2VideoEncodeBitKhr                   PipelineStageFlagBits2 = 134217728
-	PipelineStage2TransformFeedbackBitExt             PipelineStageFlagBits2 = 16777216
-	PipelineStage2ConditionalRenderingBitExt          PipelineStageFlagBits2 = 262144
-	PipelineStage2CommandPreprocessBitExt             PipelineStageFlagBits2 = 131072
-	PipelineStage2FragmentShadingRateAttachmentBitKhr PipelineStageFlagBits2 = 4194304
-	PipelineStage2AccelerationStructureBuildBitKhr    PipelineStageFlagBits2 = 33554432
-	PipelineStage2RayTracingShaderBitKhr              PipelineStageFlagBits2 = 2097152
-	PipelineStage2FragmentDensityProcessBitExt        PipelineStageFlagBits2 = 8388608
-	PipelineStage2TaskShaderBitExt                    PipelineStageFlagBits2 = 524288
-	PipelineStage2MeshShaderBitExt                    PipelineStageFlagBits2 = 1048576
-	PipelineStage2SubpassShaderBitHuawei              PipelineStageFlagBits2 = 549755813888
-	PipelineStage2InvocationMaskBitHuawei             PipelineStageFlagBits2 = 1099511627776
-	PipelineStage2AccelerationStructureCopyBitKhr     PipelineStageFlagBits2 = 268435456
-	PipelineStage2MicromapBuildBitExt                 PipelineStageFlagBits2 = 1073741824
-	PipelineStage2ClusterCullingShaderBitHuawei       PipelineStageFlagBits2 = 2199023255552
-	PipelineStage2OpticalFlowBitNv                    PipelineStageFlagBits2 = 536870912
-	PipelineStage2ConvertCooperativeVectorMatrixBitNv PipelineStageFlagBits2 = 17592186044416
-	PipelineStage2DataGraphBitArm                     PipelineStageFlagBits2 = 4398046511104
-	PipelineStage2CopyIndirectBitKhr                  PipelineStageFlagBits2 = 70368744177664
-	PipelineStage2MemoryDecompressionBitExt           PipelineStageFlagBits2 = 35184372088832
+	SubpassContentsInlineAndSecondaryCommandBuffersKhr SubpassContents = 1000562000
 )
 
-// VkDescriptorType extension values
+// VkSubpassDescriptionFlagBits extension values
 const (
-	DescriptorTypeAccelerationStructureKhr           DescriptorType = 1000150000
-	DescriptorTypeAccelerationStructureNv            DescriptorType = 1000165000
-	DescriptorTypeSampleWeightImageQcom              DescriptorType = 1000440000
-	DescriptorTypeBlockMatchImageQcom                DescriptorType = 1000440001
-	DescriptorTypeTensorArm                          DescriptorType = 1000460000
-	DescriptorTypeMutableExt                         DescriptorType = 1000494000
-	DescriptorTypePartitionedAccelerationStructureNv DescriptorType = 1000570000
+	SubpassDescriptionPerViewAttributesBitNvx                         SubpassDescriptionFlagBits = 1
+	SubpassDescriptionPerViewPositionXOnlyBitNvx                      SubpassDescriptionFlagBits = 2
+	SubpassDescriptionTileShadingApronBitQcom                         SubpassDescriptionFlagBits = 256
+	SubpassDescriptionRasterizationOrderAttachmentColorAccessBitExt   SubpassDescriptionFlagBits = 16
+	SubpassDescriptionRasterizationOrderAttachmentDepthAccessBitExt   SubpassDescriptionFlagBits = 32
+	SubpassDescriptionRasterizationOrderAttachmentStencilAccessBitExt SubpassDescriptionFlagBits = 64
+	SubpassDescriptionEnableLegacyDitheringBitExt                     SubpassDescriptionFlagBits = 128
+	SubpassDescriptionFragmentRegionBitExt                            SubpassDescriptionFlagBits = 4
+	SubpassDescriptionCustomResolveBitExt                             SubpassDescriptionFlagBits = 8
 )
 
-// VkIndexType extension values
+// VkSwapchainCreateFlagBitsKHR extension values
 const (
-	IndexTypeNoneKhr IndexType = 1000150000
+	SwapchainCreateSplitInstanceBindRegionsBitKhr SwapchainCreateFlagBitsKHR = 1
+	SwapchainCreateProtectedBitKhr                SwapchainCreateFlagBitsKHR = 2
+	SwapchainCreateMutableFormatBitKhr            SwapchainCreateFlagBitsKHR = 4
+	SwapchainCreatePresentTimingBitExt            SwapchainCreateFlagBitsKHR = 512
+	SwapchainCreatePresentId2BitKhr               SwapchainCreateFlagBitsKHR = 64
+	SwapchainCreatePresentWait2BitKhr             SwapchainCreateFlagBitsKHR = 128
+	SwapchainCreateDeferredMemoryAllocationBitKhr SwapchainCreateFlagBitsKHR = 8
 )
 
-// VkIndirectCommandsTokenTypeNV extension values
+// VkTensorCreateFlagBitsARM extension values
 const (
-	IndirectCommandsTokenTypeDrawMeshTasksNv IndirectCommandsTokenTypeNV = 1000328000
-	IndirectCommandsTokenTypePipelineNv      IndirectCommandsTokenTypeNV = 1000428003
-	IndirectCommandsTokenTypeDispatchNv      IndirectCommandsTokenTypeNV = 1000428004
+	TensorCreateDescriptorBufferCaptureReplayBitArm TensorCreateFlagBitsARM = 4
 )
 
-// VkPhysicalDeviceDataGraphProcessingEngineTypeARM extension values
+// VkTensorUsageFlagBitsARM extension values
 const (
-	PhysicalDeviceDataGraphProcessingEngineTypeNeuralQcom  PhysicalDeviceDataGraphProcessingEngineTypeARM = 1000629000
-	PhysicalDeviceDataGraphProcessingEngineTypeComputeQcom PhysicalDeviceDataGraphProcessingEngineTypeARM = 1000629001
+	TensorUsageDataGraphBitArm TensorUsageFlagBitsARM = 32
+)
+
+// VkTensorViewCreateFlagBitsARM extension values
+const (
+	TensorViewCreateDescriptorBufferCaptureReplayBitArm TensorViewCreateFlagBitsARM = 1
+)
+
+// VkTimeDomainKHR extension values
+const (
+	TimeDomainPresentStageLocalExt TimeDomainKHR = 1000208000
+	TimeDomainSwapchainLocalExt    TimeDomainKHR = 1000208001
+)
+
+// VkToolPurposeFlagBits extension values
+const (
+	ToolPurposeDebugReportingBitExt ToolPurposeFlagBits = 32
+	ToolPurposeDebugMarkersBitExt   ToolPurposeFlagBits = 64
+)
+
+// VkVideoCodecOperationFlagBitsKHR extension values
+const (
+	VideoCodecOperationEncodeH264BitKhr VideoCodecOperationFlagBitsKHR = 65536
+	VideoCodecOperationEncodeH265BitKhr VideoCodecOperationFlagBitsKHR = 131072
+	VideoCodecOperationDecodeH264BitKhr VideoCodecOperationFlagBitsKHR = 1
+	VideoCodecOperationDecodeH265BitKhr VideoCodecOperationFlagBitsKHR = 2
+	VideoCodecOperationDecodeAv1BitKhr  VideoCodecOperationFlagBitsKHR = 4
+	VideoCodecOperationEncodeAv1BitKhr  VideoCodecOperationFlagBitsKHR = 262144
+	VideoCodecOperationDecodeVp9BitKhr  VideoCodecOperationFlagBitsKHR = 8
 )
 
 // VkVideoCodingControlFlagBitsKHR extension values
@@ -5259,152 +5365,46 @@ const (
 	VideoCodingControlEncodeQualityLevelBitKhr VideoCodingControlFlagBitsKHR = 4
 )
 
-// VkBuildAccelerationStructureFlagBitsKHR extension values
+// VkVideoEncodeAV1CapabilityFlagBitsKHR extension values
 const (
-	BuildAccelerationStructureMotionBitNv                          BuildAccelerationStructureFlagBitsKHR = 32
-	BuildAccelerationStructureAllowOpacityMicromapUpdateBitExt     BuildAccelerationStructureFlagBitsKHR = 64
-	BuildAccelerationStructureAllowDisableOpacityMicromapsBitExt   BuildAccelerationStructureFlagBitsKHR = 128
-	BuildAccelerationStructureAllowOpacityMicromapDataUpdateBitExt BuildAccelerationStructureFlagBitsKHR = 256
-	BuildAccelerationStructureAllowDisplacementMicromapUpdateBitNv BuildAccelerationStructureFlagBitsKHR = 512
-	BuildAccelerationStructureAllowDataAccessBitKhr                BuildAccelerationStructureFlagBitsKHR = 2048
-	BuildAccelerationStructureAllowClusterOpacityMicromapsBitNv    BuildAccelerationStructureFlagBitsKHR = 4096
+	VideoEncodeAv1CapabilityCompoundPredictionIntraRefreshBitKhr VideoEncodeAV1CapabilityFlagBitsKHR = 32
 )
 
-// VkInstanceCreateFlagBits extension values
+// VkVideoEncodeCapabilityFlagBitsKHR extension values
 const (
-	InstanceCreateEnumeratePortabilityBitKhr InstanceCreateFlagBits = 1
+	VideoEncodeCapabilityQuantizationDeltaMapBitKhr VideoEncodeCapabilityFlagBitsKHR = 4
+	VideoEncodeCapabilityEmphasisMapBitKhr          VideoEncodeCapabilityFlagBitsKHR = 8
 )
 
-// VkResolveModeFlagBits extension values
+// VkVideoEncodeFlagBitsKHR extension values
 const (
-	ResolveModeExternalFormatDownsampleBitAndroid ResolveModeFlagBits = 16
-	ResolveModeCustomBitExt                       ResolveModeFlagBits = 32
+	VideoEncodeIntraRefreshBitKhr             VideoEncodeFlagBitsKHR = 4
+	VideoEncodeWithQuantizationDeltaMapBitKhr VideoEncodeFlagBitsKHR = 1
+	VideoEncodeWithEmphasisMapBitKhr          VideoEncodeFlagBitsKHR = 2
 )
 
-// VkShaderCreateFlagBitsEXT extension values
+// VkVideoEncodeH264CapabilityFlagBitsKHR extension values
 const (
-	ShaderCreateAllowVaryingSubgroupSizeBitExt      ShaderCreateFlagBitsEXT = 2
-	ShaderCreateRequireFullSubgroupsBitExt          ShaderCreateFlagBitsEXT = 4
-	ShaderCreateNoTaskShaderBitExt                  ShaderCreateFlagBitsEXT = 8
-	ShaderCreateDispatchBaseBitExt                  ShaderCreateFlagBitsEXT = 16
-	ShaderCreateFragmentShadingRateAttachmentBitExt ShaderCreateFlagBitsEXT = 32
-	ShaderCreateFragmentDensityMapAttachmentBitExt  ShaderCreateFlagBitsEXT = 64
-	ShaderCreateIndirectBindableBitExt              ShaderCreateFlagBitsEXT = 128
-	ShaderCreate64BitIndexingBitExt                 ShaderCreateFlagBitsEXT = 32768
+	VideoEncodeH264CapabilityBPictureIntraRefreshBitKhr VideoEncodeH264CapabilityFlagBitsKHR = 1024
+	VideoEncodeH264CapabilityMbQpDiffWraparoundBitKhr   VideoEncodeH264CapabilityFlagBitsKHR = 512
+)
+
+// VkVideoEncodeH265CapabilityFlagBitsKHR extension values
+const (
+	VideoEncodeH265CapabilityBPictureIntraRefreshBitKhr VideoEncodeH265CapabilityFlagBitsKHR = 2048
+	VideoEncodeH265CapabilityCuQpDiffWraparoundBitKhr   VideoEncodeH265CapabilityFlagBitsKHR = 1024
+)
+
+// VkVideoSessionCreateFlagBitsKHR extension values
+const (
+	VideoSessionCreateAllowEncodeParameterOptimizationsBitKhr VideoSessionCreateFlagBitsKHR = 2
+	VideoSessionCreateInlineQueriesBitKhr                     VideoSessionCreateFlagBitsKHR = 4
+	VideoSessionCreateAllowEncodeQuantizationDeltaMapBitKhr   VideoSessionCreateFlagBitsKHR = 8
+	VideoSessionCreateAllowEncodeEmphasisMapBitKhr            VideoSessionCreateFlagBitsKHR = 16
+	VideoSessionCreateInlineSessionParametersBitKhr           VideoSessionCreateFlagBitsKHR = 32
 )
 
 // VkVideoSessionParametersCreateFlagBitsKHR extension values
 const (
 	VideoSessionParametersCreateQuantizationMapCompatibleBitKhr VideoSessionParametersCreateFlagBitsKHR = 1
-)
-
-// VkRenderingAttachmentFlagBitsKHR extension values
-const (
-	RenderingAttachmentInputAttachmentFeedbackBitKhr       RenderingAttachmentFlagBitsKHR = 1
-	RenderingAttachmentResolveSkipTransferFunctionBitKhr   RenderingAttachmentFlagBitsKHR = 2
-	RenderingAttachmentResolveEnableTransferFunctionBitKhr RenderingAttachmentFlagBitsKHR = 4
-)
-
-// VkBufferUsageFlagBits2 extension values
-const (
-	BufferUsage2ExecutionGraphScratchBitAmdx                  BufferUsageFlagBits2 = 33554432
-	BufferUsage2ConditionalRenderingBitExt                    BufferUsageFlagBits2 = 512
-	BufferUsage2ShaderBindingTableBitKhr                      BufferUsageFlagBits2 = 1024
-	BufferUsage2TransformFeedbackBufferBitExt                 BufferUsageFlagBits2 = 2048
-	BufferUsage2TransformFeedbackCounterBufferBitExt          BufferUsageFlagBits2 = 4096
-	BufferUsage2VideoDecodeSrcBitKhr                          BufferUsageFlagBits2 = 8192
-	BufferUsage2VideoDecodeDstBitKhr                          BufferUsageFlagBits2 = 16384
-	BufferUsage2VideoEncodeDstBitKhr                          BufferUsageFlagBits2 = 32768
-	BufferUsage2VideoEncodeSrcBitKhr                          BufferUsageFlagBits2 = 65536
-	BufferUsage2AccelerationStructureBuildInputReadOnlyBitKhr BufferUsageFlagBits2 = 524288
-	BufferUsage2AccelerationStructureStorageBitKhr            BufferUsageFlagBits2 = 1048576
-	BufferUsage2SamplerDescriptorBufferBitExt                 BufferUsageFlagBits2 = 2097152
-	BufferUsage2ResourceDescriptorBufferBitExt                BufferUsageFlagBits2 = 4194304
-	BufferUsage2PushDescriptorsDescriptorBufferBitExt         BufferUsageFlagBits2 = 67108864
-	BufferUsage2MicromapBuildInputReadOnlyBitExt              BufferUsageFlagBits2 = 8388608
-	BufferUsage2MicromapStorageBitExt                         BufferUsageFlagBits2 = 16777216
-	BufferUsage2CompressedDataDgf1BitAmdx                     BufferUsageFlagBits2 = 8589934592
-	BufferUsage2DataGraphForeignDescriptorBitArm              BufferUsageFlagBits2 = 536870912
-	BufferUsage2TileMemoryBitQcom                             BufferUsageFlagBits2 = 134217728
-	BufferUsage2MemoryDecompressionBitExt                     BufferUsageFlagBits2 = 4294967296
-	BufferUsage2PreprocessBufferBitExt                        BufferUsageFlagBits2 = 2147483648
-)
-
-// VkImageLayout extension values
-const (
-	ImageLayoutPresentSrcKhr                           ImageLayout = 1000001002
-	ImageLayoutVideoDecodeDstKhr                       ImageLayout = 1000024000
-	ImageLayoutVideoDecodeSrcKhr                       ImageLayout = 1000024001
-	ImageLayoutVideoDecodeDpbKhr                       ImageLayout = 1000024002
-	ImageLayoutSharedPresentKhr                        ImageLayout = 1000111000
-	ImageLayoutFragmentDensityMapOptimalExt            ImageLayout = 1000218000
-	ImageLayoutFragmentShadingRateAttachmentOptimalKhr ImageLayout = 1000226003
-	ImageLayoutVideoEncodeDstKhr                       ImageLayout = 1000299000
-	ImageLayoutVideoEncodeSrcKhr                       ImageLayout = 1000299001
-	ImageLayoutVideoEncodeDpbKhr                       ImageLayout = 1000299002
-	ImageLayoutAttachmentFeedbackLoopOptimalExt        ImageLayout = 1000339000
-	ImageLayoutTensorAliasingArm                       ImageLayout = 1000460000
-	ImageLayoutVideoEncodeQuantizationMapKhr           ImageLayout = 1000553000
-	ImageLayoutZeroInitializedExt                      ImageLayout = 1000620000
-)
-
-// VkDebugReportObjectTypeEXT extension values
-const (
-	DebugReportObjectTypeSamplerYcbcrConversionExt   DebugReportObjectTypeEXT = 1000011000
-	DebugReportObjectTypeDescriptorUpdateTemplateExt DebugReportObjectTypeEXT = 1000011000
-	DebugReportObjectTypeCuModuleNvxExt              DebugReportObjectTypeEXT = 1000029000
-	DebugReportObjectTypeCuFunctionNvxExt            DebugReportObjectTypeEXT = 1000029001
-	DebugReportObjectTypeAccelerationStructureKhrExt DebugReportObjectTypeEXT = 1000150000
-	DebugReportObjectTypeAccelerationStructureNvExt  DebugReportObjectTypeEXT = 1000165000
-	DebugReportObjectTypeCudaModuleNvExt             DebugReportObjectTypeEXT = 1000307000
-	DebugReportObjectTypeCudaFunctionNvExt           DebugReportObjectTypeEXT = 1000307001
-	DebugReportObjectTypeBufferCollectionFuchsiaExt  DebugReportObjectTypeEXT = 1000366000
-)
-
-// VkAccessFlagBits extension values
-const (
-	AccessTransformFeedbackWriteBitExt            AccessFlagBits = 33554432
-	AccessTransformFeedbackCounterReadBitExt      AccessFlagBits = 67108864
-	AccessTransformFeedbackCounterWriteBitExt     AccessFlagBits = 134217728
-	AccessConditionalRenderingReadBitExt          AccessFlagBits = 1048576
-	AccessColorAttachmentReadNoncoherentBitExt    AccessFlagBits = 524288
-	AccessAccelerationStructureReadBitKhr         AccessFlagBits = 2097152
-	AccessAccelerationStructureWriteBitKhr        AccessFlagBits = 4194304
-	AccessFragmentDensityMapReadBitExt            AccessFlagBits = 16777216
-	AccessFragmentShadingRateAttachmentReadBitKhr AccessFlagBits = 8388608
-	AccessCommandPreprocessReadBitExt             AccessFlagBits = 131072
-	AccessCommandPreprocessWriteBitExt            AccessFlagBits = 262144
-)
-
-// VkPresentModeKHR extension values
-const (
-	PresentModeSharedDemandRefreshKhr     PresentModeKHR = 1000111000
-	PresentModeSharedContinuousRefreshKhr PresentModeKHR = 1000111001
-	PresentModeFifoLatestReadyKhr         PresentModeKHR = 1000621000
-)
-
-// VkPipelineCreateFlagBits extension values
-const (
-	PipelineCreateRayTracingNoNullAnyHitShadersBitKhr            PipelineCreateFlagBits = 16384
-	PipelineCreateRayTracingNoNullClosestHitShadersBitKhr        PipelineCreateFlagBits = 32768
-	PipelineCreateRayTracingNoNullMissShadersBitKhr              PipelineCreateFlagBits = 65536
-	PipelineCreateRayTracingNoNullIntersectionShadersBitKhr      PipelineCreateFlagBits = 131072
-	PipelineCreateRayTracingSkipTrianglesBitKhr                  PipelineCreateFlagBits = 4096
-	PipelineCreateRayTracingSkipAabbsBitKhr                      PipelineCreateFlagBits = 8192
-	PipelineCreateRayTracingShaderGroupHandleCaptureReplayBitKhr PipelineCreateFlagBits = 524288
-	PipelineCreateDeferCompileBitNv                              PipelineCreateFlagBits = 32
-	PipelineCreateRenderingFragmentDensityMapAttachmentBitExt    PipelineCreateFlagBits = 4194304
-	PipelineCreateRenderingFragmentShadingRateAttachmentBitKhr   PipelineCreateFlagBits = 2097152
-	PipelineCreateCaptureStatisticsBitKhr                        PipelineCreateFlagBits = 64
-	PipelineCreateCaptureInternalRepresentationsBitKhr           PipelineCreateFlagBits = 128
-	PipelineCreateIndirectBindableBitNv                          PipelineCreateFlagBits = 262144
-	PipelineCreateLibraryBitKhr                                  PipelineCreateFlagBits = 2048
-	PipelineCreateDescriptorBufferBitExt                         PipelineCreateFlagBits = 536870912
-	PipelineCreateRetainLinkTimeOptimizationInfoBitExt           PipelineCreateFlagBits = 8388608
-	PipelineCreateLinkTimeOptimizationBitExt                     PipelineCreateFlagBits = 1024
-	PipelineCreateRayTracingAllowMotionBitNv                     PipelineCreateFlagBits = 1048576
-	PipelineCreateColorAttachmentFeedbackLoopBitExt              PipelineCreateFlagBits = 33554432
-	PipelineCreateDepthStencilAttachmentFeedbackLoopBitExt       PipelineCreateFlagBits = 67108864
-	PipelineCreateRayTracingOpacityMicromapBitExt                PipelineCreateFlagBits = 16777216
-	PipelineCreateRayTracingDisplacementMicromapBitNv            PipelineCreateFlagBits = 268435456
 )


### PR DESCRIPTION
## Summary

- Fix Vulkan crash: `vkCmdSetBlendConstants(const float[4])` generated with wrong CIF (scalar float instead of pointer). C array params decay to pointers in C ABI.
- Fix `CmdSetFragmentShadingRateKHR` and `CmdSetFragmentShadingRateEnumNV` — same array param issue (`combinerOps[2]`)
- Deterministic `const_gen.go` output — sorted map keys for extension enums (was 1780+ line noise diffs on every regeneration)
- Generator now fully idempotent (two runs = 0 diff)

## Test plan

- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — 15/15 pass
- [x] `golangci-lint run` — 0 issues
- [x] `gofmt -l .` — 0 unformatted
- [x] vk-gen idempotent (two consecutive runs = 0 diff)
- [ ] Vulkan visual test on Windows (gogpu agent)