### PR TITLE
fix(metal): pin autorelease pools to OS threads

### DIFF
--- a/hal/metal/encoder.go
+++ b/hal/metal/encoder.go
@@ -42,9 +42,9 @@ func (e *CommandEncoder) BeginEncoding(label string) error {
 	// This prevents LIFO violations when pools from different frames overlap
 	// on the ObjC autorelease pool stack (macOS Tahoe SIGABRT fix).
 	pool := NewAutoreleasePool()
+	defer pool.Drain()
 	e.cmdBuffer = MsgSend(e.device.commandQueue, Sel("commandBuffer"))
 	if e.cmdBuffer == 0 {
-		pool.Drain()
 		return fmt.Errorf("metal: failed to create command buffer")
 	}
 	Retain(e.cmdBuffer)
@@ -53,7 +53,6 @@ func (e *CommandEncoder) BeginEncoding(label string) error {
 		_ = MsgSend(e.cmdBuffer, Sel("setLabel:"), uintptr(nsLabel))
 		Release(nsLabel)
 	}
-	pool.Drain()
 	hal.Logger().Debug("metal: encoding started", "label", label)
 	return nil
 }
@@ -268,9 +267,9 @@ func (e *CommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.Ren
 	// Scoped pool: rpDesc and other autoreleased objects are only needed during
 	// encoder creation. The encoder itself is Retained to survive pool drain.
 	pool := NewAutoreleasePool()
+	defer pool.Drain()
 	rpDesc := MsgSend(ID(GetClass("MTLRenderPassDescriptor")), Sel("renderPassDescriptor"))
 	if rpDesc == 0 {
-		pool.Drain()
 		return nil
 	}
 	colorAttachments := MsgSend(rpDesc, Sel("colorAttachments"))
@@ -337,11 +336,9 @@ func (e *CommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.Ren
 	}
 	encoder := MsgSend(e.cmdBuffer, Sel("renderCommandEncoderWithDescriptor:"), uintptr(rpDesc))
 	if encoder == 0 {
-		pool.Drain()
 		return nil
 	}
 	Retain(encoder)
-	pool.Drain() // drain now — encoder is Retained, rpDesc no longer needed
 	return &RenderPassEncoder{raw: encoder, device: e.device}
 }
 
@@ -353,9 +350,9 @@ func (e *CommandEncoder) BeginComputePass(desc *hal.ComputePassDescriptor) hal.C
 	}
 	// Scoped pool: encoder is Retained to survive pool drain.
 	pool := NewAutoreleasePool()
+	defer pool.Drain()
 	encoder := MsgSend(e.cmdBuffer, Sel("computeCommandEncoder"))
 	if encoder == 0 {
-		pool.Drain()
 		return nil
 	}
 	Retain(encoder)
@@ -364,7 +361,6 @@ func (e *CommandEncoder) BeginComputePass(desc *hal.ComputePassDescriptor) hal.C
 		_ = MsgSend(encoder, Sel("setLabel:"), uintptr(nsLabel))
 		Release(nsLabel)
 	}
-	pool.Drain()
 	return &ComputePassEncoder{raw: encoder, device: e.device}
 }
 

--- a/hal/metal/objc.go
+++ b/hal/metal/objc.go
@@ -398,24 +398,87 @@ func Release(obj ID) {
 	_ = MsgSend(obj, Sel("release"))
 }
 
