### PR TITLE
test(metal): align storage-mode fixture with GPU policy

### DIFF
--- a/hal/metal/texture_copy_test.go
+++ b/hal/metal/texture_copy_test.go
@@ -450,7 +450,7 @@ func TestCommandEncoderCopiesBetweenLayeredTextures(t *testing.T) {
 
 func TestQueueWriteTextureLayeredShapes(t *testing.T) {
 	device, queue := newMetalTextureCopyTestDevice(t)
-	hasUnifiedMemory := device.hasUnifiedMemory
+	supportsSharedTextures := device.isAppleGPU
 
 	shapes := []struct {
 		name      string
@@ -471,10 +471,10 @@ func TestQueueWriteTextureLayeredShapes(t *testing.T) {
 	for _, shape := range shapes {
 		for _, storage := range storageModes {
 			t.Run(shape.name+"/"+storage.name, func(t *testing.T) {
-				if storage.shared && !hasUnifiedMemory {
-					t.Skip("direct Shared-texture writes require unified memory")
+				if storage.shared && !supportsSharedTextures {
+					t.Skip("direct Shared-texture writes require an Apple GPU family")
 				}
-				device.hasUnifiedMemory = storage.shared
+				device.isAppleGPU = storage.shared
 
 				const (
 					width       = uint32(4)


### PR DESCRIPTION
## Summary

- drive the layered `Queue.WriteTexture` storage-mode matrix through `Device.isAppleGPU`, the predicate production texture allocation actually uses
- skip the Shared-direct cases when the host does not expose an Apple GPU family
- leave Metal production behavior unchanged

## Root cause

The test added in #261 simulated Private and Shared texture allocation by changing `hasUnifiedMemory`. After #272, texture allocation intentionally uses Apple GPU-family membership (`isAppleGPU`) instead, avoiding Shared texture policy on Intel/AMD devices.

On Apple Silicon, the stale fixture therefore could not force the `private staging` case: `CreateTexture` still saw `isAppleGPU=true`, allocated Shared storage, and failed the expectation:

```text
texture shared mode = true; want false
```

This updates the test injection point to match the current policy. The Private-staging and Shared-direct data paths remain exercised on Apple GPUs; non-Apple GPUs continue to exercise the production-supported Private path.

## Validation

- `CGO_ENABLED=0 GOWORK=off go test -count=1 ./hal/metal -run '^TestQueueWriteTextureLayeredShapes/1D_array/private_staging$' -v`
- full layered storage matrix, repeated three times
- `CGO_ENABLED=0 GOWORK=off go test -count=1 ./hal/metal`
- `CGO_ENABLED=0 GOWORK=off go test -count=1 ./...`
- `CGO_ENABLED=0 GOWORK=off go test -count=1 -tags rust ./...`
- default and Rust-tagged builds, plus the root WASM build

The complete local macOS default and Rust-tagged test runs now pass without excluding `hal/metal`. This is deliberately separate from Android PR #268.
