### PR TITLE
fix(software): CopyTextureToBuffer + blend state + BGRA readTexel (v0.30.21)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 
 ## Current Version
 
-v0.30.20 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.1, gputypes v0.5.1, goffi v0.6.0, webgpu v0.5.3
+v0.30.21 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.1, gputypes v0.5.1, goffi v0.6.0, webgpu v0.5.3
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.21] - 2026-07-15
+
+### Fixed
+
+- **Software `CopyTextureToBuffer` row stride** — row-by-row copy respecting
+  `BytesPerRow` from `BufferLayout`. Was flat `copy(dst, src)` ignoring row
+  alignment, causing progressive row shift (128 bytes/row at 800px width)
+  that produced horizontal dashed-line artifacts in GPU texture readback.
+
+- **Software `configureRasterPipeline` blend state** — extract blend state from
+  `Fragment.Targets[0].Blend` into the raster pipeline. Was always `BlendDisabled`,
+  preventing premultiplied alpha compositing for textured quads. Added
+  `convertBlendState`, `convertBlendFactor`, `convertBlendOp` conversion functions.
+
+- **Software `readTexel` BGRA format** — swap R/B channels when sampling textures
+  with `BGRA8Unorm` or `BGRA8UnormSrgb` format. Was always reading as RGBA,
+  causing red/blue channel swap for offscreen BGRA textures.
+
 ## [0.30.20] - 2026-07-14
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.30.14
+## Current State: v0.30.21
 
 ✅ **Triple-backend architecture (ADR-038)** — Native Go, Rust FFI, Browser WASM via build tags
 ✅ **All 5 Native HAL backends complete** (~127K LOC)
@@ -84,6 +84,13 @@
 ✅ **GLES GLSL version propagation (Rust parity)** — detected `GL_SHADING_LANGUAGE_VERSION` flows from adapter → device → naga GLSL writer. No more hardcoded `#version 430`. Runtime binding fallback (`glGetUniformBlockIndex` + `glUniformBlockBinding` + `glUniform1i`) for GL < 4.2 where `layout(binding=N)` unavailable. `shaderBindingLayout` capability flag (Rust `SHADER_BINDING_LAYOUT` parity). Triangle verified on WSL2 Mesa d3d12 GL 4.1.
 ✅ **Wayland SHM presentation (enterprise quality)** — display wrapper pattern (Qt6 parity), `wl_display_roundtrip_queue`, proper proxy cleanup, triple-buffer freeze fix (bufferBusyMap pointer + roundtrip_queue dispatch). Verified on WSL2.
 ✅ **Codecov OIDC** — replaced token + GPG verification with GitHub OIDC. No more intermittent CI failures from GPG keyserver.
+✅ **PresentPixels check-before-mutate** — validate `hal.PixelPresenter` before discarding acquired texture. Rust wgpu validate-then-mutate pattern (v0.30.20)
+✅ **DX12 UMA GPU classification** — `CheckFeatureSupport(D3D12_FEATURE_ARCHITECTURE)` replaces VRAM heuristic. Exact Rust wgpu parity. CacheCoherentUMA stored for future memory pool optimization (v0.30.20, @Zeroes1)
+✅ **goffi v0.6.0 — ADR-049 three-tier FFI error handling** — 764 call sites migrated. Tier 1 (creation): check error. Tier 2 (void/hot path): infallible by GPU spec. Tier 3 (Wayland syscalls): errno diagnostics. Enterprise research: Rust wgpu-hal, Mesa, ash (v0.30.17)
+✅ **vk-gen enterprise improvements** — C array params decay to pointers, deterministic output (sorted map keys), auto-gofmt via go/format, correct build tag (v0.30.18)
+✅ **Software CopyTextureToBuffer row stride** — row-by-row copy respecting BytesPerRow (v0.30.21)
+✅ **Software blend state wiring** — extract blend from Fragment.Targets into raster pipeline (v0.30.21)
+✅ **Software BGRA readTexel** — R/B channel swap for BGRA8Unorm/Srgb textures (v0.30.21)
 
 ### Remaining validation (planned)
 - **Phase C** (P2): Spec compliance edge cases, feature gates
