### PR TITLE
docs: CODEOWNERS + ROADMAP + ARCHITECTURE update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,10 @@
 # Default owners for everything in the repo
 * @kolkov
+
+# Android platform (guarded preview)
+# Recursive patterns (**) cover nested directories (vk/, testdata/)
+hal/vulkan/**/*android*    @besmpl
+hal/allbackends/*android*  @besmpl
+**/surface_*android*       @besmpl
+docs/ANDROID.md            @besmpl
+scripts/**/*android*       @besmpl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1383,10 +1383,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Research
 
-- **[Validation Gap Analysis](docs/dev/research/VALIDATION-GAP-ANALYSIS-RUST-WGPU.md)** — 121-check
-  comparison vs Rust wgpu-core. Coverage: 22% → ~37% after Phase A.
-- **[ADR: Validation Phases](docs/dev/research/ADR-VALIDATION-PHASES.md)** — phased implementation
-  plan (A: crash prevention, B: correctness, C: spec compliance)
+- **Validation Gap Analysis** — 121-check comparison vs Rust wgpu-core. Coverage: 22% → ~37% after Phase A.
+- **Validation Phases ADR** — phased implementation plan (A: crash prevention, B: correctness, C: spec compliance)
 
 ## [0.25.4] - 2026-04-23
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,48 @@
 # Contributing to wgpu
 
