### PR TITLE
fix(surface): handle nil WritePixels receiver

### DIFF
--- a/headless_surface_native_test.go
+++ b/headless_surface_native_test.go
@@ -363,3 +363,10 @@ func TestHeadlessSurfaceReadPixelsStateErrors(t *testing.T) {
 		}
 	})
 }
+
+func TestSurfaceWritePixelsNil(t *testing.T) {
+	var surface *Surface
+	if err := surface.WritePixels(nil, 0, 0); !errors.Is(err, ErrReleased) {
+		t.Fatalf("WritePixels error = %v, want ErrReleased", err)
+	}
+}

--- a/surface_native.go
+++ b/surface_native.go
@@ -409,7 +409,7 @@ func (s *Surface) PresentPixels(data []byte, width, height uint32, damageRects [
 // Call between GetCurrentTexture() and Present(). No render pass needed.
 // Returns ErrReleased if the surface is not configured.
 func (s *Surface) WritePixels(data []byte, width, height uint32) error {
-	if s.released || s.core == nil {
+	if s == nil || s.released || s.core == nil {
 		return ErrReleased
 	}
 	raw := s.core.RawSurface()


### PR DESCRIPTION
## Summary

- return `ErrReleased` when `WritePixels` is called on a nil `*Surface`
- match the nil-receiver behavior added for `ReadPixels` in #276
- add a focused regression proving the call returns an error instead of panicking

This addresses the sole non-blocking follow-up noted during review of #276. It does not change the behavior of configured, released, or unsupported surfaces.

## Validation

Passed locally with `CGO_ENABLED=0` and `GOWORK=off`:

- `go test -count=1 . -run '^TestSurfaceWritePixelsNil$'`
- `go test -count=1 ./hal/software ./core .`
- `go test -count=1 ./...`
- `go test -race -count=1 .`
- `go test -count=1 -tags rust ./...`
- default and Rust-tagged builds
- browser WASM root build
- Android arm64 full build
- `golangci-lint v2.12.2 run --timeout=5m --new-from-rev=upstream/main ./...`
- `gofmt` and `git diff --check`

Follow-up to #276.