@@ -184,6 +191,10 @@ Target: stable, documented, conformant WebGPU implementation in Pure Go.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.30.21** | 2026-07 | Software: CopyTextureToBuffer row stride, blend state wiring, BGRA readTexel |
+| **v0.30.20** | 2026-07 | PresentPixels check-before-mutate + DX12 UMA classification (@Zeroes1 #254) |
+| **v0.30.17-19** | 2026-07 | goffi v0.6.0 ADR-049 (764 FFI call sites), vk-gen array params + deterministic output, webgpu v0.5.3 |
+| **v0.30.15** | 2026-07 | PresentPixels/WritePixels 3-layer API, software blit debug cleanup |
 | **v0.30.0** | 2026-06 | **BREAKING: Unified public API (ADR-047).** StencilOperation→gputypes, Device.released→atomic.Bool, sentinel methods, MinBindGroups, CopyBufferToTexture+ClearBuffer native, browser fence stubs, browser-compute example. |
 | **v0.29.16** | 2026-06 | HAL wrapper stubs for Rust/Browser builds — public API compiles on all build targets. README updated. |
 | **v0.29.15** | 2026-06 | naga v0.17.15 (HLSL sampler fix, @georgebuilds), x/sys v0.46.0. |

--- a/hal/software/command.go
+++ b/hal/software/command.go
@@ -123,12 +123,26 @@ func (c *CommandEncoder) CopyTextureToBuffer(src hal.Texture, dst hal.Buffer, re
 		srcTex.mu.RLock()
 		dstBuf.mu.Lock()
 
-		offset := region.BufferLayout.Offset
 		bpp := formatBytesPerPixel(srcTex.format)
-		size := uint64(region.Size.Width) * uint64(region.Size.Height) * uint64(region.Size.DepthOrArrayLayers) * bpp
+		srcBytesPerRow := uint64(region.Size.Width) * bpp
+		dstBytesPerRow := uint64(region.BufferLayout.BytesPerRow)
+		if dstBytesPerRow == 0 {
+			dstBytesPerRow = srcBytesPerRow
+		}
 
-		if size <= uint64(len(srcTex.data)) && offset+size <= uint64(len(dstBuf.data)) {
-			copy(dstBuf.data[offset:offset+size], srcTex.data[:size])
+		dstOffset := region.BufferLayout.Offset
+		srcOffset := (uint64(region.TextureBase.Origin.Y)*uint64(srcTex.width) + uint64(region.TextureBase.Origin.X)) * bpp
+		srcStride := uint64(srcTex.width) * bpp
+
+		for row := uint32(0); row < region.Size.Height; row++ {
+			srcStart := srcOffset + uint64(row)*srcStride
+			srcEnd := srcStart + srcBytesPerRow
+			dstStart := dstOffset + uint64(row)*dstBytesPerRow
+			dstEnd := dstStart + srcBytesPerRow
+
+			if srcEnd <= uint64(len(srcTex.data)) && dstEnd <= uint64(len(dstBuf.data)) {
+				copy(dstBuf.data[dstStart:dstEnd], srcTex.data[srcStart:srcEnd])
+			}
 		}
 
 		dstBuf.mu.Unlock()

--- a/hal/software/draw.go
+++ b/hal/software/draw.go
@@ -1388,9 +1388,10 @@ func clampBlitBounds(minX, minY, maxX, maxY int, scissor [4]uint32) (int, int, i
 	return minX, minY, maxX, maxY
 }
 
-// configureRasterPipeline applies scissor, depth, and stencil state from the
-// command encoder to a newly created raster.Pipeline. This is the single point
-// where WebGPU render pass state is translated to the raster package's config.
+// configureRasterPipeline applies scissor, depth, stencil, and blend state
+// from the command encoder to a newly created raster.Pipeline. This is the
+// single point where WebGPU render pass state is translated to the raster
+// package's config.
 func (r *RenderPassEncoder) configureRasterPipeline(pipe *raster.Pipeline) {
 	// Scissor: clip fragments to the scissor rectangle set by SetScissorRect.
 	if r.hasScissor {
@@ -1402,8 +1403,19 @@ func (r *RenderPassEncoder) configureRasterPipeline(pipe *raster.Pipeline) {
 		})
 	}
 
+	if r.pipeline == nil || r.pipeline.desc == nil {
+		return
+	}
+
+	// Blend state from the first fragment target.
+	if frag := r.pipeline.desc.Fragment; frag != nil && len(frag.Targets) > 0 {
+		if blend := frag.Targets[0].Blend; blend != nil {
+			pipe.SetBlendState(convertBlendState(blend))
+		}
+	}
+
 	// Depth and stencil state from the render pipeline descriptor.
-	if r.pipeline == nil || r.pipeline.desc == nil || r.pipeline.desc.DepthStencil == nil {
+	if r.pipeline.desc.DepthStencil == nil {
 		return
 	}
 	ds := r.pipeline.desc.DepthStencil
@@ -1497,5 +1509,70 @@ func convertStencilOp(op hal.StencilOperation) raster.StencilOp {
 		return raster.StencilOpDecrementWrap
 	default: // Keep or undefined
 		return raster.StencilOpKeep
+	}
+}
+
+// convertBlendState maps a gputypes.BlendState to raster.BlendState.
+func convertBlendState(bs *gputypes.BlendState) raster.BlendState {
+	return raster.BlendState{
+		Enabled:  true,
+		SrcColor: convertBlendFactor(bs.Color.SrcFactor),
+		DstColor: convertBlendFactor(bs.Color.DstFactor),
+		ColorOp:  convertBlendOp(bs.Color.Operation),
+		SrcAlpha: convertBlendFactor(bs.Alpha.SrcFactor),
+		DstAlpha: convertBlendFactor(bs.Alpha.DstFactor),
+		AlphaOp:  convertBlendOp(bs.Alpha.Operation),
+	}
+}
+
+// convertBlendFactor maps gputypes.BlendFactor to raster.BlendFactor.
+func convertBlendFactor(f gputypes.BlendFactor) raster.BlendFactor {
+	switch f {
+	case gputypes.BlendFactorZero:
+		return raster.BlendFactorZero
+	case gputypes.BlendFactorOne:
+		return raster.BlendFactorOne
+	case gputypes.BlendFactorSrc:
+		return raster.BlendFactorSrc
+	case gputypes.BlendFactorOneMinusSrc:
+		return raster.BlendFactorOneMinusSrc
+	case gputypes.BlendFactorSrcAlpha:
+		return raster.BlendFactorSrcAlpha
+	case gputypes.BlendFactorOneMinusSrcAlpha:
+		return raster.BlendFactorOneMinusSrcAlpha
+	case gputypes.BlendFactorDst:
+		return raster.BlendFactorDst
+	case gputypes.BlendFactorOneMinusDst:
+		return raster.BlendFactorOneMinusDst
+	case gputypes.BlendFactorDstAlpha:
+		return raster.BlendFactorDstAlpha
+	case gputypes.BlendFactorOneMinusDstAlpha:
+		return raster.BlendFactorOneMinusDstAlpha
+	case gputypes.BlendFactorSrcAlphaSaturated:
+		return raster.BlendFactorSrcAlphaSaturated
+	case gputypes.BlendFactorConstant:
+		return raster.BlendFactorConstant
+	case gputypes.BlendFactorOneMinusConstant:
+		return raster.BlendFactorOneMinusConstant
+	default:
+		return raster.BlendFactorOne
+	}
+}
+
+// convertBlendOp maps gputypes.BlendOperation to raster.BlendOperation.
+func convertBlendOp(op gputypes.BlendOperation) raster.BlendOperation {
+	switch op {
+	case gputypes.BlendOperationAdd:
+		return raster.BlendOpAdd
+	case gputypes.BlendOperationSubtract:
+		return raster.BlendOpSubtract
+	case gputypes.BlendOperationReverseSubtract:
+		return raster.BlendOpReverseSubtract
+	case gputypes.BlendOperationMin:
+		return raster.BlendOpMin
+	case gputypes.BlendOperationMax:
+		return raster.BlendOpMax
+	default:
+		return raster.BlendOpAdd
 	}
 }

--- a/hal/software/shader/interpreter.go
+++ b/hal/software/shader/interpreter.go
@@ -21,6 +21,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+
+	"github.com/gogpu/gputypes"
 )
 
 // Execute runs the named entry point with the given input variable values.
@@ -1962,7 +1964,8 @@ func sampleBilinear(tex *Texture2D, u, v float32) Vec4 {
 }
 
 // readTexel reads a single texel from the texture at pixel coordinates (x, y),
-// unpacking it to RGBA according to the texture's bytes-per-pixel. Single- and
+// unpacking it to RGBA according to the texture's bytes-per-pixel and format.
+// BGRA formats swap R and B channels to return normalized RGBA. Single- and
 // two-channel formats follow the WebGPU convention of filling missing color
 // channels with 0 and alpha with 1. A zero BytesPerPixel means "unspecified"
 // and is treated as 4 (RGBA8) for backward compatibility.
@@ -1981,6 +1984,14 @@ func readTexel(tex *Texture2D, x, y int) Vec4 {
 	case 2:
 		return Vec4{float32(tex.Data[idx]) / 255.0, float32(tex.Data[idx+1]) / 255.0, 0, 1}
 	default:
+		if isBGRAFormat(tex.Format) {
+			return Vec4{
+				float32(tex.Data[idx+2]) / 255.0,
+				float32(tex.Data[idx+1]) / 255.0,
+				float32(tex.Data[idx+0]) / 255.0,
+				float32(tex.Data[idx+3]) / 255.0,
+			}
+		}
 		return Vec4{
 			float32(tex.Data[idx+0]) / 255.0,
 			float32(tex.Data[idx+1]) / 255.0,
@@ -1988,6 +1999,11 @@ func readTexel(tex *Texture2D, x, y int) Vec4 {
 			float32(tex.Data[idx+3]) / 255.0,
 		}
 	}
+}
+
+// isBGRAFormat returns true if the format stores bytes in BGRA order.
+func isBGRAFormat(format uint32) bool {
+	return format == uint32(gputypes.TextureFormatBGRA8Unorm) || format == uint32(gputypes.TextureFormatBGRA8UnormSrgb)
 }
 
 // clampInt clamps an integer to [0, hi].


### PR DESCRIPTION
## Summary

### Fixed

- **Software `CopyTextureToBuffer` row stride** — row-by-row copy respecting `BytesPerRow` from `BufferLayout`. Was flat `copy(dst, src)` ignoring row alignment.

- **Software `configureRasterPipeline` blend state** — extract blend state from `Fragment.Targets[0].Blend` into the raster pipeline. Was always `BlendDisabled`. Added `convertBlendState`, `convertBlendFactor`, `convertBlendOp`.

- **Software `readTexel` BGRA format** — swap R/B channels for `BGRA8Unorm` / `BGRA8UnormSrgb`. Replaced hardcoded magic numbers with `gputypes` imports.

## Test plan

- [x] `go build ./...` — all platforms
- [x] `go test ./...` — 15/15 pass
- [x] `gofmt -l .` — clean