### PR TITLE
chore: bump go-webgpu/webgpu v0.5.3 (v0.30.19)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 
 ## Current Version
 
-v0.30.18 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.1, gputypes v0.5.1, goffi v0.6.0
+v0.30.19 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.1, gputypes v0.5.1, goffi v0.6.0, webgpu v0.5.3
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.19] - 2026-07-12
+
+### Changed
+
+- **Bump `go-webgpu/webgpu`** v0.5.2 → v0.5.3 (Rust FFI backend)
+
 ## [0.30.18] - 2026-07-12
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/go-webgpu/goffi v0.6.0
-	github.com/go-webgpu/webgpu v0.5.2
+	github.com/go-webgpu/webgpu v0.5.3
 	github.com/gogpu/gpucontext v0.21.1
 	github.com/gogpu/gputypes v0.5.1
 	github.com/gogpu/naga v0.17.15

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/go-webgpu/goffi v0.6.0 h1:dTBwfzj8CZUW0w0fgeMaYGBrIktK7nzfjMsnSpkSt4Y=
 github.com/go-webgpu/goffi v0.6.0/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/go-webgpu/webgpu v0.5.2 h1:E+yKCbRw/Dgn77pb/CX3kXatwwROGX7/B4ZFbRPaRbQ=
-github.com/go-webgpu/webgpu v0.5.2/go.mod h1:d2RR3tI2kUtcMfpC+qJt46IRkDslRhftjCfQvnprGkY=
+github.com/go-webgpu/webgpu v0.5.3 h1:EFinkgY9eSNBsougS8Z+m5v4Ue8k2B1w9G77Dvh1wTQ=
+github.com/go-webgpu/webgpu v0.5.3/go.mod h1:/kJpg7pKvyQqjg6ewvQBc9HmS2FuzVESRqopbdaaYW8=
 github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
 github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=


### PR DESCRIPTION
## Summary

- Bump `go-webgpu/webgpu` v0.5.2 → v0.5.3 (Rust FFI backend)
- CHANGELOG + AGENTS.md updated

## Test plan

- [x] `GOWORK=off go build ./...`
- [x] `go test ./...` — all pass