### PR TITLE
Metal: lower large indexed multi-draws to ICBs

### DIFF
--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 	"unsafe"
 
@@ -43,7 +44,9 @@ type Device struct {
 	// hasUnifiedMemory=true but are NOT Apple GPU family and do not support
 	// MTLStorageModeShared for multisample textures. This field drives texture
 	// storage mode selection instead of hasUnifiedMemory.
-	isAppleGPU bool
+	isAppleGPU      bool
+	icbTranslatorMu sync.Mutex
+	icbTranslators  map[gputypes.IndexFormat]indexedICBTranslator
 }
 
 // newDevice creates a new Device from a Metal device.
@@ -763,10 +766,23 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 	}
 	_ = MsgSend(pipelineDesc, Sel("setSampleCount:"), uintptr(sampleCount))
 
-	// Create pipeline state
+	// Create pipeline state. ICB support stays entirely private: eligible
+	// pipelines get one flagged attempt and transparently retry ordinary
+	// creation if Metal rejects the stricter descriptor.
 	var errorPtr ID
-	pipelineState := MsgSend(d.raw, Sel("newRenderPipelineStateWithDescriptor:error:"),
-		uintptr(pipelineDesc), uintptr(unsafe.Pointer(&errorPtr)))
+	icbCandidate := d.canCreateICBPipeline(desc, pipelineDesc)
+	pipelineState, icbCompatible := createRenderPipelineState(icbCandidate, func(icb bool) ID {
+		errorPtr = 0
+		if icbCandidate {
+			var enabled uintptr
+			if icb {
+				enabled = 1
+			}
+			_ = MsgSend(pipelineDesc, Sel("setSupportIndirectCommandBuffers:"), enabled)
+		}
+		return MsgSend(d.raw, Sel("newRenderPipelineStateWithDescriptor:error:"),
+			uintptr(pipelineDesc), uintptr(unsafe.Pointer(&errorPtr)))
+	})
 
 	if pipelineState == 0 {
 		errMsg := unknownError
@@ -791,11 +807,12 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 		pipeLayout = pl
 	}
 	return &RenderPipeline{
-		raw:       pipelineState,
-		device:    d,
-		layout:    pipeLayout,
-		cullMode:  cullModeToMTL(desc.Primitive.CullMode),
-		frontFace: frontFaceToMTL(desc.Primitive.FrontFace),
+		raw:           pipelineState,
+		device:        d,
+		layout:        pipeLayout,
+		cullMode:      cullModeToMTL(desc.Primitive.CullMode),
+		frontFace:     frontFaceToMTL(desc.Primitive.FrontFace),
+		icbCompatible: icbCompatible,
 
 		depthStencil:    depthStencilState,
 		depthBias:       depthBias,
@@ -1176,10 +1193,7 @@ func (d *Device) FreeCommandBuffer(cmdBuffer hal.CommandBuffer) {
 	if !ok || cb == nil {
 		return
 	}
-	if cb.raw != 0 {
-		Release(cb.raw)
-		cb.raw = 0
-	}
+	cb.Destroy()
 }
 
 // CreateRenderBundleEncoder is not supported in Metal backend.
@@ -1262,6 +1276,7 @@ func (d *Device) WaitIdle() error {
 // Destroy releases the device and associated resources.
 func (d *Device) Destroy() {
 	hal.Logger().Debug("metal: device destroyed")
+	d.releaseIndexedICBTranslators()
 	if d.eventListener != 0 {
 		Release(d.eventListener)
 		d.eventListener = 0

--- a/hal/metal/encoder.go
+++ b/hal/metal/encoder.go
@@ -7,6 +7,7 @@ package metal
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/hal"
@@ -22,6 +23,10 @@ type CommandEncoder struct {
 	device    *Device
 	cmdBuffer ID
 	label     string
+	icbOwners []*indexedICBOwnership
+	finished  *CommandBuffer
+	passState renderPassPendingState
+	recordErr error
 }
 
 // IsRecording returns true if the encoder has an active command buffer.
@@ -37,6 +42,7 @@ func (e *CommandEncoder) BeginEncoding(label string) error {
 		return fmt.Errorf("metal: encoder is already recording")
 	}
 	e.label = label
+	e.recordErr = nil
 
 	// Scoped autorelease pool — drain immediately after creating the command buffer.
 	// The command buffer is Retained so it survives the pool drain.
@@ -64,8 +70,18 @@ func (e *CommandEncoder) EndEncoding() (hal.CommandBuffer, error) {
 	if e.cmdBuffer == 0 {
 		return nil, fmt.Errorf("metal: command encoder is not recording")
 	}
-	cb := &CommandBuffer{raw: e.cmdBuffer, device: e.device}
+	if e.recordErr != nil {
+		err := e.recordErr
+		e.recordErr = nil
+		Release(e.cmdBuffer)
+		e.cmdBuffer = 0
+		e.releaseICBOwners()
+		return nil, err
+	}
+	cb := &CommandBuffer{raw: e.cmdBuffer, device: e.device, icbOwners: e.icbOwners}
 	e.cmdBuffer = 0 // Recording state becomes false
+	e.icbOwners = nil
+	e.finished = cb
 	hal.Logger().Debug("metal: encoding ended")
 	return cb, nil
 }
@@ -78,13 +94,58 @@ func (e *CommandEncoder) DiscardEncoding() {
 		Release(e.cmdBuffer)
 		e.cmdBuffer = 0 // Recording state becomes false
 	}
+	e.releaseICBOwners()
+	e.recordErr = nil
 }
 
 // ResetAll resets command buffers for reuse.
-func (e *CommandEncoder) ResetAll(_ []hal.CommandBuffer) {}
+func (e *CommandEncoder) ResetAll(commandBuffers []hal.CommandBuffer) {
+	if len(commandBuffers) == 0 {
+		if e.finished != nil {
+			e.finished.Destroy()
+			e.finished = nil
+		}
+		return
+	}
+	for _, raw := range commandBuffers {
+		if cb, ok := raw.(*CommandBuffer); ok && cb != nil {
+			cb.Destroy()
+			if e.finished == cb {
+				e.finished = nil
+			}
+		}
+	}
+}
 
-// Destroy is a no-op for Metal (command buffers are managed by MTLCommandQueue).
-func (e *CommandEncoder) Destroy() {}
+// Destroy releases recording, finished, and private ICB state.
+func (e *CommandEncoder) Destroy() {
+	if e == nil {
+		return
+	}
+	if e.cmdBuffer != 0 {
+		Release(e.cmdBuffer)
+		e.cmdBuffer = 0
+	}
+	e.releaseICBOwners()
+	e.recordErr = nil
+	if e.finished != nil {
+		e.finished.Destroy()
+		e.finished = nil
+	}
+}
+
+func (e *CommandEncoder) failRecording(err error) {
+	if e != nil && err != nil && e.recordErr == nil {
+		e.recordErr = err
+	}
+}
+
+func (e *CommandEncoder) releaseICBOwners() {
+	for _, owner := range e.icbOwners {
+		owner.release()
+	}
+	e.icbOwners = nil
+}
 
 // TransitionBuffers transitions buffer states for synchronization.
 func (e *CommandEncoder) TransitionBuffers(_ []hal.BufferBarrier) {}
@@ -286,11 +347,12 @@ func (e *CommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.Ren
 	if e.cmdBuffer == 0 {
 		return nil
 	}
-	// Scoped pool: rpDesc and other autoreleased objects are only needed during
-	// encoder creation. The encoder itself is Retained to survive pool drain.
+	// Keep any temporary Objective-C objects scoped to descriptor construction.
+	// rpDesc is created with new, so it remains owned after this pool drains and
+	// can safely outlive BeginRenderPass while native encoder creation is deferred.
 	pool := NewAutoreleasePool()
 	defer pool.Drain()
-	rpDesc := MsgSend(ID(GetClass("MTLRenderPassDescriptor")), Sel("renderPassDescriptor"))
+	rpDesc := MsgSend(ID(GetClass("MTLRenderPassDescriptor")), Sel("new"))
 	if rpDesc == 0 {
 		return nil
 	}
@@ -356,12 +418,12 @@ func (e *CommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.Ren
 		}
 		_ = MsgSend(stencilAttachment, Sel("setStoreAction:"), uintptr(storeOpToMTL(dsa.StencilStoreOp)))
 	}
-	encoder := MsgSend(e.cmdBuffer, Sel("renderCommandEncoderWithDescriptor:"), uintptr(rpDesc))
-	if encoder == 0 {
-		return nil
-	}
-	Retain(encoder)
-	return &RenderPassEncoder{raw: encoder, device: e.device}
+	// Keep the descriptor alive but delay creation of the native render encoder
+	// until the first draw. Metal requires the ICB translator to run on a compute
+	// encoder before the render encoder exists; retaining the descriptor gives
+	// that backend-private lowering a narrow seam without journaling draw calls.
+	e.passState = renderPassPendingState{}
+	return &RenderPassEncoder{descriptor: rpDesc, commandEncoder: e, device: e.device, pending: &e.passState}
 }
 
 // BeginComputePass begins a compute pass.
@@ -388,17 +450,28 @@ func (e *CommandEncoder) BeginComputePass(desc *hal.ComputePassDescriptor) hal.C
 
 // CommandBuffer implements hal.CommandBuffer for Metal.
 type CommandBuffer struct {
-	raw      ID
-	device   *Device
-	drawable ID // Attached drawable for presentation
+	raw       ID
+	device    *Device
+	drawable  ID // Attached drawable for presentation
+	icbOwners []*indexedICBOwnership
+	destroy   sync.Once
 }
 
 // Destroy releases the command buffer.
 func (cb *CommandBuffer) Destroy() {
-	if cb.raw != 0 {
-		Release(cb.raw)
-		cb.raw = 0
+	if cb == nil {
+		return
 	}
+	cb.destroy.Do(func() {
+		if cb.raw != 0 {
+			Release(cb.raw)
+			cb.raw = 0
+		}
+		for _, owner := range cb.icbOwners {
+			owner.release()
+		}
+		cb.icbOwners = nil
+	})
 }
 
 // SetDrawable attaches a drawable for presentation.
@@ -409,21 +482,120 @@ func (cb *CommandBuffer) SetDrawable(drawable ID) {
 
 // RenderPassEncoder implements hal.RenderPassEncoder for Metal.
 type RenderPassEncoder struct {
-	raw           ID
-	device        *Device
-	pipeline      *RenderPipeline
-	currentLayout *PipelineLayout // set by SetPipeline for SetBindGroup slot offsets
-	indexBuffer   *Buffer
-	indexFormat   gputypes.IndexFormat
-	indexOffset   uint64
+	raw            ID
+	descriptor     ID
+	commandEncoder *CommandEncoder
+	device         *Device
+	pipeline       *RenderPipeline
+	currentLayout  *PipelineLayout // set by SetPipeline for SetBindGroup slot offsets
+	indexBuffer    *Buffer
+	indexFormat    gputypes.IndexFormat
+	indexOffset    uint64
+	pending        *renderPassPendingState
+}
+
+const (
+	maxRenderBindGroups     = 4
+	maxRenderDynamicOffsets = 16
+)
+
+type renderBindGroupState struct {
+	group       *BindGroup
+	offsets     [maxRenderDynamicOffsets]uint32
+	offsetCount uint8
+	set         bool
+}
+
+type renderVertexBufferState struct {
+	buffer *Buffer
+	offset uint64
+	set    bool
+}
+
+type renderPassPendingState struct {
+	bindGroups    [maxRenderBindGroups]renderBindGroupState
+	vertexBuffers [maxVertexBuffers]renderVertexBufferState
+	viewport      MTLViewport
+	scissor       MTLScissorRect
+	blend         gputypes.Color
+	stencil       uint32
+	viewportSet   bool
+	scissorSet    bool
+	blendSet      bool
+	stencilSet    bool
+}
+
+func (e *RenderPassEncoder) beginNative() bool {
+	if e == nil {
+		return false
+	}
+	if e.raw != 0 {
+		return true
+	}
+	if e.descriptor == 0 || e.commandEncoder == nil || e.commandEncoder.cmdBuffer == 0 {
+		return false
+	}
+
+	pool := NewAutoreleasePool()
+	encoder := MsgSend(e.commandEncoder.cmdBuffer, Sel("renderCommandEncoderWithDescriptor:"), uintptr(e.descriptor))
+	Release(e.descriptor)
+	e.descriptor = 0
+	if encoder == 0 {
+		e.commandEncoder.failRecording(fmt.Errorf("metal: failed to create render command encoder"))
+		pool.Drain()
+		return false
+	}
+	Retain(encoder)
+	e.raw = encoder
+	pool.Drain()
+	e.replayPendingState()
+	return true
+}
+
+func (e *RenderPassEncoder) replayPendingState() {
+	if e.pipeline != nil {
+		e.applyPipeline(e.pipeline)
+	}
+	if e.pending == nil {
+		return
+	}
+	for i := range e.pending.bindGroups {
+		state := &e.pending.bindGroups[i]
+		if state.set {
+			e.applyBindGroup(uint32(i), state.group, state.offsets[:state.offsetCount])
+		}
+	}
+	for i := range e.pending.vertexBuffers {
+		state := &e.pending.vertexBuffers[i]
+		if state.set {
+			e.applyVertexBuffer(uint32(i), state.buffer, state.offset)
+		}
+	}
+	if e.pending.viewportSet {
+		msgSendVoid(e.raw, Sel("setViewport:"), argStruct(e.pending.viewport, mtlViewportType))
+	}
+	if e.pending.scissorSet {
+		msgSendVoid(e.raw, Sel("setScissorRect:"), argStruct(e.pending.scissor, mtlScissorRectType))
+	}
+	if e.pending.blendSet {
+		e.applyBlendConstant(e.pending.blend)
+	}
+	if e.pending.stencilSet {
+		_ = MsgSend(e.raw, Sel("setStencilReferenceValue:"), uintptr(e.pending.stencil))
+	}
 }
 
 // End finishes the render pass.
 func (e *RenderPassEncoder) End() {
+	e.beginNative()
 	if e.raw != 0 {
 		_ = MsgSend(e.raw, Sel("endEncoding"))
 		Release(e.raw)
 		e.raw = 0
+	}
+	if e.descriptor != 0 {
+		Release(e.descriptor)
+		e.descriptor = 0
 	}
 }
 
@@ -435,6 +607,13 @@ func (e *RenderPassEncoder) SetPipeline(pipeline hal.RenderPipeline) {
 	}
 	e.pipeline = p
 	e.currentLayout = p.layout // store for SetBindGroup slot offset lookup
+	if e.raw == 0 {
+		return
+	}
+	e.applyPipeline(p)
+}
+
+func (e *RenderPassEncoder) applyPipeline(p *RenderPipeline) {
 	_ = MsgSend(e.raw, Sel("setRenderPipelineState:"), uintptr(p.raw))
 	_ = MsgSend(e.raw, Sel("setCullMode:"), uintptr(p.cullMode))
 	_ = MsgSend(e.raw, Sel("setFrontFacingWinding:"), uintptr(p.frontFace))
@@ -488,6 +667,21 @@ func (e *RenderPassEncoder) SetBindGroup(index uint32, group hal.BindGroup, offs
 	if !ok || bg == nil {
 		return
 	}
+	if e.pending != nil && index < maxRenderBindGroups && len(offsets) <= maxRenderDynamicOffsets {
+		state := &e.pending.bindGroups[index]
+		state.group = bg
+		state.offsetCount = uint8(len(offsets))
+		state.set = true
+		copy(state.offsets[:], offsets)
+		clear(state.offsets[len(offsets):])
+	}
+	if e.raw == 0 {
+		return
+	}
+	e.applyBindGroup(index, bg, offsets)
+}
+
+func (e *RenderPassEncoder) applyBindGroup(index uint32, bg *BindGroup, offsets []uint32) {
 
 	// Metal uses per-type sequential indices: [[buffer(N)]], [[texture(M)]], [[sampler(K)]].
 	// naga MSL generates these indices sequentially across ALL bind groups in the
@@ -539,9 +733,22 @@ func (e *RenderPassEncoder) SetBindGroup(index uint32, group hal.BindGroup, offs
 // SetVertexBuffer sets a vertex buffer.
 func (e *RenderPassEncoder) SetVertexBuffer(slot uint32, buffer hal.Buffer, offset uint64) {
 	buf, ok := buffer.(*Buffer)
-	if !ok || buf == nil {
+	if !ok || buf == nil || slot >= maxVertexBuffers {
 		return
 	}
+	if e.pending != nil {
+		state := &e.pending.vertexBuffers[slot]
+		state.buffer = buf
+		state.offset = offset
+		state.set = true
+	}
+	if e.raw == 0 {
+		return
+	}
+	e.applyVertexBuffer(slot, buf, offset)
+}
+
+func (e *RenderPassEncoder) applyVertexBuffer(slot uint32, buf *Buffer, offset uint64) {
 	bufIdx := maxVertexBuffers - 1 - slot
 	_ = MsgSend(e.raw, Sel("setVertexBuffer:offset:atIndex:"), uintptr(buf.raw), uintptr(offset), uintptr(bufIdx))
 }
@@ -560,12 +767,26 @@ func (e *RenderPassEncoder) SetIndexBuffer(buffer hal.Buffer, format gputypes.In
 // SetViewport sets the viewport.
 func (e *RenderPassEncoder) SetViewport(x, y, width, height, minDepth, maxDepth float32) {
 	viewport := MTLViewport{OriginX: float64(x), OriginY: float64(y), Width: float64(width), Height: float64(height), ZNear: float64(minDepth), ZFar: float64(maxDepth)}
+	if e.pending != nil {
+		e.pending.viewport = viewport
+		e.pending.viewportSet = true
+	}
+	if e.raw == 0 {
+		return
+	}
 	msgSendVoid(e.raw, Sel("setViewport:"), argStruct(viewport, mtlViewportType))
 }
 
 // SetScissorRect sets the scissor rectangle.
 func (e *RenderPassEncoder) SetScissorRect(x, y, width, height uint32) {
 	scissor := MTLScissorRect{X: NSUInteger(x), Y: NSUInteger(y), Width: NSUInteger(width), Height: NSUInteger(height)}
+	if e.pending != nil {
+		e.pending.scissor = scissor
+		e.pending.scissorSet = true
+	}
+	if e.raw == 0 {
+		return
+	}
 	msgSendVoid(e.raw, Sel("setScissorRect:"), argStruct(scissor, mtlScissorRectType))
 }
 
@@ -574,6 +795,17 @@ func (e *RenderPassEncoder) SetBlendConstant(color *gputypes.Color) {
 	if color == nil {
 		return
 	}
+	if e.pending != nil {
+		e.pending.blend = *color
+		e.pending.blendSet = true
+	}
+	if e.raw == 0 {
+		return
+	}
+	e.applyBlendConstant(*color)
+}
+
+func (e *RenderPassEncoder) applyBlendConstant(color gputypes.Color) {
 	msgSendVoid(e.raw, Sel("setBlendColorRed:green:blue:alpha:"),
 		argFloat32(float32(color.R)),
 		argFloat32(float32(color.G)),
@@ -584,18 +816,28 @@ func (e *RenderPassEncoder) SetBlendConstant(color *gputypes.Color) {
 
 // SetStencilReference sets the stencil reference value.
 func (e *RenderPassEncoder) SetStencilReference(ref uint32) {
+	if e.pending != nil {
+		e.pending.stencil = ref
+		e.pending.stencilSet = true
+	}
+	if e.raw == 0 {
+		return
+	}
 	_ = MsgSend(e.raw, Sel("setStencilReferenceValue:"), uintptr(ref))
 }
 
 // Draw draws primitives.
 func (e *RenderPassEncoder) Draw(vertexCount, instanceCount, firstVertex, firstInstance uint32) {
+	if !e.beginNative() {
+		return
+	}
 	_ = MsgSend(e.raw, Sel("drawPrimitives:vertexStart:vertexCount:instanceCount:baseInstance:"),
 		uintptr(MTLPrimitiveTypeTriangle), uintptr(firstVertex), uintptr(vertexCount), uintptr(instanceCount), uintptr(firstInstance))
 }
 
 // DrawIndexed draws indexed primitives.
 func (e *RenderPassEncoder) DrawIndexed(indexCount, instanceCount, firstIndex uint32, baseVertex int32, firstInstance uint32) {
-	if e.indexBuffer == nil {
+	if e.indexBuffer == nil || !e.beginNative() {
 		return
 	}
 	indexType := indexFormatToMTL(e.indexFormat)
@@ -621,6 +863,9 @@ func (e *RenderPassEncoder) DrawIndirect(buffer hal.Buffer, offset uint64, drawC
 	if _, ok := indirect.RecordOffset(offset, 16, drawCount-1); !ok {
 		return
 	}
+	if !e.beginNative() {
+		return
+	}
 	for i := uint32(0); i < drawCount; i++ {
 		recordOffset, _ := indirect.RecordOffset(offset, 16, i)
 		_ = MsgSend(e.raw, Sel("drawPrimitives:indirectBuffer:indirectBufferOffset:"),
@@ -642,6 +887,12 @@ func (e *RenderPassEncoder) DrawIndexedIndirect(buffer hal.Buffer, offset uint64
 	if _, ok := indirect.RecordOffset(offset, 20, drawCount-1); !ok {
 		return
 	}
+	if e.tryFirstIndexedICB(buf, offset, drawCount) {
+		return
+	}
+	if !e.beginNative() {
+		return
+	}
 	indexType := indexFormatToMTL(e.indexFormat)
 	for i := uint32(0); i < drawCount; i++ {
 		recordOffset, ok := indirect.RecordOffset(offset, 20, i)
@@ -651,6 +902,17 @@ func (e *RenderPassEncoder) DrawIndexedIndirect(buffer hal.Buffer, offset uint64
 		_ = MsgSend(e.raw, Sel("drawIndexedPrimitives:indexType:indexBuffer:indexBufferOffset:indirectBuffer:indirectBufferOffset:"),
 			uintptr(MTLPrimitiveTypeTriangle), uintptr(indexType), uintptr(e.indexBuffer.raw), uintptr(e.indexOffset), uintptr(buf.raw), uintptr(recordOffset))
 	}
+}
+
+func (e *RenderPassEncoder) tryFirstIndexedICB(buffer *Buffer, offset uint64, count uint32) bool {
+	commands, ok := e.prepareIndexedICB(buffer, offset, count)
+	if !ok {
+		return false
+	}
+	if !e.beginNative() {
+		return true
+	}
+	return e.executeIndexedICB(commands, buffer)
 }
 
 func indexedIndirectRecordOffset(offset uint64, index uint32) (uint64, bool) {

--- a/hal/metal/encoder_test.go
+++ b/hal/metal/encoder_test.go
@@ -6,10 +6,21 @@
 package metal
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/gogpu/gputypes"
 )
+
+func TestCommandEncoderRecordingErrorKeepsFirstFailure(t *testing.T) {
+	first := errors.New("first")
+	encoder := &CommandEncoder{}
+	encoder.failRecording(first)
+	encoder.failRecording(errors.New("second"))
+	if !errors.Is(encoder.recordErr, first) {
+		t.Fatalf("recording error = %v, want first failure", encoder.recordErr)
+	}
+}
 
 // TestCommandEncoder_RecordingState is a regression test for Issue #24.
 // The IsRecording() method returns cmdBuffer != 0.
@@ -99,6 +110,83 @@ func TestCommandEncoder_IsRecordingMethod(t *testing.T) {
 	enc.cmdBuffer = 0
 	if enc.IsRecording() != (enc.cmdBuffer != 0) {
 		t.Error("IsRecording() should equal (cmdBuffer != 0)")
+	}
+}
+
+func TestRenderPassDeferredStateKeepsLatestValues(t *testing.T) {
+	firstPipeline := &RenderPipeline{}
+	latestPipeline := &RenderPipeline{}
+	firstGroup := &BindGroup{}
+	latestGroup := &BindGroup{}
+	firstVertex := &Buffer{}
+	latestVertex := &Buffer{}
+	index := &Buffer{}
+	state := renderPassPendingState{}
+	pass := &RenderPassEncoder{pending: &state}
+
+	pass.SetPipeline(firstPipeline)
+	pass.SetPipeline(latestPipeline)
+	pass.SetBindGroup(1, firstGroup, []uint32{4, 8})
+	pass.SetBindGroup(1, latestGroup, []uint32{12})
+	pass.SetVertexBuffer(2, firstVertex, 16)
+	pass.SetVertexBuffer(2, latestVertex, 24)
+	pass.SetIndexBuffer(index, gputypes.IndexFormatUint32, 32)
+	pass.SetViewport(1, 2, 3, 4, 0.25, 0.75)
+	pass.SetScissorRect(5, 6, 7, 8)
+	pass.SetBlendConstant(&gputypes.Color{R: 0.1, G: 0.2, B: 0.3, A: 0.4})
+	pass.SetStencilReference(9)
+
+	if pass.pipeline != latestPipeline {
+		t.Fatal("deferred pipeline did not keep latest value")
+	}
+	group := pass.pending.bindGroups[1]
+	if !group.set || group.group != latestGroup || group.offsetCount != 1 || group.offsets[0] != 12 {
+		t.Fatalf("deferred bind group = %#v, want latest group and offsets", group)
+	}
+	vertex := pass.pending.vertexBuffers[2]
+	if !vertex.set || vertex.buffer != latestVertex || vertex.offset != 24 {
+		t.Fatalf("deferred vertex buffer = %#v, want latest buffer and offset", vertex)
+	}
+	if pass.indexBuffer != index || pass.indexFormat != gputypes.IndexFormatUint32 || pass.indexOffset != 32 {
+		t.Fatal("deferred index buffer state was not retained")
+	}
+	if !pass.pending.viewportSet || pass.pending.viewport != (MTLViewport{OriginX: 1, OriginY: 2, Width: 3, Height: 4, ZNear: 0.25, ZFar: 0.75}) {
+		t.Fatalf("deferred viewport = %#v", pass.pending.viewport)
+	}
+	if !pass.pending.scissorSet || pass.pending.scissor != (MTLScissorRect{X: 5, Y: 6, Width: 7, Height: 8}) {
+		t.Fatalf("deferred scissor = %#v", pass.pending.scissor)
+	}
+	if !pass.pending.blendSet || pass.pending.blend != (gputypes.Color{R: 0.1, G: 0.2, B: 0.3, A: 0.4}) {
+		t.Fatalf("deferred blend constant = %#v", pass.pending.blend)
+	}
+	if !pass.pending.stencilSet || pass.pending.stencil != 9 {
+		t.Fatalf("deferred stencil reference = %d", pass.pending.stencil)
+	}
+}
+
+func TestRenderPassDeferredStateUsesBoundedStorage(t *testing.T) {
+	group := &BindGroup{}
+	buffer := &Buffer{}
+	pipeline := &RenderPipeline{}
+	state := renderPassPendingState{}
+	var pass RenderPassEncoder
+	offsets := []uint32{1, 2, 3, 4}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		clear(state.bindGroups[:])
+		clear(state.vertexBuffers[:])
+		pass = RenderPassEncoder{pending: &state}
+		pass.SetPipeline(pipeline)
+		pass.SetBindGroup(0, group, offsets)
+		pass.SetVertexBuffer(0, buffer, 12)
+		pass.SetIndexBuffer(buffer, gputypes.IndexFormatUint16, 4)
+		pass.SetViewport(0, 0, 10, 10, 0, 1)
+		pass.SetScissorRect(0, 0, 10, 10)
+		pass.SetBlendConstant(&gputypes.Color{A: 1})
+		pass.SetStencilReference(2)
+	})
+	if allocs != 0 {
+		t.Fatalf("deferred state allocated %.2f objects per recording", allocs)
 	}
 }
 

--- a/hal/metal/icb_indexed.go
+++ b/hal/metal/icb_indexed.go
@@ -1,0 +1,421 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build darwin && !(js && wasm)
+
+package metal
+
+import (
+	"fmt"
+	"sync"
+	"unsafe"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/internal/indirect"
+)
+
+const (
+	indexedICBMinCommands     uint32 = 1024
+	indexedICBMaxCommands     uint32 = 52428 // floor(1 MiB / 20-byte records)
+	indexedICBMaxRetainedIDs         = 128
+	indexedICBThreadsPerGroup uint32 = 64
+)
+
+type indexedICBTranslator struct {
+	library  ID
+	pipeline ID
+}
+
+type indexedICBParams struct {
+	commandBase uint32
+	count       uint32
+}
+
+type indexedICBArena struct {
+	icb            ID
+	argumentBuffer ID
+	capacity       uint32
+}
+
+type indexedICBCommands struct {
+	icb   ID
+	count uint32
+	owner *indexedICBOwnership
+}
+
+// indexedICBOwnership is the single terminal-path owner for native objects and
+// explicitly retained buffers referenced by one ICB execution. The fixed array
+// makes residency bounded before any optimized work is encoded.
+type indexedICBOwnership struct {
+	once          sync.Once
+	objects       [indexedICBMaxRetainedIDs]ID
+	objectCount   int
+	releaseObject func(ID)
+}
+
+// retainOwned adopts an existing +1 Objective-C reference.
+func (o *indexedICBOwnership) retainOwned(id ID) bool {
+	if o == nil || id == 0 || o.objectCount >= len(o.objects) {
+		return false
+	}
+	o.objects[o.objectCount] = id
+	o.objectCount++
+	return true
+}
+
+func (o *indexedICBOwnership) retainReference(id ID) bool {
+	if o == nil || id == 0 || o.objectCount >= len(o.objects) {
+		return false
+	}
+	Retain(id)
+	return o.retainOwned(id)
+}
+
+func (o *indexedICBOwnership) release() {
+	if o == nil {
+		return
+	}
+	o.once.Do(func() {
+		release := o.releaseObject
+		if release == nil {
+			release = Release
+		}
+		for i := o.objectCount - 1; i >= 0; i-- {
+			release(o.objects[i])
+			o.objects[i] = 0
+		}
+		o.objectCount = 0
+	})
+}
+
+func indexedICBCountEligible(count uint32) bool {
+	return count >= indexedICBMinCommands && count <= indexedICBMaxCommands
+}
+
+func indexedICBArenaCapacity(count, max uint32) uint32 {
+	if count == 0 || max == 0 || count > max {
+		return 0
+	}
+	capacity := indexedICBMinCommands
+	if capacity > max {
+		capacity = max
+	}
+	for capacity < count {
+		next := capacity * 2
+		if next < capacity || next > max {
+			capacity = max
+			break
+		}
+		capacity = next
+	}
+	if capacity < count {
+		return 0
+	}
+	return capacity
+}
+
+func indexedICBDispatchGroups(count uint32) uint32 {
+	if count == 0 {
+		return 0
+	}
+	return (count + indexedICBThreadsPerGroup - 1) / indexedICBThreadsPerGroup
+}
+
+func (d *Device) indexedICBTranslator(format gputypes.IndexFormat) (indexedICBTranslator, error) {
+	d.icbTranslatorMu.Lock()
+	defer d.icbTranslatorMu.Unlock()
+	if d.icbTranslators == nil {
+		d.icbTranslators = make(map[gputypes.IndexFormat]indexedICBTranslator, 2)
+	}
+	if translator, ok := d.icbTranslators[format]; ok {
+		return translator, nil
+	}
+	translator, err := compileIndexedICBTranslator(d, format)
+	if err != nil {
+		return indexedICBTranslator{}, err
+	}
+	d.icbTranslators[format] = translator
+	return translator, nil
+}
+
+func (d *Device) releaseIndexedICBTranslators() {
+	d.icbTranslatorMu.Lock()
+	defer d.icbTranslatorMu.Unlock()
+	for format, translator := range d.icbTranslators {
+		if translator.pipeline != 0 {
+			Release(translator.pipeline)
+		}
+		if translator.library != 0 {
+			Release(translator.library)
+		}
+		delete(d.icbTranslators, format)
+	}
+}
+
+func compileIndexedICBTranslator(d *Device, format gputypes.IndexFormat) (indexedICBTranslator, error) {
+	indexType := "uint"
+	switch format {
+	case gputypes.IndexFormatUint16:
+		indexType = "ushort"
+	case gputypes.IndexFormatUint32:
+	default:
+		return indexedICBTranslator{}, fmt.Errorf("metal: unsupported ICB index format %d", format)
+	}
+	source := fmt.Sprintf(`
+#include <metal_stdlib>
+#include <metal_command_buffer>
+using namespace metal;
+struct DrawIndexedArgs { uint indexCount; uint instanceCount; uint firstIndex; int baseVertex; uint firstInstance; };
+struct ICBContainer { command_buffer commandBuffer [[id(0)]]; };
+struct IndexedICBParams { uint commandBase; uint count; };
+kernel void wgpu_translate_indexed_icb(device const DrawIndexedArgs* args [[buffer(0)]],
+    device ICBContainer* container [[buffer(1)]], device const %s* indices [[buffer(2)]],
+    constant IndexedICBParams& params [[buffer(3)]], uint id [[thread_position_in_grid]]) {
+    if (id >= params.count) return;
+    DrawIndexedArgs a = args[id];
+    render_command command(container->commandBuffer, params.commandBase + id);
+    command.draw_indexed_primitives(primitive_type::triangle, a.indexCount,
+        indices + a.firstIndex, a.instanceCount, a.baseVertex, a.firstInstance);
+}
+`, indexType)
+
+	str := NSString(source)
+	defer Release(str)
+	var errorPtr ID
+	library := MsgSend(d.raw, Sel("newLibraryWithSource:options:error:"), uintptr(str), 0, uintptr(unsafe.Pointer(&errorPtr)))
+	if library == 0 {
+		return indexedICBTranslator{}, fmt.Errorf("metal: indexed ICB translator compilation failed: %s", formatNSError(errorPtr))
+	}
+	name := NSString("wgpu_translate_indexed_icb")
+	function := MsgSend(library, Sel("newFunctionWithName:"), uintptr(name))
+	Release(name)
+	if function == 0 {
+		Release(library)
+		return indexedICBTranslator{}, fmt.Errorf("metal: indexed ICB translator function missing")
+	}
+	pipeline := MsgSend(d.raw, Sel("newComputePipelineStateWithFunction:error:"), uintptr(function), uintptr(unsafe.Pointer(&errorPtr)))
+	Release(function)
+	if pipeline == 0 {
+		Release(library)
+		return indexedICBTranslator{}, fmt.Errorf("metal: indexed ICB translator pipeline creation failed: %s", formatNSError(errorPtr))
+	}
+	return indexedICBTranslator{library: library, pipeline: pipeline}, nil
+}
+
+func (d *Device) newIndexedICBArena(translator indexedICBTranslator, count uint32) (*indexedICBArena, error) {
+	capacity := indexedICBArenaCapacity(count, indexedICBMaxCommands)
+	if capacity == 0 {
+		return nil, fmt.Errorf("metal: indexed ICB command count out of range")
+	}
+	descriptor := MsgSend(ID(GetClass("MTLIndirectCommandBufferDescriptor")), Sel("new"))
+	if descriptor == 0 {
+		return nil, fmt.Errorf("metal: failed to create ICB descriptor")
+	}
+	defer Release(descriptor)
+	_ = MsgSend(descriptor, Sel("setCommandTypes:"), uintptr(MTLIndirectCommandTypeDrawIndexed))
+	_ = MsgSend(descriptor, Sel("setInheritPipelineState:"), uintptr(YES))
+	_ = MsgSend(descriptor, Sel("setInheritBuffers:"), uintptr(YES))
+	icb := MsgSend(d.raw, Sel("newIndirectCommandBufferWithDescriptor:maxCommandCount:options:"),
+		uintptr(descriptor), uintptr(capacity), 0)
+	if icb == 0 {
+		return nil, fmt.Errorf("metal: failed to create indexed ICB")
+	}
+
+	name := NSString("wgpu_translate_indexed_icb")
+	function := MsgSend(translator.library, Sel("newFunctionWithName:"), uintptr(name))
+	Release(name)
+	if function == 0 {
+		Release(icb)
+		return nil, fmt.Errorf("metal: indexed ICB translator function missing")
+	}
+	defer Release(function)
+	argumentEncoder := MsgSend(function, Sel("newArgumentEncoderWithBufferIndex:"), uintptr(1))
+	if argumentEncoder == 0 {
+		Release(icb)
+		return nil, fmt.Errorf("metal: failed to create ICB argument encoder")
+	}
+	defer Release(argumentEncoder)
+	encodedLength := MsgSendUint(argumentEncoder, Sel("encodedLength"))
+	argumentBuffer := MsgSend(d.raw, Sel("newBufferWithLength:options:"), uintptr(encodedLength), uintptr(MTLResourceStorageModePrivate))
+	if argumentBuffer == 0 {
+		Release(icb)
+		return nil, fmt.Errorf("metal: failed to create ICB argument buffer")
+	}
+	_ = MsgSend(argumentEncoder, Sel("setArgumentBuffer:offset:"), uintptr(argumentBuffer), 0)
+	_ = MsgSend(argumentEncoder, Sel("setIndirectCommandBuffer:atIndex:"), uintptr(icb), 0)
+	return &indexedICBArena{icb: icb, argumentBuffer: argumentBuffer, capacity: capacity}, nil
+}
+
+func (d *Device) indexedICBSelectorsAvailable() bool {
+	if d == nil || d.raw == 0 || !DeviceSupportsFamily(d.raw, MTLGPUFamilyApple7) {
+		return false
+	}
+	for _, name := range []string{
+		"newIndirectCommandBufferWithDescriptor:maxCommandCount:options:",
+		"newLibraryWithSource:options:error:",
+		"newComputePipelineStateWithFunction:error:",
+		"newBufferWithLength:options:",
+	} {
+		selector := Sel(name)
+		if selector == 0 || !MsgSendBool(d.raw, Sel("respondsToSelector:"), uintptr(selector)) {
+			return false
+		}
+	}
+	class := GetClass("MTLIndirectCommandBufferDescriptor")
+	if class == 0 {
+		return false
+	}
+	for _, name := range []string{"setCommandTypes:", "setInheritPipelineState:", "setInheritBuffers:"} {
+		selector := Sel(name)
+		if selector == 0 || !MsgSendBool(ID(class), Sel("instancesRespondToSelector:"), uintptr(selector)) {
+			return false
+		}
+	}
+	for _, name := range []string{
+		"resetWithRange:", "executeCommandsInBuffer:withRange:",
+		"newArgumentEncoderWithBufferIndex:", "setArgumentBuffer:offset:",
+		"setIndirectCommandBuffer:atIndex:",
+	} {
+		if Sel(name) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (e *RenderPassEncoder) prepareIndexedICB(arguments *Buffer, offset uint64, count uint32) (*indexedICBCommands, bool) {
+	if e == nil || e.commandEncoder == nil || e.commandEncoder.cmdBuffer == 0 || e.device == nil ||
+		e.raw != 0 || e.pipeline == nil || !e.pipeline.icbCompatible || e.indexBuffer == nil ||
+		arguments == nil || arguments.raw == 0 || e.indexBuffer.raw == 0 || !indexedICBCountEligible(count) ||
+		!e.device.indexedICBSelectorsAvailable() {
+		return nil, false
+	}
+	if e.indexFormat != gputypes.IndexFormatUint16 && e.indexFormat != gputypes.IndexFormatUint32 {
+		return nil, false
+	}
+	if !indirect.RangeFits(arguments.size, offset, 20, count) {
+		return nil, false
+	}
+
+	translator, err := e.device.indexedICBTranslator(e.indexFormat)
+	if err != nil {
+		return nil, false
+	}
+	arena, err := e.device.newIndexedICBArena(translator, count)
+	if err != nil {
+		return nil, false
+	}
+	owner := &indexedICBOwnership{}
+	if !owner.retainOwned(arena.icb) || !owner.retainOwned(arena.argumentBuffer) {
+		owner.release()
+		return nil, false
+	}
+	if !e.retainIndexedICBResources(owner, arguments) {
+		owner.release()
+		return nil, false
+	}
+
+	rng := NSRange{Length: NSUInteger(count)}
+	msgSendVoid(arena.icb, Sel("resetWithRange:"), argStruct(rng, nsRangeType))
+	pool := NewAutoreleasePool()
+	compute := MsgSend(e.commandEncoder.cmdBuffer, Sel("computeCommandEncoder"))
+	if compute == 0 {
+		pool.Drain()
+		owner.release()
+		return nil, false
+	}
+	Retain(compute)
+	pool.Drain()
+	_ = MsgSend(compute, Sel("setComputePipelineState:"), uintptr(translator.pipeline))
+	_ = MsgSend(compute, Sel("setBuffer:offset:atIndex:"), uintptr(arguments.raw), uintptr(offset), 0)
+	_ = MsgSend(compute, Sel("setBuffer:offset:atIndex:"), uintptr(arena.argumentBuffer), 0, 1)
+	_ = MsgSend(compute, Sel("setBuffer:offset:atIndex:"), uintptr(e.indexBuffer.raw), uintptr(e.indexOffset), 2)
+	params := indexedICBParams{count: count}
+	_ = MsgSend(compute, Sel("setBytes:length:atIndex:"), uintptr(unsafe.Pointer(&params)), uintptr(unsafe.Sizeof(params)), 3)
+	_ = MsgSend(compute, Sel("useResource:usage:"), uintptr(arguments.raw), 1)
+	_ = MsgSend(compute, Sel("useResource:usage:"), uintptr(arena.argumentBuffer), 1)
+	_ = MsgSend(compute, Sel("useResource:usage:"), uintptr(e.indexBuffer.raw), 1)
+	_ = MsgSend(compute, Sel("useResource:usage:"), uintptr(arena.icb), 2)
+	groups := MTLSize{Width: NSUInteger(indexedICBDispatchGroups(count)), Height: 1, Depth: 1}
+	threads := MTLSize{Width: NSUInteger(indexedICBThreadsPerGroup), Height: 1, Depth: 1}
+	msgSendVoid(compute, Sel("dispatchThreadgroups:threadsPerThreadgroup:"),
+		argStruct(groups, mtlSizeType), argStruct(threads, mtlSizeType))
+	_ = MsgSend(compute, Sel("endEncoding"))
+	Release(compute)
+
+	e.commandEncoder.icbOwners = append(e.commandEncoder.icbOwners, owner)
+	return &indexedICBCommands{icb: arena.icb, count: count, owner: owner}, true
+}
+
+func (e *RenderPassEncoder) executeIndexedICB(commands *indexedICBCommands, arguments *Buffer) bool {
+	if commands == nil || commands.icb == 0 || commands.count == 0 || e.raw == 0 {
+		return false
+	}
+	e.declareIndexedICBResources(arguments)
+	rng := NSRange{Length: NSUInteger(commands.count)}
+	msgSendVoid(e.raw, Sel("executeCommandsInBuffer:withRange:"),
+		argPointer(uintptr(commands.icb)), argStruct(rng, nsRangeType))
+	return true
+}
+
+func (e *RenderPassEncoder) declareIndexedICBResources(arguments *Buffer) {
+	declare := func(id ID) {
+		if id != 0 {
+			_ = MsgSend(e.raw, Sel("useResource:usage:"), uintptr(id), 1)
+		}
+	}
+	if arguments != nil {
+		declare(arguments.raw)
+	}
+	if e.indexBuffer != nil {
+		declare(e.indexBuffer.raw)
+	}
+	if e.pending == nil {
+		return
+	}
+	for i := range e.pending.vertexBuffers {
+		state := &e.pending.vertexBuffers[i]
+		if state.set && state.buffer != nil {
+			declare(state.buffer.raw)
+		}
+	}
+	for i := range e.pending.bindGroups {
+		state := &e.pending.bindGroups[i]
+		if !state.set || state.group == nil {
+			continue
+		}
+		for _, entry := range state.group.entries {
+			if binding, ok := entry.Resource.(gputypes.BufferBinding); ok {
+				declare(ID(binding.Buffer))
+			}
+		}
+	}
+}
+
+func (e *RenderPassEncoder) retainIndexedICBResources(owner *indexedICBOwnership, arguments *Buffer) bool {
+	if !owner.retainReference(arguments.raw) || !owner.retainReference(e.indexBuffer.raw) {
+		return false
+	}
+	if e.pending == nil {
+		return true
+	}
+	for i := range e.pending.vertexBuffers {
+		state := &e.pending.vertexBuffers[i]
+		if state.set && state.buffer != nil && !owner.retainReference(state.buffer.raw) {
+			return false
+		}
+	}
+	for i := range e.pending.bindGroups {
+		state := &e.pending.bindGroups[i]
+		if !state.set || state.group == nil {
+			continue
+		}
+		for _, entry := range state.group.entries {
+			binding, ok := entry.Resource.(gputypes.BufferBinding)
+			if !ok || binding.Buffer == 0 || !owner.retainReference(ID(binding.Buffer)) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/hal/metal/icb_indexed_test.go
+++ b/hal/metal/icb_indexed_test.go
@@ -1,0 +1,114 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build darwin && !(js && wasm)
+
+package metal
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/gogpu/wgpu/hal"
+)
+
+func TestIndexedICBArenaCapacityIsGeometricAndBounded(t *testing.T) {
+	const max = uint32(52428)
+	for _, test := range []struct {
+		count uint32
+		want  uint32
+	}{
+		{1024, 1024},
+		{1025, 2048},
+		{10000, 16384},
+		{max, max},
+		{max + 1, 0},
+	} {
+		if got := indexedICBArenaCapacity(test.count, max); got != test.want {
+			t.Fatalf("capacity(%d) = %d, want %d", test.count, got, test.want)
+		}
+	}
+}
+
+func TestIndexedICBCountGate(t *testing.T) {
+	for count, want := range map[uint32]bool{
+		0: false, 1: false, 20: false, 1023: false, 1024: true,
+		indexedICBMaxCommands: true, indexedICBMaxCommands + 1: false,
+	} {
+		if got := indexedICBCountEligible(count); got != want {
+			t.Fatalf("eligible(%d) = %v, want %v", count, got, want)
+		}
+	}
+}
+
+func TestIndexedICBOwnershipReleasesExactlyOnceAcrossRaces(t *testing.T) {
+	var mu sync.Mutex
+	released := make(map[ID]int)
+	owner := &indexedICBOwnership{releaseObject: func(id ID) {
+		mu.Lock()
+		released[id]++
+		mu.Unlock()
+	}}
+	for _, id := range []ID{1, 2, 3} {
+		if !owner.retainOwned(id) {
+			t.Fatalf("failed to retain object %d", id)
+		}
+	}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			owner.release()
+		}()
+	}
+	wg.Wait()
+	for _, id := range []ID{1, 2, 3} {
+		if released[id] != 1 {
+			t.Fatalf("object %d released %d times, want once", id, released[id])
+		}
+	}
+}
+
+func TestCommandEncoderResetAllReleasesFinishedICBOwnership(t *testing.T) {
+	releases := 0
+	owner := &indexedICBOwnership{releaseObject: func(ID) { releases++ }}
+	owner.retainOwned(1)
+	cb := &CommandBuffer{icbOwners: []*indexedICBOwnership{owner}}
+	encoder := &CommandEncoder{finished: cb}
+
+	encoder.ResetAll(nil)
+	encoder.ResetAll([]hal.CommandBuffer{cb})
+	if releases != 1 {
+		t.Fatalf("release count = %d, want one", releases)
+	}
+	if encoder.finished != nil || cb.icbOwners != nil {
+		t.Fatal("finished ICB ownership was retained after reset")
+	}
+}
+
+func TestCommandBufferDestroyReleasesExactlyOnceAcrossRaces(t *testing.T) {
+	var mu sync.Mutex
+	releases := 0
+	owner := &indexedICBOwnership{releaseObject: func(ID) {
+		mu.Lock()
+		releases++
+		mu.Unlock()
+	}}
+	owner.retainOwned(1)
+	cb := &CommandBuffer{icbOwners: []*indexedICBOwnership{owner}}
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cb.Destroy()
+		}()
+	}
+	wg.Wait()
+	if releases != 1 {
+		t.Fatalf("release count = %d, want one", releases)
+	}
+}

--- a/hal/metal/icb_pipeline.go
+++ b/hal/metal/icb_pipeline.go
@@ -1,0 +1,60 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build darwin && !(js && wasm)
+
+package metal
+
+import (
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/hal"
+)
+
+func renderPipelineICBCandidate(desc *hal.RenderPipelineDescriptor) bool {
+	if desc == nil || desc.Primitive.Topology != gputypes.PrimitiveTopologyTriangleList {
+		return false
+	}
+	layout, ok := desc.Layout.(*PipelineLayout)
+	if !ok || layout == nil {
+		return false
+	}
+	for _, rawLayout := range layout.layouts {
+		group, ok := rawLayout.(*BindGroupLayout)
+		if !ok || group == nil {
+			return false
+		}
+		for _, entry := range group.entries {
+			if entry.Buffer == nil || entry.Buffer.Type == gputypes.BufferBindingTypeStorage ||
+				entry.Texture != nil || entry.StorageTexture != nil || entry.Sampler != nil {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (d *Device) canCreateICBPipeline(desc *hal.RenderPipelineDescriptor, pipelineDesc ID) bool {
+	if d == nil || d.raw == 0 || pipelineDesc == 0 || !renderPipelineICBCandidate(desc) {
+		return false
+	}
+	// Metal family support is cumulative. Apple8+ devices also report Apple7,
+	// so this admits the M1 proof family and later Apple GPU families while
+	// leaving Intel and AMD devices on the ordinary path.
+	if !DeviceSupportsFamily(d.raw, MTLGPUFamilyApple7) {
+		return false
+	}
+	setter := Sel("setSupportIndirectCommandBuffers:")
+	return setter != 0 && MsgSendBool(pipelineDesc, Sel("respondsToSelector:"), uintptr(setter))
+}
+
+// createRenderPipelineState centralizes the fail-closed policy: an ICB
+// candidate gets one flagged attempt, followed by the ordinary attempt on any
+// failure. Callers only observe failure when the ordinary pipeline also fails.
+func createRenderPipelineState(candidate bool, create func(icb bool) ID) (ID, bool) {
+	if candidate {
+		if pipeline := create(true); pipeline != 0 {
+			return pipeline, true
+		}
+	}
+	return create(false), false
+}

--- a/hal/metal/icb_pipeline_test.go
+++ b/hal/metal/icb_pipeline_test.go
@@ -1,0 +1,115 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build darwin && !(js && wasm)
+
+package metal
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/hal"
+)
+
+func TestRenderPipelineICBCandidateIsPrivateAndBufferOnly(t *testing.T) {
+	bufferLayout := &BindGroupLayout{entries: []gputypes.BindGroupLayoutEntry{{Buffer: &gputypes.BufferBindingLayout{}}}}
+	readOnlyStorageLayout := &BindGroupLayout{entries: []gputypes.BindGroupLayoutEntry{{Buffer: &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeReadOnlyStorage}}}}
+	writableStorageLayout := &BindGroupLayout{entries: []gputypes.BindGroupLayoutEntry{{Buffer: &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeStorage}}}}
+	textureLayout := &BindGroupLayout{entries: []gputypes.BindGroupLayoutEntry{{Texture: &gputypes.TextureBindingLayout{}}}}
+
+	tests := []struct {
+		name string
+		desc hal.RenderPipelineDescriptor
+		want bool
+	}{
+		{
+			name: "triangle buffer-only",
+			desc: hal.RenderPipelineDescriptor{
+				Primitive: gputypes.PrimitiveState{Topology: gputypes.PrimitiveTopologyTriangleList},
+				Layout:    &PipelineLayout{layouts: []hal.BindGroupLayout{bufferLayout}},
+			},
+			want: true,
+		},
+		{
+			name: "triangle without bindings",
+			desc: hal.RenderPipelineDescriptor{
+				Primitive: gputypes.PrimitiveState{Topology: gputypes.PrimitiveTopologyTriangleList},
+				Layout:    &PipelineLayout{},
+			},
+			want: true,
+		},
+		{
+			name: "read-only storage binding",
+			desc: hal.RenderPipelineDescriptor{
+				Primitive: gputypes.PrimitiveState{Topology: gputypes.PrimitiveTopologyTriangleList},
+				Layout:    &PipelineLayout{layouts: []hal.BindGroupLayout{readOnlyStorageLayout}},
+			},
+			want: true,
+		},
+		{
+			name: "writable storage binding",
+			desc: hal.RenderPipelineDescriptor{
+				Primitive: gputypes.PrimitiveState{Topology: gputypes.PrimitiveTopologyTriangleList},
+				Layout:    &PipelineLayout{layouts: []hal.BindGroupLayout{writableStorageLayout}},
+			},
+		},
+		{
+			name: "texture binding",
+			desc: hal.RenderPipelineDescriptor{
+				Primitive: gputypes.PrimitiveState{Topology: gputypes.PrimitiveTopologyTriangleList},
+				Layout:    &PipelineLayout{layouts: []hal.BindGroupLayout{textureLayout}},
+			},
+		},
+		{
+			name: "non-triangle topology",
+			desc: hal.RenderPipelineDescriptor{
+				Primitive: gputypes.PrimitiveState{Topology: gputypes.PrimitiveTopologyLineList},
+				Layout:    &PipelineLayout{layouts: []hal.BindGroupLayout{bufferLayout}},
+			},
+		},
+		{
+			name: "foreign layout",
+			desc: hal.RenderPipelineDescriptor{Primitive: gputypes.PrimitiveState{Topology: gputypes.PrimitiveTopologyTriangleList}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := renderPipelineICBCandidate(&tt.desc); got != tt.want {
+				t.Fatalf("candidate = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateRenderPipelineStateRetriesOrdinaryAfterICBFailure(t *testing.T) {
+	var attempts []bool
+	pipeline, compatible := createRenderPipelineState(true, func(icb bool) ID {
+		attempts = append(attempts, icb)
+		if icb {
+			return 0
+		}
+		return 42
+	})
+	if pipeline != 42 || compatible {
+		t.Fatalf("result = (%d, %v), want (42, false)", pipeline, compatible)
+	}
+	if len(attempts) != 2 || !attempts[0] || attempts[1] {
+		t.Fatalf("attempts = %v, want [true false]", attempts)
+	}
+}
+
+func TestCreateRenderPipelineStateSkipsFlagForIneligiblePipeline(t *testing.T) {
+	var attempts []bool
+	pipeline, compatible := createRenderPipelineState(false, func(icb bool) ID {
+		attempts = append(attempts, icb)
+		return 7
+	})
+	if pipeline != 7 || compatible {
+		t.Fatalf("result = (%d, %v), want (7, false)", pipeline, compatible)
+	}
+	if len(attempts) != 1 || attempts[0] {
+		t.Fatalf("attempts = %v, want [false]", attempts)
+	}
+}

--- a/hal/metal/metal.go
+++ b/hal/metal/metal.go
@@ -114,6 +114,7 @@ func preRegisterSelectors() {
 		"newSamplerStateWithDescriptor:",
 		"newCommandQueue",
 		"newRenderPipelineStateWithDescriptor:error:",
+		"setSupportIndirectCommandBuffers:",
 		"newLibraryWithSource:options:error:",
 		"newFunctionWithName:",
 		"supportsFamily:",

--- a/hal/metal/resource.go
+++ b/hal/metal/resource.go
@@ -198,11 +198,12 @@ func (l *PipelineLayout) Destroy() {
 
 // RenderPipeline implements hal.RenderPipeline for Metal.
 type RenderPipeline struct {
-	raw       ID // id<MTLRenderPipelineState>
-	device    *Device
-	layout    *PipelineLayout // for SetBindGroup slot offset lookup
-	cullMode  MTLCullMode
-	frontFace MTLWinding
+	raw           ID // id<MTLRenderPipelineState>
+	device        *Device
+	layout        *PipelineLayout // for SetBindGroup slot offset lookup
+	cullMode      MTLCullMode
+	frontFace     MTLWinding
+	icbCompatible bool
 
 	depthStencil    ID // id<MTLDepthStencilState>
 	depthBias       float32

--- a/hal/metal/types.go
+++ b/hal/metal/types.go
@@ -82,6 +82,13 @@ type MTLScissorRect struct {
 	Width, Height NSUInteger
 }
 
+// MTLIndirectCommandType values accepted by MTLIndirectCommandBufferDescriptor.
+type MTLIndirectCommandType NSUInteger
+
+const (
+	MTLIndirectCommandTypeDrawIndexed MTLIndirectCommandType = 1 << 1
+)
+
 // MTLPixelFormat represents a pixel format.
 type MTLPixelFormat NSUInteger
 

--- a/indirect_count_integration_test.go
+++ b/indirect_count_integration_test.go
@@ -3,6 +3,7 @@
 package wgpu_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"math"
@@ -15,9 +16,21 @@ import (
 )
 
 const countedIndexedShader = `
+struct Params {
+    expected_instance: u32,
+    _padding: vec3<u32>,
+};
+
+@group(0) @binding(0)
+var<uniform> params: Params;
+
+@group(0) @binding(1)
+var<storage, read> shifts: array<f32>;
+
 @vertex
-fn vs_main(@location(0) pos: vec2<f32>) -> @builtin(position) vec4<f32> {
-    return vec4<f32>(pos, 0.0, 1.0);
+fn vs_main(@location(0) pos: vec2<f32>, @builtin(instance_index) instance: u32) -> @builtin(position) vec4<f32> {
+    let x = select(pos.x + 4.0, pos.x + shifts[0], instance == params.expected_instance);
+    return vec4<f32>(x, pos.y, 0.0, 1.0);
 }
 
 @fragment
@@ -26,7 +39,54 @@ fn fs_main() -> @location(0) vec4<f32> {
 }
 `
 
+const countedIndirectWriterShader = `
+@group(0) @binding(0)
+var<storage, read_write> args: array<u32>;
+
+@compute @workgroup_size(1)
+fn main() {
+    args[1] = 1u;
+    args[6] = 1u;
+}
+`
+
 func TestMultiDrawIndexedIndirectRendersDistinctRecords(t *testing.T) {
+	uint16Indices := []byte{0, 0, 1, 0, 2, 0, 2, 0, 3, 0, 0, 0}
+	uint32Indices := make([]byte, 4+6*4)
+	for i, index := range []uint32{0, 1, 2, 2, 3, 0} {
+		binary.LittleEndian.PutUint32(uint32Indices[4+i*4:], index)
+	}
+	for _, test := range []struct {
+		name        string
+		vertices    []float32
+		indices     []byte
+		format      gputypes.IndexFormat
+		indexOffset uint64
+		baseVertex  int32
+	}{
+		{
+			name:     "uint16",
+			vertices: []float32{-1, -1, 1, -1, 1, 1, -1, 1},
+			indices:  uint16Indices, format: gputypes.IndexFormatUint16,
+		},
+		{
+			name:     "uint32_nonzero_index_offset_base_vertex",
+			vertices: []float32{9, 9, -1, -1, 1, -1, 1, 1, -1, 1},
+			indices:  uint32Indices, format: gputypes.IndexFormatUint32, indexOffset: 4, baseVertex: 1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			icbPixels := runCountedIndexedICBCase(t, test.vertices, test.indices, test.format, test.indexOffset, test.baseVertex, false)
+			loopPixels := runCountedIndexedICBCase(t, test.vertices, test.indices, test.format, test.indexOffset, test.baseVertex, true)
+			if !bytes.Equal(icbPixels, loopPixels) {
+				t.Fatal("first-draw ICB pixels differ from later-draw loop oracle")
+			}
+		})
+	}
+}
+
+func runCountedIndexedICBCase(t *testing.T, vertices []float32, indexData []byte, indexFormat gputypes.IndexFormat, indexOffset uint64, baseVertex int32, forceLoop bool) []byte {
+	t.Helper()
 	instance, err := wgpu.CreateInstance(&wgpu.InstanceDescriptor{Backends: wgpu.BackendsPrimary})
 	if err != nil {
 		t.Skipf("CreateInstance: %v", err)
@@ -49,32 +109,85 @@ func TestMultiDrawIndexedIndirectRendersDistinctRecords(t *testing.T) {
 	defer device.Release()
 	queue := device.Queue()
 
-	vertices := []float32{-1, -1, 1, -1, 1, 1, -1, 1}
 	vertexData := make([]byte, len(vertices)*4)
 	for i, value := range vertices {
 		binary.LittleEndian.PutUint32(vertexData[i*4:], math.Float32bits(value))
 	}
-	indexData := []byte{0, 0, 1, 0, 2, 0, 2, 0, 3, 0, 0, 0}
-
-	// Four padding bytes make the starting offset observable. The two records
-	// select different triangles; both are required to fill the target.
-	indirectData := make([]byte, 4+2*20)
-	putCountedIndexedIndirectRecord(indirectData[4:], 3, 1, 0, 0, 0)
-	putCountedIndexedIndirectRecord(indirectData[24:], 3, 1, 3, 0, 0)
+	// Aligned padding makes the starting offset observable. The first two
+	// records select different triangles; the remaining zero-instance records
+	// keep the 1,024-command batch visually inert while exercising Metal's ICB
+	// threshold. A compute pass changes the first two instance counts from zero
+	// to one before the render pass, proving the translator consumes GPU-written
+	// arguments.
+	const drawCount = uint32(1024)
+	const argumentsOffset = uint64(256)
+	indirectData := make([]byte, argumentsOffset+uint64(drawCount)*20)
+	putCountedIndexedIndirectRecord(indirectData[argumentsOffset:], 3, 0, 0, baseVertex, 3)
+	putCountedIndexedIndirectRecord(indirectData[argumentsOffset+20:], 3, 0, 3, baseVertex, 3)
 
 	vertexBuffer := createCountedIndirectTestBuffer(t, device, queue, vertexData, wgpu.BufferUsageVertex|wgpu.BufferUsageCopyDst)
 	defer vertexBuffer.Release()
 	indexBuffer := createCountedIndirectTestBuffer(t, device, queue, indexData, wgpu.BufferUsageIndex|wgpu.BufferUsageCopyDst)
 	defer indexBuffer.Release()
-	indirectBuffer := createCountedIndirectTestBuffer(t, device, queue, indirectData, wgpu.BufferUsageIndirect|wgpu.BufferUsageCopyDst)
+	indirectBuffer := createCountedIndirectTestBuffer(t, device, queue, indirectData, wgpu.BufferUsageIndirect|wgpu.BufferUsageStorage|wgpu.BufferUsageCopyDst)
 	defer indirectBuffer.Release()
+
+	writerShader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{WGSL: countedIndirectWriterShader})
+	if err != nil {
+		t.Fatalf("CreateShaderModule(writer): %v", err)
+	}
+	defer writerShader.Release()
+	writerBGL, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{Entries: []wgpu.BindGroupLayoutEntry{{
+		Binding: 0, Visibility: wgpu.ShaderStageCompute,
+		Buffer: &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeStorage},
+	}}})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout(writer): %v", err)
+	}
+	defer writerBGL.Release()
+	writerLayout, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{BindGroupLayouts: []*wgpu.BindGroupLayout{writerBGL}})
+	if err != nil {
+		t.Fatalf("CreatePipelineLayout(writer): %v", err)
+	}
+	defer writerLayout.Release()
+	writerPipeline, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Layout: writerLayout, Module: writerShader, EntryPoint: "main",
+	})
+	if err != nil {
+		t.Fatalf("CreateComputePipeline(writer): %v", err)
+	}
+	defer writerPipeline.Release()
+	writerGroup, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Layout: writerBGL,
+		Entries: []wgpu.BindGroupEntry{{
+			Binding: 0, Buffer: indirectBuffer, Offset: argumentsOffset, Size: uint64(drawCount) * 20,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup(writer): %v", err)
+	}
+	defer writerGroup.Release()
 
 	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{WGSL: countedIndexedShader})
 	if err != nil {
 		t.Fatalf("CreateShaderModule: %v", err)
 	}
 	defer shader.Release()
-	layout, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{})
+	renderBGL, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{Entries: []wgpu.BindGroupLayoutEntry{
+		{
+			Binding: 0, Visibility: gputypes.ShaderStageVertex,
+			Buffer: &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeUniform, MinBindingSize: 16},
+		},
+		{
+			Binding: 1, Visibility: gputypes.ShaderStageVertex,
+			Buffer: &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeReadOnlyStorage, MinBindingSize: 4},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout(render): %v", err)
+	}
+	defer renderBGL.Release()
+	layout, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{BindGroupLayouts: []*wgpu.BindGroupLayout{renderBGL}})
 	if err != nil {
 		t.Fatalf("CreatePipelineLayout: %v", err)
 	}
@@ -105,6 +218,25 @@ func TestMultiDrawIndexedIndirectRendersDistinctRecords(t *testing.T) {
 	}
 	defer pipeline.Release()
 
+	uniformData := make([]byte, 16)
+	binary.LittleEndian.PutUint32(uniformData, 3)
+	storageData := make([]byte, 4)
+	renderUniform := createCountedIndirectTestBuffer(t, device, queue, uniformData, wgpu.BufferUsageUniform|wgpu.BufferUsageCopyDst)
+	defer renderUniform.Release()
+	renderStorage := createCountedIndirectTestBuffer(t, device, queue, storageData, wgpu.BufferUsageStorage|wgpu.BufferUsageCopyDst)
+	defer renderStorage.Release()
+	renderGroup, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Layout: renderBGL,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: renderUniform, Size: 16},
+			{Binding: 1, Buffer: renderStorage, Size: 4},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup(render): %v", err)
+	}
+	defer renderGroup.Release()
+
 	const width, height = uint32(64), uint32(16)
 	target, err := device.CreateTexture(&wgpu.TextureDescriptor{
 		Size:          wgpu.Extent3D{Width: width, Height: height, DepthOrArrayLayers: 1},
@@ -121,10 +253,35 @@ func TestMultiDrawIndexedIndirectRendersDistinctRecords(t *testing.T) {
 		t.Fatalf("CreateTextureView: %v", err)
 	}
 	defer targetView.Release()
+	clearOnlyTarget, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Size:          wgpu.Extent3D{Width: width, Height: 1, DepthOrArrayLayers: 1},
+		MipLevelCount: 1, SampleCount: 1, Dimension: gputypes.TextureDimension2D,
+		Format: gputypes.TextureFormatRGBA8Unorm,
+		Usage:  gputypes.TextureUsageRenderAttachment | gputypes.TextureUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture(clear-only): %v", err)
+	}
+	defer clearOnlyTarget.Release()
+	clearOnlyView, err := device.CreateTextureView(clearOnlyTarget, nil)
+	if err != nil {
+		t.Fatalf("CreateTextureView(clear-only): %v", err)
+	}
+	defer clearOnlyView.Release()
 
 	encoder, err := device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{})
 	if err != nil {
 		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	compute, err := encoder.BeginComputePass(&wgpu.ComputePassDescriptor{})
+	if err != nil {
+		t.Fatalf("BeginComputePass: %v", err)
+	}
+	compute.SetPipeline(writerPipeline)
+	compute.SetBindGroup(0, writerGroup, nil)
+	compute.Dispatch(1, 1, 1)
+	if err := compute.End(); err != nil {
+		t.Fatalf("ComputePass.End: %v", err)
 	}
 	pass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
 		ColorAttachments: []wgpu.RenderPassColorAttachment{{
@@ -136,19 +293,44 @@ func TestMultiDrawIndexedIndirectRendersDistinctRecords(t *testing.T) {
 		t.Fatalf("BeginRenderPass: %v", err)
 	}
 	pass.SetPipeline(pipeline)
+	pass.SetBindGroup(0, renderGroup, nil)
 	pass.SetVertexBuffer(0, vertexBuffer, 0)
-	pass.SetIndexBuffer(indexBuffer, gputypes.IndexFormatUint16, 0)
-	pass.MultiDrawIndexedIndirect(indirectBuffer, 4, 2)
+	pass.SetIndexBuffer(indexBuffer, indexFormat, indexOffset)
+	if forceLoop {
+		pass.Draw(0, 0, 0, 0)
+	}
+	pass.MultiDrawIndexedIndirect(indirectBuffer, argumentsOffset, drawCount)
 	if err := pass.End(); err != nil {
 		t.Fatalf("RenderPass.End: %v", err)
 	}
-	encoder.TransitionTextures([]wgpu.TextureBarrier{{
-		Texture: target,
-		Usage: wgpu.TextureUsageTransition{
-			OldUsage: gputypes.TextureUsageRenderAttachment,
-			NewUsage: gputypes.TextureUsageCopySrc,
+	clearOnlyPass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
+		ColorAttachments: []wgpu.RenderPassColorAttachment{{
+			View: clearOnlyView, LoadOp: gputypes.LoadOpClear, StoreOp: gputypes.StoreOpStore,
+			ClearValue: gputypes.Color{R: 1, G: 0.25, B: 0.5, A: 1},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("BeginRenderPass(clear-only): %v", err)
+	}
+	if err := clearOnlyPass.End(); err != nil {
+		t.Fatalf("RenderPass.End(clear-only): %v", err)
+	}
+	encoder.TransitionTextures([]wgpu.TextureBarrier{
+		{
+			Texture: target,
+			Usage: wgpu.TextureUsageTransition{
+				OldUsage: gputypes.TextureUsageRenderAttachment,
+				NewUsage: gputypes.TextureUsageCopySrc,
+			},
 		},
-	}})
+		{
+			Texture: clearOnlyTarget,
+			Usage: wgpu.TextureUsageTransition{
+				OldUsage: gputypes.TextureUsageRenderAttachment,
+				NewUsage: gputypes.TextureUsageCopySrc,
+			},
+		},
+	})
 
 	readbackSize := uint64(width * height * 4)
 	readback, err := device.CreateBuffer(&wgpu.BufferDescriptor{
@@ -163,6 +345,18 @@ func TestMultiDrawIndexedIndirectRendersDistinctRecords(t *testing.T) {
 		TextureBase:  wgpu.ImageCopyTexture{Texture: target},
 		Size:         wgpu.Extent3D{Width: width, Height: height, DepthOrArrayLayers: 1},
 	}})
+	clearOnlyReadback, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Size: uint64(width * 4), Usage: gputypes.BufferUsageMapRead | gputypes.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer(clear-only readback): %v", err)
+	}
+	defer clearOnlyReadback.Release()
+	encoder.CopyTextureToBuffer(clearOnlyTarget, clearOnlyReadback, []wgpu.BufferTextureCopy{{
+		BufferLayout: wgpu.ImageDataLayout{BytesPerRow: width * 4, RowsPerImage: 1},
+		TextureBase:  wgpu.ImageCopyTexture{Texture: clearOnlyTarget},
+		Size:         wgpu.Extent3D{Width: width, Height: 1, DepthOrArrayLayers: 1},
+	}})
 
 	commands, err := encoder.Finish()
 	if err != nil {
@@ -170,6 +364,22 @@ func TestMultiDrawIndexedIndirectRendersDistinctRecords(t *testing.T) {
 	}
 	if _, err := queue.Submit(commands); err != nil {
 		t.Fatalf("Submit: %v", err)
+	}
+	clearMapContext, cancelClearMap := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelClearMap()
+	if err := clearOnlyReadback.Map(clearMapContext, wgpu.MapModeRead, 0, uint64(width*4)); err != nil {
+		t.Fatalf("Map(clear-only readback): %v", err)
+	}
+	clearMapped, err := clearOnlyReadback.MappedRange(0, uint64(width*4))
+	if err != nil {
+		t.Fatalf("MappedRange(clear-only readback): %v", err)
+	}
+	clearPixel := clearMapped.Bytes()[:4]
+	if clearPixel[0] < 250 || clearPixel[1] < 60 || clearPixel[1] > 68 || clearPixel[2] < 124 || clearPixel[2] > 132 || clearPixel[3] < 250 {
+		t.Fatalf("clear-only pass pixel = %v, want approximately [255 64 128 255]", clearPixel)
+	}
+	if err := clearOnlyReadback.Unmap(); err != nil {
+		t.Fatalf("Unmap(clear-only readback): %v", err)
 	}
 	mapContext, cancelMap := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancelMap()
@@ -182,6 +392,7 @@ func TestMultiDrawIndexedIndirectRendersDistinctRecords(t *testing.T) {
 		t.Fatalf("MappedRange: %v", err)
 	}
 	pixels := mapped.Bytes()
+	result := append([]byte(nil), pixels...)
 	filled := 0
 	for pixel := 0; pixel < int(width*height); pixel++ {
 		if pixels[pixel*4+1] > 128 {
@@ -194,6 +405,7 @@ func TestMultiDrawIndexedIndirectRendersDistinctRecords(t *testing.T) {
 	if minimum := int(width*height) * 3 / 4; filled < minimum {
 		t.Fatalf("counted indexed indirect filled %d/%d pixels, want at least %d; both records did not render", filled, width*height, minimum)
 	}
+	return result
 }
 
 func createCountedIndirectTestBuffer(t *testing.T, device *wgpu.Device, queue *wgpu.Queue, data []byte, usage wgpu.BufferUsage) *wgpu.Buffer {

--- a/metal_icb_benchmark_test.go
+++ b/metal_icb_benchmark_test.go
@@ -1,0 +1,190 @@
+//go:build integration && darwin && !rust && !(js && wasm)
+
+package wgpu_test
+
+import (
+	"encoding/binary"
+	"runtime"
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+	_ "github.com/gogpu/wgpu/hal/metal"
+)
+
+const metalICBBenchmarkShader = `
+@vertex
+fn vs_main(@location(0) pos: vec2<f32>) -> @builtin(position) vec4<f32> {
+    return vec4<f32>(pos, 0.0, 1.0);
+}
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.0, 1.0, 0.0, 1.0);
+}
+`
+
+func BenchmarkMetalIndexedFrame(b *testing.B) {
+	for _, test := range []struct {
+		name      string
+		count     uint32
+		forceLoop bool
+	}{
+		{name: "direct"},
+		{name: "count_1", count: 1},
+		{name: "count_20", count: 20},
+		{name: "count_1024", count: 1024},
+		{name: "count_1024_loop", count: 1024, forceLoop: true},
+		{name: "count_10000", count: 10000},
+		{name: "count_10000_loop", count: 10000, forceLoop: true},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			benchmarkMetalIndexedFrame(b, test.count, test.forceLoop)
+		})
+	}
+}
+
+func benchmarkMetalIndexedFrame(b *testing.B, count uint32, forceLoop bool) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	instance, err := wgpu.CreateInstance(&wgpu.InstanceDescriptor{Backends: wgpu.BackendsPrimary})
+	if err != nil {
+		b.Skipf("CreateInstance: %v", err)
+	}
+	defer instance.Release()
+	adapter, err := instance.RequestAdapter(nil)
+	if err != nil {
+		b.Skipf("RequestAdapter: %v", err)
+	}
+	defer adapter.Release()
+	if info := adapter.Info(); info.Backend != gputypes.BackendMetal {
+		b.Skipf("native Metal adapter unavailable: %+v", info)
+	}
+	device, err := adapter.RequestDevice(nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer device.Release()
+	queue := device.Queue()
+
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{WGSL: metalICBBenchmarkShader})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer shader.Release()
+	layout, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer layout.Release()
+	pipeline, err := device.CreateRenderPipeline(&wgpu.RenderPipelineDescriptor{
+		Layout: layout,
+		Vertex: wgpu.VertexState{
+			Module: shader, EntryPoint: "vs_main",
+			Buffers: []gputypes.VertexBufferLayout{{
+				ArrayStride: 8,
+				Attributes:  []gputypes.VertexAttribute{{Format: gputypes.VertexFormatFloat32x2}},
+			}},
+		},
+		Fragment: &wgpu.FragmentState{
+			Module: shader, EntryPoint: "fs_main",
+			Targets: []gputypes.ColorTargetState{{
+				Format: gputypes.TextureFormatRGBA8Unorm, WriteMask: gputypes.ColorWriteMaskAll,
+			}},
+		},
+		Primitive:   gputypes.PrimitiveState{Topology: gputypes.PrimitiveTopologyTriangleList},
+		Multisample: gputypes.MultisampleState{Count: 1, Mask: 0xFFFFFFFF},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer pipeline.Release()
+
+	vertex := benchmarkMetalBuffer(b, device, queue, make([]byte, 3*8), wgpu.BufferUsageVertex|wgpu.BufferUsageCopyDst)
+	defer vertex.Release()
+	index := benchmarkMetalBuffer(b, device, queue, make([]byte, 8), wgpu.BufferUsageIndex|wgpu.BufferUsageCopyDst)
+	defer index.Release()
+	argumentCount := max(count, 1)
+	arguments := make([]byte, uint64(argumentCount)*20)
+	for i := uint32(0); i < count; i++ {
+		binary.LittleEndian.PutUint32(arguments[uint64(i)*20:], 3)
+	}
+	indirect := benchmarkMetalBuffer(b, device, queue, arguments, wgpu.BufferUsageIndirect|wgpu.BufferUsageCopyDst)
+	defer indirect.Release()
+	target, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Size:          wgpu.Extent3D{Width: 1, Height: 1, DepthOrArrayLayers: 1},
+		MipLevelCount: 1, SampleCount: 1, Dimension: gputypes.TextureDimension2D,
+		Format: gputypes.TextureFormatRGBA8Unorm,
+		Usage:  gputypes.TextureUsageRenderAttachment,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer target.Release()
+	view, err := device.CreateTextureView(target, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer view.Release()
+
+	frame := func() {
+		encoder, err := device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{})
+		if err != nil {
+			b.Fatal(err)
+		}
+		pass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
+			ColorAttachments: []wgpu.RenderPassColorAttachment{{
+				View: view, LoadOp: gputypes.LoadOpClear, StoreOp: gputypes.StoreOpStore,
+			}},
+		})
+		if err != nil {
+			b.Fatal(err)
+		}
+		pass.SetPipeline(pipeline)
+		pass.SetVertexBuffer(0, vertex, 0)
+		pass.SetIndexBuffer(index, gputypes.IndexFormatUint16, 0)
+		if count == 0 {
+			pass.DrawIndexed(3, 1, 0, 0, 0)
+		} else {
+			if forceLoop {
+				pass.Draw(0, 0, 0, 0)
+			}
+			pass.MultiDrawIndexedIndirect(indirect, 0, count)
+		}
+		if err := pass.End(); err != nil {
+			b.Fatal(err)
+		}
+		commands, err := encoder.Finish()
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := queue.Submit(commands); err != nil {
+			b.Fatal(err)
+		}
+		if err := device.WaitIdle(); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	for range 5 {
+		frame()
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		frame()
+	}
+}
+
+func benchmarkMetalBuffer(b *testing.B, device *wgpu.Device, queue *wgpu.Queue, data []byte, usage wgpu.BufferUsage) *wgpu.Buffer {
+	b.Helper()
+	buffer, err := device.CreateBuffer(&wgpu.BufferDescriptor{Size: uint64(len(data)), Usage: usage})
+	if err != nil {
+		b.Fatal(err)
+	}
+	if err := queue.WriteBuffer(buffer, 0, data); err != nil {
+		buffer.Release()
+		b.Fatal(err)
+	}
+	return buffer
+}


### PR DESCRIPTION
## Stack and review order

This is a **stacked PR** built on the current head of #253 (`1953452`) and is ready for review. Please approve the prerequisite PRs before this one.

Please review and land the stack in this order:

1. #258
2. #253
3. this PR

Until #253 lands, GitHub shows its commits in this PR's diff because its head branch is in a fork and cannot be selected as an upstream base. After the prerequisites settle, this branch will be rebased onto `main` and the verification below rerun.

## What changed

- Delay Metal render-command-encoder creation until the first draw while retaining bounded, latest-value pre-draw state. Clear/store/resolve-only passes still instantiate at pass end.
- Privately mark eligible buffer-only triangle pipelines as ICB-compatible. A rejected flagged pipeline transparently retries ordinary creation.
- Translate a profitable first indexed multi-draw into one bounded Metal indirect command buffer with one compute dispatch and one ICB execution.
- Retain every ICB-referenced argument, index, vertex, and bound buffer through command-buffer completion, with once-only cleanup across completion, discard, setup failure, and teardown.
- Preserve the exact #253 loop for count zero, small or oversized counts, later draws, non-indexed draws, incompatible pipelines, writable storage bindings, unsupported devices, and every preflight failure.

## Scope

The optimization is entirely private to `hal/metal`. It adds no public feature, flag, token, prepared-command API, or caller-managed lifetime. Metal feature reporting remains unchanged.

The initial eligibility policy is intentionally narrow:

- Apple7-family support or later, with runtime selector checks
- first draw in the pass
- triangle-list indexed draw
- 1,024 through 52,428 commands
- buffer-only pipeline with no writable storage binding

## Verification

- `CGO_ENABLED=0 go test ./...`
- focused Metal unit tests and race tests
- native Metal pixel/readback parity for uint16 and uint32 indices, non-zero argument/index offsets, `baseVertex`, `firstInstance`, GPU-written indirect arguments, bound uniform/read-only-storage buffers, first-vs-later execution, and clear-only passes
- Linux amd64 and Windows amd64 cgo-free builds
- Rust-tag build
- browser/WASM root build and browser-package compile
- `git diff --check` and formatting checks

Paired Apple M1 complete-frame benchmarks against the exact #253 base measured median improvements of about 19% at 1,024 commands and 60% at 10,000 commands. Direct, count-1, and count-20 controls stayed within the 5% time/allocation gate in the stable paired run.
