### PR TITLE
More correction of GPU classification as integrated/discrete type for DX12

### DIFF
--- a/hal/dx12/adapter.go
+++ b/hal/dx12/adapter.go
@@ -281,22 +281,20 @@ func (a *Adapter) deviceType() gputypes.DeviceType {
 		return gputypes.DeviceTypeCPU
 	}
 
-	// Check for dedicated video memory to distinguish discrete from integrated
-	if a.desc.DedicatedVideoMemory > 0 {
-		// Heuristic: >512MB dedicated VRAM is likely discrete
-		if a.desc.DedicatedVideoMemory > 512*1024*1024 {
-			return gputypes.DeviceTypeDiscreteGPU
-		}
+	// Heuristic: >512MB dedicated VRAM is almost always a discrete GPU
+	// (NVIDIA/AMD with dedicated GDDR). Smaller amounts (≤512MB) are typically
+	// a reserved pool from system memory on integrated GPUs (Intel HD/UHD, AMD APU).
+	if a.desc.DedicatedVideoMemory > 512*1024*1024 {
+		return gputypes.DeviceTypeDiscreteGPU
 	}
 
-	// If there's no dedicated video memory, it's likely integrated
-	if a.desc.DedicatedVideoMemory == 0 && a.desc.SharedSystemMemory > 0 {
+	if a.desc.DedicatedVideoMemory > 0 {
 		return gputypes.DeviceTypeIntegratedGPU
 	}
 
-	// Assume discrete if there's any dedicated memory
-	if a.desc.DedicatedVideoMemory > 0 {
-		return gputypes.DeviceTypeDiscreteGPU
+	// No dedicated memory + shared system memory → integrated
+	if a.desc.SharedSystemMemory > 0 {
+		return gputypes.DeviceTypeIntegratedGPU
 	}
 
 	return gputypes.DeviceTypeOther
@@ -589,11 +587,11 @@ func (a *AdapterLegacy) deviceType() gputypes.DeviceType {
 	if a.desc.DedicatedVideoMemory > 512*1024*1024 {
 		return gputypes.DeviceTypeDiscreteGPU
 	}
-	if a.desc.DedicatedVideoMemory == 0 && a.desc.SharedSystemMemory > 0 {
+	if a.desc.DedicatedVideoMemory > 0 {
 		return gputypes.DeviceTypeIntegratedGPU
 	}
-	if a.desc.DedicatedVideoMemory > 0 {
-		return gputypes.DeviceTypeDiscreteGPU
+	if a.desc.SharedSystemMemory > 0 {
+		return gputypes.DeviceTypeIntegratedGPU
 	}
 	return gputypes.DeviceTypeOther
 }


### PR DESCRIPTION
DedicatedVideoMemory — the amount of memory in bytes physically soldered on the GPU and accessible only by the GPU. For discrete GPUs this is real GDDR/HBM. For integrated Intel/AMD GPUs this is a reserve carved out of system DDR (typically 32–512 MB) that the driver "dedicates" and makes inaccessible to the CPU. The BIOS/UEFI allocates this region at boot.

SharedSystemMemory — the amount of system DDR that the GPU can use cooperatively with the CPU. This is a memory-mapped region accessible to both. For an iGPU this can be 8–32 GB (essentially all available RAM). For discrete GPUs this can also be > 0 (via PCIe BAR / Resizable BAR), but the bulk of video memory is still in DedicatedVideoMemory.

Key heuristic: if DedicatedVideoMemory is low (≤ 512 MB) and SharedSystemMemory is large, the GPU is guaranteed to be integrated — it has no dedicated VRAM and operates out of shared system DDR.

for other modes except DX12 - not required.