### PR TITLE
fix(gles): attach depth/stencil to swapchain FBO on surface render pass (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.26] - 2026-07-30
+
+### Fixed
+
+- **GLES: depth/stencil not attached to swapchain FBO on surface render pass** —
+  `setupSurfaceTarget()` had an early return that skipped depth/stencil attachment.
+  3D content with depth testing was invisible on GLES while Vulkan and DX12 worked
+  correctly. Now attaches depth/stencil to the swapchain FBO via
+  `AttachDepthStencilToFBOCommand`. Matches Rust wgpu-hal GLES `begin_render_pass`
+  which uses the same draw_fbo path for both surface and offscreen targets. (#284)
+
+### Changed
+
+- **deps:** gpucontext v0.22.0 → v0.23.0
+
 ## [0.30.25] - 2026-07-29
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.6.2
 	github.com/go-webgpu/webgpu v0.5.4
-	github.com/gogpu/gpucontext v0.22.0
+	github.com/gogpu/gpucontext v0.23.0
 	github.com/gogpu/gputypes v0.5.1
 	github.com/gogpu/naga v0.17.16
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.2 h1:xuMaUbqsNQ/xiyy5UwAKZb5vQZUDg9QRCrJIpHJaXSE
 github.com/go-webgpu/goffi v0.6.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V4=
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
-github.com/gogpu/gpucontext v0.22.0 h1:H4pS3H/iU392BUL1qyfSnbXOK2XpL9msl6loqhpECRg=
-github.com/gogpu/gpucontext v0.22.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
+github.com/gogpu/gpucontext v0.23.0 h1:DiqZfXk2x5mql76zLUToB6a352J6NoAuE25VZbT/D5g=
+github.com/gogpu/gpucontext v0.23.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=
 github.com/gogpu/gputypes v0.5.1/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.16 h1:SaDkx2laBNg1+nM25X91F7vopLalbI+MGn8diM9YB9Y=

--- a/hal/gles/command.go
+++ b/hal/gles/command.go
@@ -294,7 +294,7 @@ func (e *CommandEncoder) setupColorAttachment(desc *hal.RenderPassDescriptor, rp
 	}
 
 	if tv.isSurface {
-		e.setupSurfaceTarget(tv, rpe)
+		e.setupSurfaceTarget(desc, tv, rpe)
 		return
 	}
 
@@ -313,7 +313,7 @@ func (e *CommandEncoder) setupColorAttachment(desc *hal.RenderPassDescriptor, rp
 // Y-flip (WriterFlagAdjustCoordinateSpace). Queue.Present performs an explicit
 // Y-flipping glBlitFramebuffer from this FBO to FBO 0 before SwapBuffers.
 // Mirrors Rust wgpu-hal/src/gles/egl.rs Surface::configure/Surface::present.
-func (e *CommandEncoder) setupSurfaceTarget(tv *TextureView, rpe *RenderPassEncoder) {
+func (e *CommandEncoder) setupSurfaceTarget(desc *hal.RenderPassDescriptor, tv *TextureView, rpe *RenderPassEncoder) {
 	if tv.surfaceTex != nil && tv.surfaceTex.surface != nil {
 		surf := tv.surfaceTex.surface
 		e.commands = append(e.commands, &BindSurfaceFramebufferCommand{surface: surf})
@@ -324,6 +324,17 @@ func (e *CommandEncoder) setupSurfaceTarget(tv *TextureView, rpe *RenderPassEnco
 				width:  float32(cfg.Width),
 				height: float32(cfg.Height),
 			})
+		}
+		// Attach depth/stencil to the swapchain FBO if requested.
+		// The swapchain FBO is a real GL FBO (not FBO 0), so glFramebufferTexture2D
+		// works. Matches Rust wgpu-hal GLES: BindAttachment for depth/stencil after
+		// ResetFramebuffer { is_default: false } (command.rs:575-601).
+		if desc.DepthStencilAttachment != nil {
+			if dsView, ok := desc.DepthStencilAttachment.View.(*TextureView); ok && dsView.texture != nil {
+				e.commands = append(e.commands, &AttachDepthStencilToFBOCommand{
+					depthTexture: dsView.texture,
+				})
+			}
 		}
 		return
 	}
@@ -844,6 +855,18 @@ func (c *AttachDepthStencilCommand) Execute(ctx *gl.Context) {
 	// combined depth+stencil formats (e.g., Depth24PlusStencil8). For
 	// depth-only formats the driver silently ignores the stencil part.
 	// Use the texture's actual target (GL_TEXTURE_2D or GL_TEXTURE_2D_MULTISAMPLE).
+	ctx.FramebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, c.depthTexture.target, c.depthTexture.id, 0)
+}
+
+// AttachDepthStencilToFBOCommand attaches a depth/stencil texture to the
+// currently bound FBO. Unlike AttachDepthStencilCommand, this does not
+// reference a color texture — it operates on whatever FBO is currently bound
+// (typically the surface swapchain FBO).
+type AttachDepthStencilToFBOCommand struct {
+	depthTexture *Texture
+}
+
+func (c *AttachDepthStencilToFBOCommand) Execute(ctx *gl.Context) {
 	ctx.FramebufferTexture2D(gl.FRAMEBUFFER, gl.DEPTH_STENCIL_ATTACHMENT, c.depthTexture.target, c.depthTexture.id, 0)
 }
 


### PR DESCRIPTION
## Summary

- **#284**: GLES depth/stencil not attached to swapchain FBO on surface render pass — 3D content invisible
- Root cause: `setupSurfaceTarget()` early return skipped depth/stencil attachment
- Fix: `AttachDepthStencilToFBOCommand` attaches to currently bound FBO (swapchain FBO is a real GL FBO, not FBO 0)
- Matches Rust wgpu-hal GLES `begin_render_pass` which uses same `draw_fbo` path for surface and offscreen
- Also bumps gpucontext v0.22.0 → v0.23.0

## Test plan

- [x] `go build ./...` — native
- [x] `GOOS=js GOARCH=wasm go build .` — browser
- [x] All tests pass
- [x] `golangci-lint` — 0 issues
- [x] `gofmt` — clean
- [ ] Visual: `GOGPU_GRAPHICS_API=gles go run g3d/examples/fullscreen-overlay/` — 3D cube visible (requires g3d)
