### PR TITLE
docs(android): reconcile preview integration after #273

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ CGO_ENABLED=0 go build
 > **Note:** wgpu uses Pure Go FFI via [goffi](https://github.com/go-webgpu/goffi). Both `CGO_ENABLED=0` (default, zero C compiler dependency) and `CGO_ENABLED=1` (for race detector or coexistence with CGO libraries) are supported.
 
 The unreleased Android/arm64 Vulkan implementation is documented separately in
-[Android Vulkan preview](docs/ANDROID.md). It requires the exact canonical
-goffi candidate named there and is not yet a released support claim.
+[Android Vulkan preview](docs/ANDROID.md). It consumes canonical goffi v0.6.1
+and is not yet a released support claim; the optional Rust path temporarily
+pins the exact merged WebGPU Android source until that dependency is released.
 
 New surface integrations should use the explicit safe or unsafe target API
 described in [Surface targets](docs/SURFACE-TARGETS.md). The original

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -1,10 +1,13 @@
 # Android Vulkan preview
 
-Android/arm64 support is an unreleased implementation preview in
-[gogpu/wgpu#268](https://github.com/gogpu/wgpu/pull/268), not a released support
-claim. Its current scope is Vulkan, arm64, Android API 29 or newer, and both
-`CGO_ENABLED=0` and `CGO_ENABLED=1`. GLES, software fallback, 32-bit Android,
-debug callbacks, and API 28 or older are out of scope.
+Android/arm64 support is an unreleased implementation preview on WGPU `main`,
+not a released support claim. It landed in
+[gogpu/wgpu#273](https://github.com/gogpu/wgpu/pull/273), whose squash included
+the Android WSI work prepared and discussed in
+[gogpu/wgpu#268](https://github.com/gogpu/wgpu/pull/268). Its current scope is
+Vulkan, arm64, Android API 29 or newer, and both `CGO_ENABLED=0` and
+`CGO_ENABLED=1`. GLES, software fallback, 32-bit Android, debug callbacks, and
+API 28 or older are out of scope.
 
 The default backend consumes canonical
 [goffi v0.6.1](https://github.com/go-webgpu/goffi/releases/tag/v0.6.1), released
@@ -81,22 +84,20 @@ filter. The canonical backend's existing application-version request remains
 unchanged; actual extensions, commands, features, and device evidence decide
 whether a Vulkan implementation works.
 
-## Merge order
+## Integration status
 
-The Android Vulkan work remains in
-[wgpu#268](https://github.com/gogpu/wgpu/pull/268). This typed-surface change is
-best reviewed and merged after #268. Its five WGPU prerequisites (#264, #265,
-#266, #267, and #269), goffi#62/v0.6.1, and webgpu#24 are merged. This branch is
-rebased onto the resulting WGPU `main`, so none of those five WGPU prerequisite
-commits are replayed here. Until #268 lands, its Android-owned commits remain
-below this PR's typed-target commits; they can be dropped in one final rebase
-without changing the public design.
+The five WGPU prerequisites (#264, #265, #266, #267, and #269), goffi#62/v0.6.1,
+webgpu#24, and typed-surface PR #273 are merged. The #273 squash also included
+the Android-owned commits originally carried by #268, so WGPU `main` already
+contains both the Vulkan WSI implementation and the typed public/HAL surface
+API. PR #268 remains the implementation's design and review record rather than
+a code dependency.
 
 [wgpu#253](https://github.com/gogpu/wgpu/pull/253) is the design precedent for
 matching Rust's typed public/HAL seam; it is not a code dependency of Android.
-The default Vulkan path needs #268 and goffi v0.6.1. The `rust` build-tag path
-needs the canonical `go-webgpu/webgpu` helper as well. No WGPU-local copy of
-that helper should be merged.
+The default Vulkan path uses goffi v0.6.1. The `rust` build-tag path needs the
+canonical `go-webgpu/webgpu` helper as well. No WGPU-local copy of that helper
+should be added.
 
 ## Reproducing deterministic proof
 
@@ -126,9 +127,8 @@ These are deterministic cross-build and binary-shape checks. They do not prove
 process startup, adapter enumeration, surface creation, rendering,
 presentation, rotation, or lifecycle recovery on a physical device.
 
-Before the preview can become a released support claim, the canonical
-`go-webgpu/webgpu` helper and the WGPU prerequisites must merge and ship through
-canonical refs; #268 must rebase to Android-only commits; and API 29 plus API
-36 arm64 devices must pass startup, known-color presentation, rotation,
-Activity recreation, and repeated native-window replacement without crashes,
-hangs, stale frames, or validation errors.
+Before the preview can become a released support claim, this WGPU integration
+and a canonical `go-webgpu/webgpu` release containing the Android helper must
+ship; API 29 plus API 36 arm64 devices must also pass startup, known-color
+presentation, rotation, Activity recreation, and repeated native-window
+replacement without crashes, hangs, stale frames, or validation errors.

--- a/docs/SURFACE-TARGETS.md
+++ b/docs/SURFACE-TARGETS.md
@@ -10,9 +10,9 @@ target and ownership mode explicitly.
 ## Exhaustive API mapping
 
 This map covers every exported production symbol added or behaviorally changed
-by this follow-up relative to PR #268. Test-only declarations are excluded.
-Build-tagged implementations of the same package selector are one logical Go
-symbol. The Rust references are the pinned v29.0.3 sources for
+by the typed-surface integration in PR #273. Test-only declarations are
+excluded. Build-tagged implementations of the same package selector are one
+logical Go symbol. The Rust references are the pinned v29.0.3 sources for
 [`Instance::create_surface`](https://github.com/gfx-rs/wgpu/blob/4cbe6232b2d7c289b6e1a38416a6ae1461a22e81/wgpu/src/api/instance.rs#L175-L280),
 [`SurfaceTarget` and `SurfaceTargetUnsafe`](https://github.com/gfx-rs/wgpu/blob/4cbe6232b2d7c289b6e1a38416a6ae1461a22e81/wgpu/src/api/surface.rs#L254-L458),
 and [core surface creation](https://github.com/gfx-rs/wgpu/blob/4cbe6232b2d7c289b6e1a38416a6ae1461a22e81/wgpu-core/src/instance.rs#L218-L290).


### PR DESCRIPTION
## Status

Ready to merge at exact head `3a7acf9fa217db2ee2bfd3d7b5223de66f47df30`, directly on current WGPU `main` (`93fb27ff7ad717943e870580892b7490961a3ab7`). The PR is conflict-free and GitHub reports `MERGEABLE` / `CLEAN`. [CI run 30080220791](https://github.com/gogpu/wgpu/actions/runs/30080220791) is fully green, including both Android arm64 jobs.

## Rebase result

While resolving the requested rebase, I found that [#273](https://github.com/gogpu/wgpu/pull/273) had been squash-merged with the complete #268 Android stack still below its typed-surface commits. Its merge commit `93fb27ff7ad717943e870580892b7490961a3ab7` explicitly includes:

- `feat(vulkan): add Android arm64 WSI parity`;
- `ci(android): prove arm64 preview boundaries`;
- `docs(android): define the Vulkan preview contract`;
- `test(android): cover API 36 platform policy`; and
- `build(android): consume canonical goffi v0.6.1`.

I verified the result at the tree level: every file changed by #268's Android-owned range (`0eb4143..13b59db`) is byte-identical between the old #268 head and current `main`. Replaying those commits would therefore duplicate code that is already merged rather than produce a reviewable Android delta.

The clean rebase is consequently current `main` plus one focused documentation reconciliation commit. This preserves #268 as the original design/review record without manufacturing a duplicate implementation diff.

## What this PR now changes

- records that the Android Vulkan preview is already present on WGPU `main` through #273;
- removes obsolete prerequisite/rebase instructions;
- records canonical goffi v0.6.1 as the default backend dependency;
- keeps the optional Rust path pinned to the exact merged webgpu#24 source until a canonical release contains it; and
- keeps the API 29/API 36 physical-device matrix as an explicit release-evidence gate.

## Implementation review location

The Android implementation to review is now in [merge commit `93fb27f`](https://github.com/gogpu/wgpu/commit/93fb27ff7ad717943e870580892b7490961a3ab7), with the design, ownership, API-floor, and evidence discussion retained in this PR. The relevant implementation remains in `hal/vulkan/*android*`, `hal/vulkan/swapchain*`, `hal/allbackends/register_android.go`, and `scripts/check-android-arm64-preview.sh`.

## Verification

All current GitHub checks pass:

- Android arm64 preview with Go 1.25.12 and Go 1.26.5;
- Linux, macOS, and Windows build and test;
- lint, formatting, dependencies, and GLES/EGL integration.

Focused local verification also passed:

```bash
CGO_ENABLED=0 GOWORK=off go list ./... | grep -v '/hal/metal$' | xargs env CGO_ENABLED=0 GOWORK=off go test -count=1
CGO_ENABLED=0 GOWORK=off go list -tags rust ./... | grep -v '/hal/metal$' | xargs env CGO_ENABLED=0 GOWORK=off go test -count=1 -tags rust
GOOS=android GOARCH=arm64 CGO_ENABLED=0 GOWORK=off go test -run '^$' -exec=true ./...
```

The historical Codecov bot comment predates this rebase and describes the old replay stack. The current PR changes documentation only and introduces no coverable Go lines.

Cross-build and binary-shape proof still do not substitute for representative hardware. API 29 and API 36 arm64 startup, known-color presentation, rotation, Activity recreation, repeated native-window replacement, and representative vendor/device coverage remain release-evidence gates rather than claims made here.