-Thank you for your interest in contributing to wgpu!
+Thank you for your interest in contributing to the Pure Go WebGPU implementation!
+
+wgpu is part of the [gogpu](https://github.com/gogpu) ecosystem — 1.1M+ lines of Pure Go GPU code powering 2D graphics, 3D rendering, GUI toolkit, ML frameworks, and a game engine.
+
+## AI-Assisted Contributions: Smart Coding Welcome
+
+**We welcome AI-assisted contributions.** This entire ecosystem is built using AI-assisted workflows, and we don't consider AI assistance a negative signal. What matters is the quality of the result, not the tool used to produce it.
+
+We practice [**Smart Coding**](https://dev.to/kolkov/from-vibe-coding-to-agentic-engineering-what-karpathy-got-right-and-whats-missing-62e) — a framework where human engineering judgment drives AI capabilities. The key insight: **you own architecture, AI owns implementation**. The 70/30 rule applies — spend 70% of effort on architecture, review, and validation; 30% on implementation.
+
+There are three paradigms on the AI-assisted development spectrum:
+
+| | Vibe Coding | Agentic Engineering | Smart Coding |
+|---|---|---|---|
+| **Approach** | "Give in to the vibes, forget code exists" (Karpathy) | Orchestrate AI agents with specs and quality gates | Meta-framework: engineering judgment decides when to explore vs. build |
+| **Strengths** | Fast prototyping, feasibility spikes | Parallel workflows, specification-driven | Knowledge compounds across sessions, bidirectional learning |
+| **Weakness** | Production disasters without oversight | "Like conducting an orchestra that can't remember yesterday's piece" | Requires experienced engineers who understand the domain |
+| **Our verdict** | Good for exploration, never for production | Good foundation, missing feedback loop | **This is what we practice** |
+
+**What separates Smart Coding from low-quality AI-generated code:**
+
+| Smart Coding | Low-Quality AI Code |
+|---|---|
+| Understands the reference implementation (Rust wgpu) | Copy-pastes without understanding the architecture |
+| Researches before coding — consults enterprise references | "Insert call and see what happens" |
+| Tests on real hardware and real examples | "Build passes, ship it" |
+| Handles edge cases and error paths | Happy path only |
+| Can explain design decisions when asked | "The AI suggested it" |
+| Clean commit history with meaningful messages | Single 10K-line commit with "add feature" |
+| Iterates on review feedback with understanding | Regenerates entire file and hopes for the best |
+
+**What we look for in any contribution, AI-assisted or not:**
+
+- Evidence that you understand what the code does and why
+- Rust wgpu reference consulted for non-trivial changes (we port from [gfx-rs/wgpu](https://github.com/gfx-rs/wgpu))
+- Tests that verify behavior, not just compilation
+- Willingness to iterate on review feedback
+
+**We do NOT require:**
+
+- Disclosure of AI tool usage — it's your choice
+- "Hand-written" code — we care about correctness, not process
+- Perfect first submission — we'll work with you to get it right
 
 ## Getting Started
 
@@ -8,49 +50,64 @@ Thank you for your interest in contributing to wgpu!
 2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/wgpu`
 3. Create a branch: `git checkout -b feat/your-feature`
 4. Make your changes
-5. Run tests: `go test ./...`
-6. Commit: `git commit -m "feat: add your feature"`
+5. Run checks (see below)
+6. Commit using [Conventional Commits](https://www.conventionalcommits.org/)
 7. Push: `git push origin feat/your-feature`
 8. Open a Pull Request
 
 ## Development Setup
 
 ```bash
-# Clone the repository
 git clone https://github.com/gogpu/wgpu
 cd wgpu
 
-# Install dependencies
 go mod download
-
-# Run tests
+go build ./...
 go test ./...
-
-# Run linter
-golangci-lint run
+golangci-lint run --timeout=5m
 ```
 
-## Code Style
+**Requirements:** Go 1.25+, `golangci-lint`, `CGO_ENABLED=0` (pure Go, no C compiler needed).
 
-- Follow standard Go conventions
-- Use `gofmt` for formatting
-- Use `golangci-lint` for linting
-- Write tests for new functionality
-- Document public APIs
+## Pre-Submit Checklist
+
+Run these before pushing:
+
+```bash
+go fmt ./...                      # Format
+go vet ./...                      # Vet
+golangci-lint run --timeout=5m    # Lint
+go build ./...                    # Build
+go test ./...                     # Test
+```
+
+For platform-specific changes, lint on all target platforms:
+
+```bash
+GOOS=linux GOARCH=amd64 golangci-lint run --timeout=5m
+GOOS=darwin GOARCH=arm64 golangci-lint run --timeout=5m
+```
+
+Platform-specific files (`_darwin.go`, `_linux.go`, `_windows.go`) are invisible to lint on other platforms.
 
 ## Project Structure
 
 ```
 wgpu/
-├── types/          # WebGPU type definitions
-├── core/           # Core validation and state tracking
-├── hal/            # Hardware abstraction layer
-│   ├── vulkan/     # Vulkan backend
-│   ├── metal/      # Metal backend
-│   ├── dx12/       # DirectX 12 backend
-│   └── gl/         # OpenGL backend
-├── internal/       # Internal utilities
-└── cmd/            # CLI tools (if any)
+├── *.go                # Public API (20 types wrapping core/ and hal/)
+├── core/               # Validation, resource management, state tracking
+│   └── track/          # Buffer/resource state tracking
+├── hal/                # Hardware abstraction layer (interfaces + descriptors)
+│   ├── vulkan/         # Vulkan backend (Windows, Linux, macOS, Android)
+│   ├── metal/          # Metal backend (macOS, iOS)
+│   ├── dx12/           # DirectX 12 backend (Windows)
+│   ├── gles/           # OpenGL ES backend (Windows, Linux)
+│   ├── software/       # Software rasterizer + SPIR-V interpreter
+│   ├── noop/           # No-op backend (testing)
+│   └── allbackends/    # Backend registration convenience
+├── internal/           # Internal utilities
+├── cmd/                # CLI tools and test apps
+└── examples/           # Example applications
 ```
 
 ## Commit Messages
@@ -58,51 +115,54 @@ wgpu/
 We use [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```
-feat(component): add new feature
-fix(component): fix bug
-docs: update documentation
-test: add tests
-refactor: code refactoring
-chore: maintenance tasks
+feat(vulkan): add Android arm64 WSI support
+fix(metal): pin autorelease pools to OS threads
+docs: update ARCHITECTURE.md
+test(core): add surface lifecycle tests
+refactor(hal): share checked swapchain enumeration
+chore: bump dependencies
 ```
 
-Components: `types`, `core`, `hal`, `vulkan`, `metal`, `dx12`, `gl`, `docs`, `ci`
+Components: `core`, `hal`, `vulkan`, `metal`, `dx12`, `gles`, `software`, `noop`, `docs`, `ci`
 
 ## Pull Request Guidelines
 
 - Keep PRs focused on a single change
+- Reference the Rust wgpu equivalent for non-trivial HAL/core changes
+- Add tests for new functionality
 - Update documentation if needed
-- Add tests for new features
-- Ensure all tests pass
+- Ensure all CI checks pass
 - Reference related issues
+
+For large features, consider splitting into a prerequisite stack — small, reviewable PRs that build on each other. We take responsibility for every line that lands in the codebase.
 
 ## Testing
 
-### Unit Tests
 ```bash
-go test ./...
+go test ./...              # Unit tests
+go test -cover ./...       # With coverage
+go test -race ./...        # With race detector (requires CGO_ENABLED=1)
 ```
 
-### With Coverage
-```bash
-go test -cover ./...
-```
+For backend-specific verification, run examples with backend selection:
 
-### With Race Detector
 ```bash
-go test -race ./...
+GOGPU_GRAPHICS_API=vulkan   go run ./examples/compute-sum/
+GOGPU_GRAPHICS_API=dx12     go run ./examples/compute-sum/
+GOGPU_GRAPHICS_API=software go run ./examples/compute-sum/
 ```
 
 ## Reporting Issues
 
-- Use GitHub Issues
-- Include Go version and OS
+- Use [GitHub Issues](https://github.com/gogpu/wgpu/issues)
+- Include Go version, OS, and GPU (if relevant)
 - Provide minimal reproduction
-- Include error messages
+- Include error messages and backend used (`GOGPU_GRAPHICS_API=?`)
 
 ## Questions?
 
-Open a GitHub Discussion or reach out to maintainers.
+- [GitHub Discussions](https://github.com/orgs/gogpu/discussions) for questions and ideas
+- PR comments for code-specific discussion
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -206,8 +206,7 @@ Safety guarantees: UAF protection via generation counters on `MappedRange`,
 `ErrMapRangeOverlap` for overlapping `MappedRange` calls, `MAP_ALIGNMENT = 8`
 validation, thread-safe concurrent `Device.Poll`.
 
-See [ADR-BUFFER-MAPPING-API](docs/dev/research/ADR-BUFFER-MAPPING-API.md) for the
-full design rationale and comparison with Rust wgpu.
+Design follows Rust wgpu's buffer mapping model with Go-idiomatic error handling.
 
 **Guides:** [Getting Started](docs/COMPUTE-SHADERS.md) | [Backend Differences](docs/COMPUTE-BACKENDS.md)
 
@@ -358,7 +357,7 @@ import _ "github.com/gogpu/wgpu/hal/software"
 - Blending (13 factors, 5 operations)
 - 6-plane frustum clipping (Sutherland-Hodgman)
 - 8x8 tile-based parallel rendering
-- **SPIR-V interpreter** — executes vertex/fragment/compute shaders on CPU. Designed for shader debugging, CI/CD testing, and GPU-less environments — **not for production rendering** (interpreted, ~100× slower than JIT software renderers like SwiftShader). See [ADR](docs/dev/research/ADR-SPIRV-JIT-VS-INTERPRETER.md).
+- **SPIR-V interpreter** — executes vertex/fragment/compute shaders on CPU. Designed for shader debugging, CI/CD testing, and GPU-less environments — **not for production rendering** (interpreted, ~100× slower than JIT software renderers like SwiftShader).
 
 **Debug & Testing:**
 - Render pass instrumentation: `hal.Logger().Debug()` events + `RenderPassStats` for CI e2e assertions
@@ -401,6 +400,7 @@ recipe and the explicit non-WebGPU support contract.
 | [gogpu/naga](https://github.com/gogpu/naga) | Shader compiler (WGSL to SPIR-V, HLSL, MSL, GLSL, DXIL) |
 | [gogpu/gg](https://github.com/gogpu/gg) | 2D graphics library with GPU SDF acceleration |
 | [gogpu/ui](https://github.com/gogpu/ui) | GUI toolkit: 22+ widgets, 4 themes |
+| [gogpu/galloc](https://github.com/gogpu/galloc) | O(1) offset allocator for GPU memory sub-allocation |
 | [gogpu/gputypes](https://github.com/gogpu/gputypes) | Shared WebGPU type definitions |
 | [go-webgpu/goffi](https://github.com/go-webgpu/goffi) | Pure Go FFI library |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.30.22
+## Current State: v0.30.22 + 17 merged (unreleased)
 
 ✅ **Triple-backend architecture (ADR-038)** — Native Go, Rust FFI, Browser WASM via build tags
 ✅ **All 5 Native HAL backends complete** (~127K LOC)
@@ -92,10 +92,24 @@
 ✅ **Software blend state wiring** — extract blend from Fragment.Targets into raster pipeline (v0.30.21)
 ✅ **Software BGRA readTexel** — R/B channel swap for BGRA8Unorm/Srgb textures (v0.30.21)
 ✅ **Metal MSAA storage mode fix** — `MTLGPUFamilyApple1` detection replaces `hasUnifiedMemory` for texture storage mode. Intel Mac SIGABRT on MSAA fixed. Apple Silicon keeps Shared optimization (v0.30.22, @AnyCPU #271)
+✅ **Device teardown GPU drain** — private `waitIdle()` bypasses released guard, `queue.release()` after drain. Rust `Queue::Drop` parity (@besmpl #264)
+✅ **Vulkan swapchain fail-closed** — transactional reconfiguration, capability snapshot validation, broken-state tracking, semaphore/fence error propagation (@besmpl #265)
+✅ **Explicit mock adapter** — `NewInstance` no longer fabricates mock adapter. Rust wgpu parity (@besmpl #266)
+✅ **Surface-qualified adapter selection** — `RequestAdapterWithSurface` validates via `vkGetPhysicalDeviceSurfaceSupportKHR`. Iterates all queue families — ahead of Rust wgpu (@besmpl #267)
+✅ **Surface lifetime ownership** — centralized acquisition/teardown with lease system. Instance owns release ordering. Vulkan device-level swapchain tracking (@besmpl #269)
+✅ **Vulkan nil pipeline layout guard** — HAL rejects nil layouts before Vulkan call (@besmpl #257)
+✅ **Metal autorelease pool thread pinning** — `LockOSThread` prevents goroutine migration between pool create/drain. Go 1.14+ async preemption fix (@besmpl #260)
+✅ **Metal texture array copy shape** — `setArrayLength` for 1D/2D arrays instead of `setDepth`. Rust wgpu `device.rs:436-453` parity. metalCopyPlan decomposition (@besmpl #261)
+✅ **Fixed-count indirect multi-draw** — `drawCount` on DrawIndirect/DrawIndexedIndirect. 2 improvements over Rust: feature check for both draw kinds + offset advance in fallback loop (gfx-rs/wgpu#9870). `internal/indirect` overflow-safe arithmetic (@besmpl #253)
+✅ **Metal ICB optimization** — indirect command buffers for large indexed multi-draws (1024-52428 commands). Original optimization beyond Rust wgpu (Rust uses simple loop). Deferred render encoder + compute dispatch (@besmpl #263)
+✅ **DX12 submission-ordered state reconciliation** — command-local state tracker, preamble barriers at submit time, per-plane depth/stencil tracking, preamble pool, COM lifecycle safety (@besmpl #262)
+✅ **Rust v29 typed surface targets** — `SurfaceTarget`/`SurfaceTargetUnsafe` with opaque constructors for Win32, Xlib, Wayland, Android NDK, Metal, Web. `hal.SurfaceTarget.RequireKind()` discriminator. Same contract across native/rust/browser (@besmpl #273)
+✅ **Android arm64 Vulkan (guarded preview)** — API 29+, Bionic loader via goffi v0.6.1, Rust v29 WSI parity. Callbacks rejected pending physical-device proof (@besmpl #268)
+✅ **Headless surface readback** — `HeadlessSurfaceTarget` + `Surface.ReadPixels()` for golden image testing. `hal.PixelReader` optional capability. Closes #256 (@besmpl #276)
 
 ### Remaining validation (planned)
 - **Phase C** (P2): Spec compliance edge cases, feature gates
-- See [ADR-VALIDATION-PHASES.md](docs/dev/research/ADR-VALIDATION-PHASES.md)
+- Validation Phase C — spec compliance edge cases, feature gates
 
 | Backend | Platform | Status |
 |---------|----------|--------|
@@ -113,20 +127,25 @@
 
 ### Near-term (Q3 2026)
 
+**Release v0.31.0** (after naga #82 merge):
+- [ ] Bump deps: goffi v0.6.2, webgpu v0.5.4, naga v0.17.16
+- [ ] CODEOWNERS: @besmpl for Android paths
+- [ ] CHANGELOG for 17 merged PRs
+- [ ] Integrate `gogpu/galloc` into Vulkan memory pools (replace BuddyAllocator)
+
 **GLES Linux Enterprise Parity:**
 - [ ] Shared AdapterContext for Linux — mutex + LockOSThread (FEAT-GLES-003). Windows parity.
 - [ ] Systematic GL error checking layer — `checkGL()` after every call (ADR-046)
-- [ ] GLES global UNPACK_ALIGNMENT=1 — Rust pattern, set once at device open
 
 **Public API Quality (#218):**
 - [ ] Remove HAL leaks from public API (`Surface.HAL()`, `Surface.SetPrepareFrame()`)
 - [ ] Expose `Device.CreateQuerySet` — HAL ready on all 6 backends, needs public wrapper
-- [ ] `Device.released` → `atomic.Bool` — data race fix
 - [ ] Document Surface single-thread requirement
 
 **DX12:**
-- [ ] DeviceTextureTracker — proper barrier state tracking (Rust wgpu-core parity)
+- [x] ~~DeviceTextureTracker~~ → submission-ordered state reconciliation (#262, done)
 - [ ] DXIL as default shader path (currently opt-in via `GOGPU_DX12_DXIL=1`)
+- [ ] Integrate galloc into DX12 descriptor heap management
 
 ### Mid-term (Q4 2026)
 
@@ -139,7 +158,8 @@
 - [ ] Validation Phase C — spec compliance edge cases, feature gates
 
 **Platform Expansion:**
-- [ ] **Android** — Vulkan surface via `vkCreateAndroidSurfaceKHR`. Depends on gogpu platform layer
+- [x] ~~Android~~ — Vulkan surface via typed `SurfaceTarget` (#268/#273, guarded preview)
+- [ ] Android physical-device evidence (API 29 + API 36 arm64)
 - [ ] **iOS** — Metal backend ready (naga MSL 91/91), needs platform integration
 
 ### v1.0.0 — Production Release (November 2027, Go 18th birthday)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -89,20 +89,24 @@ Key interfaces (defined in `hal/api.go`):
 Pure Go Vulkan implementation using goffi for dynamic function loading.
 
 - `vk/` — Low-level Vulkan bindings (generated types, function signatures, loader)
-- `memory/` — GPU memory allocator (buddy allocation, `maxMemoryAllocationSize` enforcement)
+- `memory/` — GPU memory allocator (buddy allocation, `maxMemoryAllocationSize` enforcement). Future: replace BuddyAllocator with [gogpu/galloc](https://github.com/gogpu/galloc) O(1) offset allocator.
 - Command encoder: free list of pre-allocated VkCommandBuffers (batch 16), `vkResetCommandPool` for batch reset (Rust wgpu-hal parity)
-- Platform surface: VkWin32, VkXlib/VkWayland, VkMetal, and Android
-  `ANativeWindow` (arm64/API 29+ preview; see [ANDROID.md](ANDROID.md))
+- Swapchain fail-closed lifecycle: transactional reconfiguration, capability snapshot validation, broken-state tracking
+- Surface-qualified adapter selection: `vkGetPhysicalDeviceSurfaceSupportKHR` across all queue families (ahead of Rust wgpu)
+- Platform surface: VkWin32, VkXlib/VkWayland, VkMetal, and Android `ANativeWindow` (arm64/API 29+ preview; see [ANDROID.md](ANDROID.md))
+- Multi-draw indirect: native `vkCmdDrawIndirect`/`vkCmdDrawIndexedIndirect` with `drawCount`, feature-gated fallback loop
 
 ### `hal/metal/` — Metal Backend
 
 Pure Go Metal implementation via Objective-C runtime message sending.
 
-- `objc.go` — Objective-C runtime (`objc_msgSend`, `NSAutoreleasePool`, selectors)
-- `encoder.go` — Command encoder, render/compute pass encoders
-- `device.go` — Device, resource creation, fence management
+- `objc.go` — Objective-C runtime (`objc_msgSend`, `NSAutoreleasePool` with OS thread pinning, selectors)
+- `encoder.go` — Command encoder, render/compute pass encoders, deferred render encoder for ICB
+- `icb_indexed.go` — Metal Indirect Command Buffers for large indexed multi-draws (1024-52428 commands). Original optimization beyond Rust wgpu.
+- `texture_copy.go` — metalCopyPlan: array layer vs 3D depth decomposition, block-compressed format support
+- `device.go` — Device, resource creation, fence management, `isAppleGPU` via `MTLGPUFamilyApple1`
 - `queue.go` — Command submission, texture writes
-- Uses scoped autorelease pools (create + drain in same function)
+- Uses scoped autorelease pools with `LockOSThread` (create + drain on same OS thread, Go 1.14+ preemption safe)
 
 ### `hal/dx12/` — DirectX 12 Backend
 
@@ -111,8 +115,10 @@ Pure Go DX12 implementation via COM interfaces.
 - `d3d12/` — D3D12 COM interfaces, GUID definitions, DRED diagnostics, loader
 - `dxgi/` — DXGI factory, adapter enumeration
 - `device.go` — Device, resource creation, descriptor heaps (SRV/sampler), dual shader compilation (HLSL→FXC or DXIL direct)
-- `command.go` — Command encoder with resource barriers (buffer/texture state transitions)
-- `queue.go` — Command submission with fence-based GPU completion tracking
+- `state_tracker.go` — Submission-ordered resource state reconciliation: command-local tracking, preamble barriers at submit time, per-plane depth/stencil. Replaces recording-time `currentState`.
+- `copy_plan.go` + `copy_commands.go` — 2D-array vs 3D volume copy decomposition, 512-byte placement alignment, block-compressed row counting
+- `command.go` — Command encoder with resource barriers (via state tracker)
+- `queue.go` — Command submission with fence-based GPU completion tracking, preamble pool (per-frame reuse, capped at maxFramesInFlight)
 - `resource.go` — Buffers (upload/default heaps), textures with deferred destruction
 - `shader_cache.go` — In-memory SHA-256 keyed LRU cache (works for both HLSL and DXIL paths)
 - **Shader compilation:** dual path — HLSL→FXC (default, SM 5.1) or DXIL direct via naga (opt-in `GOGPU_DX12_DXIL=1`, SM 6.0+, zero external dependencies)
@@ -163,7 +169,10 @@ CPU-based rasterizer with SPIR-V interpreter. Always compiled (no build tags req
 - `blit_linux.go` — Linux X11 presentation: XPutImage via goffi (Skia pattern)
 - `blit_darwin.go` — macOS presentation: CGImage + CALayer, or Metal nextDrawable + replaceRegion for CAMetalLayer. Contributor: @k-chimi
 
-**Extensions (non-standard):** `Surface.PresentPixels()` — atomic CPU pixel write + present that bypasses the WebGPU render pass pipeline. Single-pass RGBA→BGRA swizzle into DIB/X11 framebuffer + platform blit. Reduces present overhead from 3 copies to 1 for CPU-rendered content. `hal.PixelPresenter` / `hal.PixelWriter` optional interfaces (`io.WriterTo` pattern). ADR: `docs/dev/research/ADR-SOFTWARE-ZERO-COPY-PRESENTATION.md`.
+**Extensions (non-standard):**
+- `Surface.PresentPixels()` — atomic CPU pixel write + present. Single-pass RGBA→BGRA swizzle + platform blit. `hal.PixelPresenter` / `hal.PixelWriter` optional interfaces.
+- `Surface.ReadPixels()` — headless surface pixel readback for golden image testing. `hal.PixelReader` optional interface. Returns owned RGBA8 snapshot. Requires `HeadlessSurfaceTarget`.
+- `HeadlessSurfaceTarget` — zero-sized safe target for display-free software rendering.
 
 Use cases: **shader debugging** (step through every SPIR-V instruction), **CI/CD testing** (no GPU required), **headless rendering** (servers), **GPU-less fallback** (embedded systems). NOT for real-time production rendering — use GPU backends (Vulkan/DX12/Metal/GLES) for that. Verified: triangle + 4096-particle compute+render simulation. All 3 desktop platforms (Windows, Linux, macOS) have windowed presentation.
 
@@ -191,6 +200,27 @@ wgpu public API
 - ~6500 LOC total (4000 internal/browser + 2500 root wrappers), zero external dependencies
 
 Key files: `promise.go` (async→sync), `convert_enums.go` (97 TextureFormats, 31 VertexFormats + all WebGPU enums), `convert_resources.go` (JS descriptor builders), `surface.go` (Canvas + GPUCanvasContext).
+
+## Typed Surface Targets (Rust v29 Parity)
+
+Surface creation uses typed targets instead of raw `uintptr` handles:
+
+```go
+// Safe targets (recommended)
+target := wgpu.SurfaceTargetFromWindowsHWND(hwnd)
+surface, _ := instance.CreateSurfaceFromTarget(target)
+
+// Unsafe targets (platform-specific)
+target := wgpu.SurfaceTargetUnsafeAndroidNDK(nativeWindow)
+surface, _ := instance.CreateSurfaceUnsafe(target)
+
+// Legacy compatibility (preserved)
+surface, _ := instance.CreateSurface(displayHandle, windowHandle)
+```
+
+`hal.SurfaceTarget.RequireKind()` discriminator ensures every backend rejects foreign handle kinds before pointer access. Platform constructors: Win32 HWND, Xlib Window, Wayland wl_surface, Android ANativeWindow, Metal CAMetalLayer, Web Canvas.
+
+See [SURFACE-TARGETS.md](SURFACE-TARGETS.md) for the exhaustive API mapping.
 
 ## Backend Registration
 
@@ -304,7 +334,10 @@ gogpu (app framework) / gg (2D graphics)
 ```
 
 External dependencies:
-- `github.com/gogpu/naga` — shader compiler (WGSL → SPIR-V / MSL / GLSL / HLSL / DXIL), Pure Go
-- `github.com/gogpu/gputypes` v0.5.0 — shared WebGPU type definitions
-- `github.com/go-webgpu/goffi` v0.6.0 — Pure Go FFI for Vulkan/Metal symbol loading
-- `golang.org/x/sys` v0.44.0 — platform syscall definitions
+- `github.com/gogpu/naga` v0.17.15 — shader compiler (WGSL → SPIR-V / MSL / GLSL / HLSL / DXIL), Pure Go
+- `github.com/gogpu/gputypes` v0.5.1 — shared WebGPU type definitions
+- `github.com/gogpu/gpucontext` v0.21.1 — shared interfaces (DeviceProvider, PlatformProvider)
+- `github.com/go-webgpu/goffi` v0.6.2 — Pure Go FFI for Vulkan/Metal/DX12 symbol loading (Android Bionic support)
+- `github.com/go-webgpu/webgpu` v0.5.4 — Rust FFI backend (wgpu-native v29, Android surface, timestamp period)
+- `github.com/gogpu/galloc` v0.1.0 — O(1) offset allocator (planned integration for memory sub-allocation)
+- `golang.org/x/sys` v0.47.0 — platform syscall definitions


### PR DESCRIPTION
## Summary

- CODEOWNERS: @besmpl added for Android paths (5 patterns, 10 files)
- README: galloc added to ecosystem table
- ROADMAP: Current State updated with 17 merged PRs
- ARCHITECTURE: Vulkan, Metal, DX12, surface targets, headless readback, dependencies

## Test plan

- [x] Documentation only — no code changes
- [x] All CODEOWNERS patterns verified against existing files
- [x] No private paths referenced