### PR TITLE
fix(dx12): match indirect descriptor ABI size

### DIFF
--- a/hal/dx12/d3d12/types.go
+++ b/hal/dx12/d3d12/types.go
@@ -597,7 +597,11 @@ type D3D12_COMMAND_SIGNATURE_DESC struct {
 type D3D12_INDIRECT_ARGUMENT_DESC struct {
 	Type D3D12_INDIRECT_ARGUMENT_TYPE
 	// Union for different argument types
-	Union [8]byte
+	// The largest member (D3D12_INDIRECT_ARGUMENT_DESC_CONSTANT) is three
+	// uint32 values, so the C union occupies 12 bytes and the full descriptor
+	// is 16 bytes including Type. Keeping the exact size matters because
+	// CreateCommandSignature reads the native descriptor layout directly.
+	Union [12]byte
 }
 
 // D3D12_DISCARD_REGION describes a discard region.

--- a/hal/dx12/d3d12/types_test.go
+++ b/hal/dx12/d3d12/types_test.go
@@ -1,0 +1,17 @@
+//go:build windows && !(js && wasm)
+
+package d3d12
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestIndirectArgumentDescABI(t *testing.T) {
+	if got := unsafe.Sizeof(D3D12_INDIRECT_ARGUMENT_DESC{}); got != 16 {
+		t.Fatalf("D3D12_INDIRECT_ARGUMENT_DESC size = %d, want 16", got)
+	}
+	if got := unsafe.Offsetof(D3D12_INDIRECT_ARGUMENT_DESC{}.Union); got != 4 {
+		t.Fatalf("D3D12_INDIRECT_ARGUMENT_DESC.Union offset = %d, want 4", got)
+	}
+}


### PR DESCRIPTION
## Summary

Match the native D3D12_INDIRECT_ARGUMENT_DESC layout: its largest union member is three uint32 values, so the union is 12 bytes and the full descriptor is 16 bytes. Add exact size and offset assertions.

This extracts the independent DX12 ABI correctness fix from #253. It contains no counted-draw or prepared-indexed behavior.

## Verification

- GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go test -c -o /tmp/wgpu-d3d12-windows-amd64.test.exe ./hal/dx12/d3d12
- GOOS=windows GOARCH=arm64 CGO_ENABLED=0 go test -c -o /tmp/wgpu-d3d12-windows-arm64.test.exe ./hal/dx12/d3d12
- git diff --check