### PR TITLE
release: v0.30.25 — deps gpucontext v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.25] - 2026-07-29
+
+### Changed
+
+- **deps:** gpucontext v0.21.1 → v0.22.0 — `FontSmoothing` type + coordinate space docs (gogpu#396, gogpu#398)
+
 ## [0.30.24] - 2026-07-28
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.6.2
 	github.com/go-webgpu/webgpu v0.5.4
-	github.com/gogpu/gpucontext v0.21.1
+	github.com/gogpu/gpucontext v0.22.0
 	github.com/gogpu/gputypes v0.5.1
 	github.com/gogpu/naga v0.17.16
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.2 h1:xuMaUbqsNQ/xiyy5UwAKZb5vQZUDg9QRCrJIpHJaXSE
 github.com/go-webgpu/goffi v0.6.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V4=
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
-github.com/gogpu/gpucontext v0.21.1 h1:/X96uCLG8QtQVfGPYPz8ycnfsAg0iTyzqzEadWBUupU=
-github.com/gogpu/gpucontext v0.21.1/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
+github.com/gogpu/gpucontext v0.22.0 h1:H4pS3H/iU392BUL1qyfSnbXOK2XpL9msl6loqhpECRg=
+github.com/gogpu/gpucontext v0.22.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=
 github.com/gogpu/gputypes v0.5.1/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.16 h1:SaDkx2laBNg1+nM25X91F7vopLalbI+MGn8diM9YB9Y=


### PR DESCRIPTION
## [0.30.25] - 2026-07-29

### Changed

- **deps:** gpucontext v0.21.1 → v0.22.0 — `FontSmoothing` type + coordinate space docs (gogpu#396, gogpu#398)