-// AutoreleasePool manages an Objective-C autorelease pool.
+// AutoreleasePool manages an Objective-C autorelease pool. The caller must
+// call Drain once from the same goroutine that created the pool. Pool values
+// must not be copied, shared, or drained concurrently.
 type AutoreleasePool struct {
-	pool ID
+	pool   ID
+	locked bool
+	unlock func()
+	drain  func(ID)
+}
+
+type autoreleasePoolCallbacks struct {
+	lock   func()
+	unlock func()
+	create func() ID
+	drain  func(ID)
+}
+
+func newAutoreleasePoolWithCallbacks(callbacks autoreleasePoolCallbacks) (pool *AutoreleasePool) {
+	locked := callbacks.lock != nil
+	if callbacks.lock != nil {
+		callbacks.lock()
+	}
+
+	pool = &AutoreleasePool{
+		locked: locked,
+		unlock: callbacks.unlock,
+		drain:  callbacks.drain,
+	}
+	created := false
+	defer func() {
+		if created {
+			return
+		}
+		// A create callback can panic after the OS-thread lock is acquired. Make
+		// the partially constructed pool terminal before releasing that lock so
+		// a future recovery cannot accidentally unlock it twice.
+		pool.pool = 0
+		if pool.locked {
+			pool.locked = false
+		}
+		if locked && callbacks.unlock != nil {
+			callbacks.unlock()
+		}
+	}()
+
+	pool.pool = callbacks.create()
+	created = true
+	return pool
 }
 
 // NewAutoreleasePool creates a new autorelease pool.
 func NewAutoreleasePool() *AutoreleasePool {
-	poolClass := GetClass("NSAutoreleasePool")
-	pool := MsgSend(ID(poolClass), Sel("alloc"))
-	pool = MsgSend(pool, Sel("init"))
-	return &AutoreleasePool{pool: pool}
+	return newAutoreleasePoolWithCallbacks(autoreleasePoolCallbacks{
+		lock:   runtime.LockOSThread,
+		unlock: runtime.UnlockOSThread,
+		create: func() ID {
+			poolClass := GetClass("NSAutoreleasePool")
+			pool := MsgSend(ID(poolClass), Sel("alloc"))
+			return MsgSend(pool, Sel("init"))
+		},
+		drain: func(pool ID) {
+			_ = MsgSend(pool, Sel("drain"))
+		},
+	})
 }
 
 // Drain drains the autorelease pool.
 func (p *AutoreleasePool) Drain() {
-	if p.pool != 0 {
-		_ = MsgSend(p.pool, Sel("drain"))
-		p.pool = 0
+	if p == nil || !p.locked {
+		return
+	}
+	// Mark terminal before invoking Objective-C. Drain can panic, but a caller
+	// recovering that panic must not be able to drain or unlock this pool again.
+	pool := p.pool
+	p.pool = 0
+	p.locked = false
+	if p.unlock != nil {
+		defer p.unlock()
+	}
+	if pool != 0 && p.drain != nil {
+		p.drain(pool)
 	}
 }
 

--- a/hal/metal/objc_test.go
+++ b/hal/metal/objc_test.go
@@ -6,7 +6,10 @@
 package metal
 
 import (
+	"fmt"
 	"math"
+	"runtime"
+	"sync"
 	"testing"
 	"unsafe"
 )
@@ -76,6 +79,278 @@ func TestObjCRuntimeBasics(t *testing.T) {
 		t.Fatal("NSObject init returned nil")
 	}
 	_ = MsgSend(obj, releaseSel)
+}
+
+func TestAutoreleasePoolHelperNormal(t *testing.T) {
+	var events []string
+	pool := newAutoreleasePoolWithCallbacks(autoreleasePoolCallbacks{
+		lock: func() { events = append(events, "lock") },
+		unlock: func() {
+			events = append(events, "unlock")
+		},
+		create: func() ID {
+			events = append(events, "create")
+			return 41
+		},
+		drain: func(id ID) { events = append(events, "drain:"+fmt.Sprint(id)) },
+	})
+
+	if pool.pool != 41 || !pool.locked {
+		t.Fatalf("constructed pool = %#v, want live pool 41", pool)
+	}
+	pool.Drain()
+	pool.Drain()
+	if pool.pool != 0 || pool.locked {
+		t.Fatalf("drained pool = %#v, want terminal state", pool)
+	}
+	if got, want := fmt.Sprint(events), "[lock create drain:41 unlock]"; got != want {
+		t.Fatalf("events = %s, want %s", got, want)
+	}
+}
+
+func TestAutoreleasePoolHelperZeroPoolStillUnlocks(t *testing.T) {
+	unlockCalls := 0
+	drainCalls := 0
+	pool := newAutoreleasePoolWithCallbacks(autoreleasePoolCallbacks{
+		lock:   func() {},
+		unlock: func() { unlockCalls++ },
+		create: func() ID { return 0 },
+		drain:  func(ID) { drainCalls++ },
+	})
+
+	pool.Drain()
+	if unlockCalls != 1 {
+		t.Fatalf("unlock calls = %d, want 1", unlockCalls)
+	}
+	if drainCalls != 0 {
+		t.Fatalf("drain calls = %d, want 0", drainCalls)
+	}
+}
+
+func TestAutoreleasePoolHelperDoubleDrainAndNilAreNoOps(t *testing.T) {
+	unlockCalls := 0
+	drainCalls := 0
+	pool := newAutoreleasePoolWithCallbacks(autoreleasePoolCallbacks{
+		lock:   func() {},
+		unlock: func() { unlockCalls++ },
+		create: func() ID { return 9 },
+		drain:  func(ID) { drainCalls++ },
+	})
+
+	pool.Drain()
+	pool.Drain()
+	var nilPool *AutoreleasePool
+	nilPool.Drain()
+	if unlockCalls != 1 || drainCalls != 1 {
+		t.Fatalf("calls = unlock %d, drain %d; want 1, 1", unlockCalls, drainCalls)
+	}
+}
+
+func TestAutoreleasePoolHelperNestedBalances(t *testing.T) {
+	depth := 0
+	creates := 0
+	var events []string
+	callbacks := autoreleasePoolCallbacks{
+		lock: func() {
+			depth++
+			events = append(events, fmt.Sprintf("lock:%d", depth))
+		},
+		unlock: func() {
+			events = append(events, fmt.Sprintf("unlock:%d", depth))
+			depth--
+		},
+		create: func() ID {
+			creates++
+			events = append(events, fmt.Sprintf("create:%d", creates))
+			return ID(creates)
+		},
+		drain: func(id ID) { events = append(events, fmt.Sprintf("drain:%d", id)) },
+	}
+
+	outer := newAutoreleasePoolWithCallbacks(callbacks)
+	inner := newAutoreleasePoolWithCallbacks(callbacks)
+	if depth != 2 {
+		t.Fatalf("nested lock depth = %d, want 2", depth)
+	}
+	inner.Drain()
+	outer.Drain()
+	if depth != 0 {
+		t.Fatalf("final lock depth = %d, want 0", depth)
+	}
+	if got, want := fmt.Sprint(events), "[lock:1 create:1 lock:2 create:2 drain:2 unlock:2 drain:1 unlock:1]"; got != want {
+		t.Fatalf("events = %s, want %s", got, want)
+	}
+}
+
+func TestAutoreleasePoolHelperCreatePanicRollsBackLock(t *testing.T) {
+	depth := 0
+	unlockCalls := 0
+	got := recoverAutoreleasePoolPanic(func() {
+		newAutoreleasePoolWithCallbacks(autoreleasePoolCallbacks{
+			lock:   func() { depth++ },
+			unlock: func() { depth--; unlockCalls++ },
+			create: func() ID { panic("create panic") },
+			drain:  func(ID) {},
+		})
+	})
+	if got != "create panic" {
+		t.Fatalf("panic = %v, want create panic", got)
+	}
+	if depth != 0 || unlockCalls != 1 {
+		t.Fatalf("rollback = depth %d, unlock calls %d; want 0, 1", depth, unlockCalls)
+	}
+}
+
+func TestAutoreleasePoolHelperDeferredDrainCleansUpCallerPanic(t *testing.T) {
+	depth := 0
+	var events []string
+	got := recoverAutoreleasePoolPanic(func() {
+		pool := newAutoreleasePoolWithCallbacks(autoreleasePoolCallbacks{
+			lock: func() {
+				depth++
+				events = append(events, "lock")
+			},
+			unlock: func() {
+				events = append(events, "unlock")
+				depth--
+			},
+			create: func() ID {
+				events = append(events, "create")
+				return 55
+			},
+			drain: func(id ID) {
+				events = append(events, "drain:"+fmt.Sprint(id))
+			},
+		})
+		defer pool.Drain()
+
+		panic("caller panic")
+	})
+
+	if got != "caller panic" {
+		t.Fatalf("panic = %v, want caller panic", got)
+	}
+	if depth != 0 {
+		t.Fatalf("lock depth = %d, want 0", depth)
+	}
+	if got, want := fmt.Sprint(events), "[lock create drain:55 unlock]"; got != want {
+		t.Fatalf("events = %s, want %s", got, want)
+	}
+}
+
+func TestAutoreleasePoolHelperDrainPanicStillUnlocksAndTerminates(t *testing.T) {
+	depth := 0
+	unlockCalls := 0
+	drainCalls := 0
+	pool := newAutoreleasePoolWithCallbacks(autoreleasePoolCallbacks{
+		lock:   func() { depth++ },
+		unlock: func() { depth--; unlockCalls++ },
+		create: func() ID { return 77 },
+		drain: func(ID) {
+			drainCalls++
+			panic("drain panic")
+		},
+	})
+
+	got := recoverAutoreleasePoolPanic(pool.Drain)
+	if got != "drain panic" {
+		t.Fatalf("panic = %v, want drain panic", got)
+	}
+	pool.Drain()
+	if pool.pool != 0 || pool.locked || depth != 0 {
+		t.Fatalf("terminal pool = %#v, depth %d; want cleared and unlocked", pool, depth)
+	}
+	if drainCalls != 1 || unlockCalls != 1 {
+		t.Fatalf("calls = drain %d, unlock %d; want 1, 1", drainCalls, unlockCalls)
+	}
+}
+
+func recoverAutoreleasePoolPanic(fn func()) (value any) {
+	defer func() { value = recover() }()
+	fn()
+	return nil
+}
+
+func TestAutoreleasePoolPinsAndBalancesOSThread(t *testing.T) {
+	if err := Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	const workers = 8
+	const iterations = 128
+	var wait sync.WaitGroup
+	wait.Add(workers)
+	for worker := 0; worker < workers; worker++ {
+		go func() {
+			defer wait.Done()
+			for iteration := 0; iteration < iterations; iteration++ {
+				outer := NewAutoreleasePool()
+				if outer == nil || !outer.locked {
+					t.Errorf("outer pool did not pin its goroutine")
+					return
+				}
+				inner := NewAutoreleasePool()
+				if inner == nil || !inner.locked {
+					t.Errorf("inner pool did not pin its goroutine")
+					outer.Drain()
+					return
+				}
+				// Exercise goffi calls while the nested pool owns the thread. A
+				// scheduler yield must not migrate this goroutine before Drain.
+				if GetClass("NSObject") == 0 || GetClass("NSString") == 0 {
+					t.Errorf("ObjC class lookup failed")
+				}
+				runtime.Gosched()
+				inner.Drain()
+				inner.Drain()
+				if inner.locked {
+					t.Errorf("inner pool remained pinned after Drain")
+				}
+				outer.Drain()
+				outer.Drain()
+				if outer.locked {
+					t.Errorf("outer pool remained pinned after Drain")
+				}
+			}
+		}()
+	}
+	wait.Wait()
+}
+
+func TestAutoreleasePoolMetalResourceStress(t *testing.T) {
+	if err := Init(); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+
+	device := CreateSystemDefaultDevice()
+	if device == 0 {
+		t.Skip("no Metal device available")
+	}
+	defer Release(device)
+
+	const workers = 8
+	const iterations = 256
+	var wait sync.WaitGroup
+	wait.Add(workers)
+	for worker := 0; worker < workers; worker++ {
+		go func() {
+			defer wait.Done()
+			for iteration := 0; iteration < iterations; iteration++ {
+				pool := NewAutoreleasePool()
+				buffer := MsgSend(device, Sel("newBufferWithLength:options:"), uintptr(4096), uintptr(MTLResourceStorageModeShared))
+				if buffer == 0 {
+					t.Errorf("newBufferWithLength returned nil")
+					pool.Drain()
+					return
+				}
+				Release(buffer)
+				runtime.Gosched()
+				pool.Drain()
+				pool.Drain()
+			}
+		}()
+	}
+	wait.Wait()
 }
 
 func TestMetalDeviceQueries(t *testing.T) {


### PR DESCRIPTION
## Summary

- pin each Objective-C autorelease pool to the OS thread where it is created
- make drain terminal and balance the thread lock even when creation or drain panics
- defer pool cleanup immediately at encoder call sites so recovered panics cannot strand a goroutine on an OS thread
- cover nesting, zero/double drain, panic cleanup, scheduler yields, and Metal resource stress

This is extracted from #253 as an independent Metal runtime correctness fix. It does not include indexed-indirect, ICB, pipeline, or material-page changes.

## Verification

- `CGO_ENABLED=0 go test -count=1 ./hal/metal`
- `CGO_ENABLED=1 go test -race -count=1 -run '^TestAutoreleasePool' ./hal/metal`
- `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go test -run '^$' ./hal/metal`
- repeated native autorelease and resource stress tests on Apple Silicon
- `git diff --check`

The full Metal race suite still encounters a pre-existing goffi/checkptr failure in `TestCAMetalLayerDrawableSize`; the focused autorelease race suite passes.
