### PR TITLE
fix(metal): use Apple GPU family for texture storage mode (v0.30.22)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 
 ## Current Version
 
-v0.30.21 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.1, gputypes v0.5.1, goffi v0.6.0, webgpu v0.5.3
+v0.30.22 | Go 1.25+ | Dependencies: naga v0.17.15, gpucontext v0.21.1, gputypes v0.5.1, goffi v0.6.0, webgpu v0.5.3
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.22] - 2026-07-16
+
+### Fixed
+
+- **Metal MSAA storage mode crash on Intel Mac** — use `MTLGPUFamilyApple1`
+  detection instead of `hasUnifiedMemory` for texture storage mode selection.
+  Non-Apple GPU family devices (Intel/AMD) now always use `MTLStorageModePrivate`
+  for textures. Apple Silicon keeps `MTLStorageModeShared` optimization for
+  single-sample textures. Fixes #271.
+
 ## [0.30.21] - 2026-07-15
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -91,6 +91,7 @@
 ✅ **Software CopyTextureToBuffer row stride** — row-by-row copy respecting BytesPerRow (v0.30.21)
 ✅ **Software blend state wiring** — extract blend from Fragment.Targets into raster pipeline (v0.30.21)
 ✅ **Software BGRA readTexel** — R/B channel swap for BGRA8Unorm/Srgb textures (v0.30.21)
