### PR TITLE
fix(vulkan): reject pipelines without layouts

### DIFF
--- a/hal/vulkan/pipeline.go
+++ b/hal/vulkan/pipeline.go
@@ -24,6 +24,15 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 	if desc == nil {
 		return nil, fmt.Errorf("BUG: render pipeline descriptor is nil in Vulkan.CreateRenderPipeline — core validation gap")
 	}
+	// Vulkan requires a valid pipeline layout whenever a graphics pipeline has
+	// shader stages. Unlike WebGPU's browser/Rust implementations, this native
+	// HAL does not derive automatic layouts from shader reflection. Rejecting a
+	// nil layout here prevents forwarding VK_NULL_HANDLE to
+	// VkGraphicsPipelineCreateInfo, which is invalid and can crash drivers
+	// (notably lavapipe and MoltenVK) instead of returning a VkResult.
+	if desc.Layout == nil {
+		return nil, fmt.Errorf("vulkan: render pipeline layout is required (automatic layouts are not supported)")
+	}
 
 	// Get pipeline layout
 	var pipelineLayout vk.PipelineLayout
@@ -377,6 +386,9 @@ func (d *Device) DestroyRenderPipeline(pipeline hal.RenderPipeline) {
 func (d *Device) CreateComputePipeline(desc *hal.ComputePipelineDescriptor) (hal.ComputePipeline, error) {
 	if desc == nil {
 		return nil, fmt.Errorf("BUG: compute pipeline descriptor is nil in Vulkan.CreateComputePipeline — core validation gap")
+	}
+	if desc.Layout == nil {
+		return nil, fmt.Errorf("vulkan: compute pipeline layout is required (automatic layouts are not supported)")
 	}
 
 	// Get pipeline layout

--- a/hal/vulkan/pipeline_test.go
+++ b/hal/vulkan/pipeline_test.go
@@ -1,0 +1,36 @@
+//go:build !(js && wasm)
+
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+package vulkan
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gogpu/wgpu/hal"
+)
+
+func TestCreateRenderPipelineRejectsImplicitLayoutBeforeFFI(t *testing.T) {
+	// A nil Layout would become VK_NULL_HANDLE in VkGraphicsPipelineCreateInfo.
+	// The guard must run before touching the device, shader, or Vulkan command
+	// table so this malformed request cannot reach a driver and crash it.
+	_, err := (&Device{}).CreateRenderPipeline(&hal.RenderPipelineDescriptor{})
+	if err == nil {
+		t.Fatal("CreateRenderPipeline with nil layout returned nil error")
+	}
+	if want := "render pipeline layout is required"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want substring %q", err, want)
+	}
+}
+
+func TestCreateComputePipelineRejectsImplicitLayoutBeforeFFI(t *testing.T) {
+	_, err := (&Device{}).CreateComputePipeline(&hal.ComputePipelineDescriptor{})
+	if err == nil {
+		t.Fatal("CreateComputePipeline with nil layout returned nil error")
+	}
+	if want := "compute pipeline layout is required"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want substring %q", err, want)
+	}
+}


### PR DESCRIPTION
## Summary

Reject nil Vulkan render and compute pipeline layouts before building native pipeline descriptors. The native HAL does not derive automatic layouts, so forwarding VK_NULL_HANDLE is invalid and can crash drivers rather than return a VkResult.

This extracts the independent Vulkan correctness fix from #253 and closes the same pre-FFI hazard for both pipeline types. It contains no prepared-indexed, MDI, Hearth, or module-path changes.

## Verification

- go test ./hal/vulkan
- GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/wgpu-vulkan-linux-amd64.test ./hal/vulkan
- git diff --check