+✅ **Metal MSAA storage mode fix** — `MTLGPUFamilyApple1` detection replaces `hasUnifiedMemory` for texture storage mode. Intel Mac SIGABRT on MSAA fixed. Apple Silicon keeps Shared optimization (v0.30.22, @AnyCPU #271)
 
 ### Remaining validation (planned)
 - **Phase C** (P2): Spec compliance edge cases, feature gates

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.30.21
+## Current State: v0.30.22
 
 ✅ **Triple-backend architecture (ADR-038)** — Native Go, Rust FFI, Browser WASM via build tags
 ✅ **All 5 Native HAL backends complete** (~127K LOC)
@@ -191,6 +191,7 @@ Target: stable, documented, conformant WebGPU implementation in Pure Go.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| **v0.30.22** | 2026-07 | Metal: MSAA storage mode crash on Intel Mac — `MTLGPUFamilyApple1` detection (#271) |
 | **v0.30.21** | 2026-07 | Software: CopyTextureToBuffer row stride, blend state wiring, BGRA readTexel |
 | **v0.30.20** | 2026-07 | PresentPixels check-before-mutate + DX12 UMA classification (@Zeroes1 #254) |
 | **v0.30.17-19** | 2026-07 | goffi v0.6.0 ADR-049 (764 FFI call sites), vk-gen array params + deterministic output, webgpu v0.5.3 |

--- a/hal/metal/conv.go
+++ b/hal/metal/conv.go
@@ -120,6 +120,25 @@ func textureUsageToMTL(usage gputypes.TextureUsage) MTLTextureUsage {
 	return mtlUsage
 }
 
+// textureStorageMode selects the MTLStorageMode for a texture based on GPU family
+// and sample count. Returns the storage mode and whether it is Shared (CPU-writable).
+//
+// Apple GPU (A-series, M-series) + single-sample: Shared — zero-copy CPU writes via
+// replaceRegion: and setPurgeableState(empty) for immediate OS memory reclaim.
+//
+// Apple GPU + multisample: Private — MSAA textures are never CPU-read, have a
+// one-frame lifetime, and gain no benefit from Shared storage.
+//
+// Non-Apple GPU (Intel, AMD): Private always — Metal spec requires Private storage
+// for multisample textures on non-Apple GPU families, and Shared offers no advantage
+// on discrete/non-UMA architectures.
+func textureStorageMode(isAppleGPU bool, sampleCount uint32) (MTLStorageMode, bool) {
+	if isAppleGPU && sampleCount <= 1 {
+		return MTLStorageModeShared, true
+	}
+	return MTLStorageModePrivate, false
+}
+
 // textureTypeFromDimension converts WebGPU texture dimension to Metal texture type.
 func textureTypeFromDimension(dimension gputypes.TextureDimension, sampleCount, depth uint32) MTLTextureType {
 	switch dimension {

--- a/hal/metal/conv_test.go
+++ b/hal/metal/conv_test.go
@@ -123,6 +123,44 @@ func TestTextureUsageToMTL(t *testing.T) {
 	}
 }
 
+// TestTextureStorageMode verifies the GPU-family-aware storage mode selection
+// that prevents SIGABRT on Intel Mac MSAA textures (issue #271).
+//
+// Intel integrated GPUs report hasUnifiedMemory=true but do NOT belong to
+// MTLGPUFamilyApple1. Using MTLStorageModeShared for multisample textures on
+// these GPUs triggers a Metal validation error / SIGABRT. The fix uses
+// isAppleGPU (MTLGPUFamilyApple1 membership) instead of hasUnifiedMemory.
+func TestTextureStorageMode(t *testing.T) {
+	tests := []struct {
+		name         string
+		isAppleGPU   bool
+		sampleCount  uint32
+		wantMode     MTLStorageMode
+		wantIsShared bool
+	}{
+		{"Apple GPU single-sample", true, 1, MTLStorageModeShared, true},
+		{"Apple GPU multisample 4x", true, 4, MTLStorageModePrivate, false},
+		{"Apple GPU multisample 8x", true, 8, MTLStorageModePrivate, false},
+		{"non-Apple GPU single-sample", false, 1, MTLStorageModePrivate, false},
+		{"non-Apple GPU multisample 4x", false, 4, MTLStorageModePrivate, false},
+		{"Apple GPU zero-sample (treated as single)", true, 0, MTLStorageModeShared, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotMode, gotShared := textureStorageMode(tt.isAppleGPU, tt.sampleCount)
+			if gotMode != tt.wantMode {
+				t.Errorf("textureStorageMode(%v, %d) mode = %v, want %v",
+					tt.isAppleGPU, tt.sampleCount, gotMode, tt.wantMode)
+			}
+			if gotShared != tt.wantIsShared {
+				t.Errorf("textureStorageMode(%v, %d) isShared = %v, want %v",
+					tt.isAppleGPU, tt.sampleCount, gotShared, tt.wantIsShared)
+			}
+		})
+	}
+}
+
 // TestTextureTypeFromDimension tests texture type from dimension conversions.
 func TestTextureTypeFromDimension(t *testing.T) {
 	tests := []struct {

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -38,6 +38,12 @@ type Device struct {
 	// and direct CPU writes without a staging blit, which eliminates the main source
 	// of resize-induced memory growth.
 	hasUnifiedMemory bool
+	// isAppleGPU is true when the device belongs to MTLGPUFamilyApple1 or higher
+	// (Apple-designed GPU: A-series, M-series). Intel/AMD GPUs on Mac report
+	// hasUnifiedMemory=true but are NOT Apple GPU family and do not support
+	// MTLStorageModeShared for multisample textures. This field drives texture
+	// storage mode selection instead of hasUnifiedMemory.
+	isAppleGPU bool
 }
 
 // newDevice creates a new Device from a Metal device.
@@ -51,14 +57,22 @@ func newDevice(adapter *Adapter) (*Device, error) {
 		return nil, fmt.Errorf("metal: failed to create command queue")
 	}
 
-	// Detect Apple Silicon (UMA): hasUnifiedMemory returns YES on M-series chips.
-	// On UMA, MTLStorageModeShared == Private physically, so we use Shared for all
-	// user textures to enable setPurgeableState(empty) and direct CPU writes.
+	// Detect UMA: hasUnifiedMemory returns YES on Apple Silicon (M-series) and
+	// some Intel integrated GPUs (e.g. Iris Plus 655). Used for DeviceType
+	// classification and buffer storage decisions.
 	hasUMA := MsgSend(adapter.raw, Sel("hasUnifiedMemory")) != 0
+
+	// Detect Apple-designed GPU (A-series, M-series) via MTLGPUFamilyApple1.
+	// This is the correct predicate for texture storage mode: Intel/AMD GPUs
+	// may report hasUnifiedMemory=true but crash on MTLStorageModeShared for
+	// multisample textures. Only Apple GPU family supports Shared for all
+	// single-sample texture types.
+	isApple := DeviceSupportsFamily(adapter.raw, MTLGPUFamilyApple1)
 
 	hal.Logger().Info("metal: device created",
 		"name", DeviceName(adapter.raw),
 		"hasUnifiedMemory", hasUMA,
+		"isAppleGPU", isApple,
 	)
 
 	return &Device{
@@ -66,6 +80,7 @@ func newDevice(adapter *Adapter) (*Device, error) {
 		commandQueue:     queue,
 		adapter:          adapter,
 		hasUnifiedMemory: hasUMA,
+		isAppleGPU:       isApple,
 	}, nil
 }
 
@@ -211,18 +226,11 @@ func (d *Device) CreateTexture(desc *hal.TextureDescriptor) (hal.Texture, error)
 	usage := textureUsageToMTL(desc.Usage)
 	_ = MsgSend(texDesc, Sel("setUsage:"), uintptr(usage))
 
-	// On Apple Silicon (UMA), use Shared storage instead of Private.
-	// Physical memory is identical on UMA — the only differences are:
-	//   (a) Shared supports direct CPU writes via replaceRegion: (no staging copy)
-	//   (b) Shared honours setPurgeableState(empty) which immediately returns
-	//       physical pages to the OS; Private silently ignores this call.
-	// On discrete-GPU Macs, keep Private (VRAM-resident, no CPU penalty per frame).
-	storageMode := MTLStorageModePrivate
-	isShared := false
-	if d.hasUnifiedMemory {
-		storageMode = MTLStorageModeShared
-		isShared = true
-	}
+	// Select storage mode based on GPU family and sample count.
+	// Apple GPU + single-sample → Shared (zero-copy CPU writes, setPurgeableState).
+	// Apple GPU + multisample → Private (MSAA has no Shared benefit).
+	// Non-Apple GPU (Intel/AMD) → Private always (spec requirement for MSAA).
+	storageMode, isShared := textureStorageMode(d.isAppleGPU, sampleCount)
 	_ = MsgSend(texDesc, Sel("setStorageMode:"), uintptr(storageMode))
 
 	raw := MsgSend(d.raw, Sel("newTextureWithDescriptor:"), uintptr(texDesc))


### PR DESCRIPTION
## Summary

Fixes #271 — SIGABRT on Intel Mac (Iris Plus 655) when creating MSAA textures.

### Root Cause

`CreateTexture` used `hasUnifiedMemory` to select `MTLStorageModeShared` for all textures. Intel integrated GPUs report `hasUnifiedMemory=true` but are NOT Apple GPU family — Metal spec requires `MTLStorageModePrivate` for multisample textures on non-Apple-family devices.

### Fix

- Add `isAppleGPU` field to Device — detected via `DeviceSupportsFamily(adapter, MTLGPUFamilyApple1)` (all infrastructure already existed: constants, function, selector)
- Extract `textureStorageMode(isAppleGPU, sampleCount)` helper to `conv.go`
- Apple GPU + single-sample → `Shared` (our UMA optimization: zero-copy CPU writes, `setPurgeableState`)
- Apple GPU + multisample → `Private` (MSAA has no Shared benefit)
- Non-Apple GPU → `Private` always (Metal spec requirement)
- `hasUnifiedMemory` preserved for DeviceType classification

### Research

Deep analysis of Metal spec, Rust wgpu-hal reference, and Apple GPU family detection.
Rust uses `Private` for ALL textures unconditionally. Our approach is more nuanced — we keep `Shared` optimization for single-sample textures on Apple Silicon where it provides real benefits.
ADR-021: `docs/dev/architecture/ADR-021-METAL-TEXTURE-STORAGE-MODE.md`

## Test plan

- [x] `go build ./...` — Windows, macOS (arm64), Linux
- [x] `golangci-lint` — 0 new issues
- [x] `TestTextureStorageMode` — 6 cases (Apple/non-Apple × single/multi/zero)
- [ ] macOS CI (conv_test.go gated by `//go:build darwin`)
- [ ] @AnyCPU verification on Intel Iris Plus 655