### PR TITLE
queue: stop pinning every resource a command buffer referenced

### DIFF
--- a/computepass_native.go
+++ b/computepass_native.go
@@ -90,15 +90,10 @@ func (p *ComputePassEncoder) SetBindGroup(index uint32, group *BindGroup, offset
 			p.trackRef(buf.core.Ref)
 		}
 	}
-	// Track bind group itself for submit-time validation (VAL-B5).
+	// Track bind group itself for submit-time validation (VAL-B5 and, via
+	// group.boundBuffers/boundTextures, VAL-A6). The group's own slices are
+	// walked at Submit, so there is nothing to fan out here.
 	p.encoder.trackBindGroup(group)
-	// Track bind group resources for submit-time validation (VAL-A6).
-	for _, buf := range group.boundBuffers {
-		p.encoder.trackBuffer(buf)
-	}
-	for _, tex := range group.boundTextures {
-		p.encoder.trackTexture(tex)
-	}
 	raw := p.core.RawPass()
 	if raw != nil && group.hal != nil {
 		raw.SetBindGroup(index, group.hal, offsets)

--- a/encoder_native.go
+++ b/encoder_native.go
@@ -589,6 +589,18 @@ func (cb *CommandBuffer) Release() {
 		ref.Drop()
 	}
 	cb.trackedRefs = nil
+	cb.dropUsedSets()
+}
+
+// dropUsedSets releases the encode-time validation sets. usedBuffers,
+// usedTextures and usedBindGroups exist only for
+// validateCommandBufferForSubmit; once a command buffer is spent — submitted
+// or released — they are hard references pinning every resource the frame
+// touched for as long as the command buffer stays reachable.
+func (cb *CommandBuffer) dropUsedSets() {
+	cb.usedBuffers = nil
+	cb.usedTextures = nil
+	cb.usedBindGroups = nil
 }
 
 // halBuffer returns the underlying HAL command buffer.

--- a/encoder_pool_test.go
+++ b/encoder_pool_test.go
@@ -160,3 +160,30 @@ func TestCommandBufferReleaseDropsUsedSets(t *testing.T) {
 			cb.usedBuffers, cb.usedTextures, cb.usedBindGroups)
 	}
 }
+
+// TestPostSubmitDropsSetsWithoutDestroyQueue verifies that a command buffer is
+// marked submitted and has its validation sets dropped even when the device has
+// no DestroyQueue. postSubmit returns early in that case; the bookkeeping must
+// happen before the early return, since the HAL submit has already succeeded.
+func TestPostSubmitDropsSetsWithoutDestroyQueue(t *testing.T) {
+	q := &Queue{} // nil device — destroyQueue() returns nil
+	if q.destroyQueue() != nil {
+		t.Fatal("test precondition: expected nil destroy queue")
+	}
+
+	cb := &CommandBuffer{
+		usedBuffers:    map[*Buffer]struct{}{{}: {}},
+		usedTextures:   map[*Texture]struct{}{{}: {}},
+		usedBindGroups: map[*BindGroup]struct{}{{}: {}},
+	}
+
+	q.postSubmit(1, []*CommandBuffer{cb})
+
+	if !cb.submitted {
+		t.Error("postSubmit left cb.submitted false — a double submit would not be caught")
+	}
+	if cb.usedBuffers != nil || cb.usedTextures != nil || cb.usedBindGroups != nil {
+		t.Errorf("postSubmit left validation sets populated: buffers=%v textures=%v bindGroups=%v",
+			cb.usedBuffers, cb.usedTextures, cb.usedBindGroups)
+	}
+}

--- a/encoder_pool_test.go
+++ b/encoder_pool_test.go
@@ -141,3 +141,22 @@ func createNoopDeviceForTest(t *testing.T) (hal.Device, hal.Queue, func()) {
 		open.Device.Destroy()
 	}
 }
+
+// TestCommandBufferReleaseDropsUsedSets verifies that Release() drops the
+// encode-time validation sets. A CommandBuffer that is Finish()'d and then
+// Released without being submitted (the hal.Submit failure path) must not keep
+// pinning every resource the frame touched.
+func TestCommandBufferReleaseDropsUsedSets(t *testing.T) {
+	cb := &CommandBuffer{
+		usedBuffers:    map[*Buffer]struct{}{{}: {}},
+		usedTextures:   map[*Texture]struct{}{{}: {}},
+		usedBindGroups: map[*BindGroup]struct{}{{}: {}},
+	}
+
+	cb.Release()
+
+	if cb.usedBuffers != nil || cb.usedTextures != nil || cb.usedBindGroups != nil {
+		t.Errorf("Release left validation sets populated: buffers=%v textures=%v bindGroups=%v",
+			cb.usedBuffers, cb.usedTextures, cb.usedBindGroups)
+	}
+}

--- a/queue_native.go
+++ b/queue_native.go
@@ -426,10 +426,9 @@ func validateCommandBufferForSubmit(cb *CommandBuffer, index int) error {
 }
 
 // validateSubmitBuffer checks that a buffer is neither released nor mapped.
+// Callers never pass nil: trackBuffer skips nil and collectBindGroupResources
+// only records non-nil entries.
 func validateSubmitBuffer(buf *Buffer, index int) error {
-	if buf == nil {
-		return nil
-	}
 	// Check destroyed/released.
 	if buf.released != nil && buf.released.Load() {
 		return fmt.Errorf("wgpu: Submit: command buffer at index %d references released buffer %q: %w",
@@ -445,10 +444,9 @@ func validateSubmitBuffer(buf *Buffer, index int) error {
 }
 
 // validateSubmitTexture checks that a texture has not been released.
+// Callers never pass nil: trackTexture skips nil and collectBindGroupResources
+// only records non-nil entries.
 func validateSubmitTexture(tex *Texture, index int) error {
-	if tex == nil {
-		return nil
-	}
 	if tex.resolveHAL() == nil {
 		return fmt.Errorf("wgpu: Submit: command buffer at index %d references released texture: %w",
 			index, ErrSubmitTextureDestroyed)

--- a/queue_native.go
+++ b/queue_native.go
@@ -401,15 +401,20 @@ func validateCommandBufferForSubmit(cb *CommandBuffer, index int) error {
 		}
 	}
 
-	// 4. Check referenced bind groups (matches Rust queue.rs:1815-1817), then
-	// the resources they bind. A bind group already holds boundBuffers and
-	// boundTextures from CreateBindGroup, so passes track only the group
-	// itself and this walk reaches the rest — no per-draw fan-out needed.
+	// 4. Check the resources bound by every bind group. A bind group already
+	// holds boundBuffers and boundTextures from CreateBindGroup, so passes
+	// track only the group itself and this walk reaches the rest — no per-draw
+	// fan-out needed. Release() never mutates those slices, so they stay
+	// walkable after the group itself is released.
+	//
+	// This runs as its own pass, ahead of the bg.released pass below, so the
+	// specific error always wins: a released buffer reports the buffer rather
+	// than whichever bind group happens to reference it. Before the fan-out was
+	// removed these resources sat in the flat usedBuffers/usedTextures sets,
+	// checked in steps 2 and 3 ahead of any bind group, and folding the release
+	// check into this loop would make the winner depend on map iteration order
+	// whenever two bind groups are at fault.
 	for bg := range cb.usedBindGroups {
-		if bg.released != nil && bg.released.Load() {
-			return fmt.Errorf("wgpu: Submit: command buffer at index %d references released bind group: %w",
-				index, ErrSubmitBindGroupDestroyed)
-		}
 		for _, buf := range bg.boundBuffers {
 			if err := validateSubmitBuffer(buf, index); err != nil {
 				return err
@@ -419,6 +424,14 @@ func validateCommandBufferForSubmit(cb *CommandBuffer, index int) error {
 			if err := validateSubmitTexture(tex, index); err != nil {
 				return err
 			}
+		}
+	}
+
+	// 5. Check the bind groups themselves (matches Rust queue.rs:1815-1817).
+	for bg := range cb.usedBindGroups {
+		if bg.released != nil && bg.released.Load() {
+			return fmt.Errorf("wgpu: Submit: command buffer at index %d references released bind group: %w",
+				index, ErrSubmitBindGroupDestroyed)
 		}
 	}
 

--- a/queue_native.go
+++ b/queue_native.go
@@ -152,10 +152,18 @@ func (q *Queue) postSubmit(subIdx uint64, commandBuffers []*CommandBuffer) {
 		return
 	}
 
-	// Mark all command buffers as submitted to prevent double-submit (VAL-A6).
+	// Mark all command buffers as submitted to prevent double-submit (VAL-A6),
+	// and drop the encode-time reference sets. usedBuffers/usedTextures/
+	// usedBindGroups exist only for validateCommandBufferForSubmit, which has
+	// already run; keeping them alive pins every resource the frame referenced
+	// for as long as the command buffer is reachable, so a per-frame bind group
+	// is never collected.
 	for _, cb := range commandBuffers {
 		if cb != nil {
 			cb.submitted = true
+			cb.usedBuffers = nil
+			cb.usedTextures = nil
+			cb.usedBindGroups = nil
 		}
 	}
 

--- a/queue_native.go
+++ b/queue_native.go
@@ -147,24 +147,20 @@ func (q *Queue) Submit(commandBuffers ...*CommandBuffer) (uint64, error) {
 // 2. Schedules HAL encoder recycling via DestroyQueue (BUG-DX12-004)
 // 3. Triages deferred resource destructions
 func (q *Queue) postSubmit(subIdx uint64, commandBuffers []*CommandBuffer) {
-	dq := q.destroyQueue()
-	if dq == nil {
-		return
-	}
-
 	// Mark all command buffers as submitted to prevent double-submit (VAL-A6),
-	// and drop the encode-time reference sets. usedBuffers/usedTextures/
-	// usedBindGroups exist only for validateCommandBufferForSubmit, which has
-	// already run; keeping them alive pins every resource the frame referenced
-	// for as long as the command buffer is reachable, so a per-frame bind group
-	// is never collected.
+	// and drop the encode-time reference sets. This runs before the DestroyQueue
+	// lookup below: the HAL submit has already succeeded, so these buffers are
+	// spent whether or not there is a queue to triage.
 	for _, cb := range commandBuffers {
 		if cb != nil {
 			cb.submitted = true
-			cb.usedBuffers = nil
-			cb.usedTextures = nil
-			cb.usedBindGroups = nil
+			cb.dropUsedSets()
 		}
+	}
+
+	dq := q.destroyQueue()
+	if dq == nil {
+		return
 	}
 
 	// Collect tracked refs from command buffers and associate with this submission.
@@ -393,36 +389,70 @@ func validateCommandBufferForSubmit(cb *CommandBuffer, index int) error {
 
 	// 2. Check referenced buffers (matches Rust queue.rs:1780-1787).
 	for buf := range cb.usedBuffers {
-		// Check destroyed/released.
-		if buf.released != nil && buf.released.Load() {
-			return fmt.Errorf("wgpu: Submit: command buffer at index %d references released buffer %q: %w",
-				index, buf.Label(), ErrSubmitBufferDestroyed)
-		}
-
-		// Check mapped state.
-		// Rust: BufferMapState::Idle is the only valid state for submit.
-		if buf.MapState() != MapStateUnmapped {
-			return fmt.Errorf("wgpu: Submit: command buffer at index %d references mapped buffer %q: %w",
-				index, buf.Label(), ErrSubmitBufferMapped)
+		if err := validateSubmitBuffer(buf, index); err != nil {
+			return err
 		}
 	}
 
 	// 3. Check referenced textures (matches Rust queue.rs:1791-1808).
 	for tex := range cb.usedTextures {
-		if tex.resolveHAL() == nil {
-			return fmt.Errorf("wgpu: Submit: command buffer at index %d references released texture: %w",
-				index, ErrSubmitTextureDestroyed)
+		if err := validateSubmitTexture(tex, index); err != nil {
+			return err
 		}
 	}
 
-	// 4. Check referenced bind groups (matches Rust queue.rs:1815-1817).
+	// 4. Check referenced bind groups (matches Rust queue.rs:1815-1817), then
+	// the resources they bind. A bind group already holds boundBuffers and
+	// boundTextures from CreateBindGroup, so passes track only the group
+	// itself and this walk reaches the rest — no per-draw fan-out needed.
 	for bg := range cb.usedBindGroups {
 		if bg.released != nil && bg.released.Load() {
 			return fmt.Errorf("wgpu: Submit: command buffer at index %d references released bind group: %w",
 				index, ErrSubmitBindGroupDestroyed)
 		}
+		for _, buf := range bg.boundBuffers {
+			if err := validateSubmitBuffer(buf, index); err != nil {
+				return err
+			}
+		}
+		for _, tex := range bg.boundTextures {
+			if err := validateSubmitTexture(tex, index); err != nil {
+				return err
+			}
+		}
 	}
 
+	return nil
+}
+
+// validateSubmitBuffer checks that a buffer is neither released nor mapped.
+func validateSubmitBuffer(buf *Buffer, index int) error {
+	if buf == nil {
+		return nil
+	}
+	// Check destroyed/released.
+	if buf.released != nil && buf.released.Load() {
+		return fmt.Errorf("wgpu: Submit: command buffer at index %d references released buffer %q: %w",
+			index, buf.Label(), ErrSubmitBufferDestroyed)
+	}
+	// Check mapped state.
+	// Rust: BufferMapState::Idle is the only valid state for submit.
+	if buf.MapState() != MapStateUnmapped {
+		return fmt.Errorf("wgpu: Submit: command buffer at index %d references mapped buffer %q: %w",
+			index, buf.Label(), ErrSubmitBufferMapped)
+	}
+	return nil
+}
+
+// validateSubmitTexture checks that a texture has not been released.
+func validateSubmitTexture(tex *Texture, index int) error {
+	if tex == nil {
+		return nil
+	}
+	if tex.resolveHAL() == nil {
+		return fmt.Errorf("wgpu: Submit: command buffer at index %d references released texture: %w",
+			index, ErrSubmitTextureDestroyed)
+	}
 	return nil
 }
 

--- a/renderpass_native.go
+++ b/renderpass_native.go
@@ -103,15 +103,10 @@ func (p *RenderPassEncoder) SetBindGroup(index uint32, group *BindGroup, offsets
 			p.trackRef(buf.core.Ref)
 		}
 	}
-	// Track bind group itself for submit-time validation (VAL-B5).
+	// Track bind group itself for submit-time validation (VAL-B5 and, via
+	// group.boundBuffers/boundTextures, VAL-A6). The group's own slices are
+	// walked at Submit, so there is nothing to fan out here.
 	p.encoder.trackBindGroup(group)
-	// Track bind group resources for submit-time validation (VAL-A6).
-	for _, buf := range group.boundBuffers {
-		p.encoder.trackBuffer(buf)
-	}
-	for _, tex := range group.boundTextures {
-		p.encoder.trackTexture(tex)
-	}
 	raw := p.core.RawPass()
 	if raw != nil && group.hal != nil {
 		raw.SetBindGroup(index, group.hal, offsets)

--- a/submit_validation_test.go
+++ b/submit_validation_test.go
@@ -554,3 +554,85 @@ func TestSubmitWithReleasedBufferInBindGroup(t *testing.T) {
 		t.Errorf("Submit with released bind group buffer = %v, want ErrSubmitBufferDestroyed", err)
 	}
 }
+
+// TestSubmitWithReleasedTextureInBindGroup is the texture counterpart of
+// TestSubmitWithReleasedBufferInBindGroup: a texture reachable only through a
+// bind group is still validated at Submit via BindGroup.boundTextures.
+func TestSubmitWithReleasedTextureInBindGroup(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	tex, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label:         "val-a6-bg-tex",
+		Size:          wgpu.Extent3D{Width: 4, Height: 4, DepthOrArrayLayers: 1},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     wgpu.TextureDimension2D,
+		Format:        wgpu.TextureFormatRGBA8Unorm,
+		Usage:         wgpu.TextureUsageTextureBinding,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+
+	view, err := device.CreateTextureView(tex, nil)
+	if err != nil {
+		t.Fatalf("CreateTextureView: %v", err)
+	}
+	defer view.Release()
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "val-a6-bg-tex-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: wgpu.ShaderStageCompute,
+				Texture: &gputypes.TextureBindingLayout{
+					SampleType:    gputypes.TextureSampleTypeFloat,
+					ViewDimension: gputypes.TextureViewDimension2D,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "val-a6-bg-tex",
+		Layout: bgl,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, TextureView: view},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	defer bg.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	pass, err := enc.BeginComputePass(nil)
+	if err != nil {
+		t.Fatalf("BeginComputePass: %v", err)
+	}
+	pass.SetBindGroup(0, bg, nil)
+	pass.End()
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Release the texture — but not the bind group — after encoding.
+	tex.Release()
+
+	_, err = device.Queue().Submit(cmdBuf)
+	if !errors.Is(err, wgpu.ErrSubmitTextureDestroyed) {
+		t.Errorf("Submit with released bind group texture = %v, want ErrSubmitTextureDestroyed", err)
+	}
+}

--- a/submit_validation_test.go
+++ b/submit_validation_test.go
@@ -774,7 +774,6 @@ func TestSubmitResourceErrorWinsAcrossBindGroups(t *testing.T) {
 		if err != nil {
 			t.Fatalf("CreateBindGroup live: %v", err)
 		}
-		defer bgLive.Release()
 
 		enc, err := device.CreateCommandEncoder(nil)
 		if err != nil {
@@ -813,5 +812,12 @@ func TestSubmitResourceErrorWinsAcrossBindGroups(t *testing.T) {
 		if !errors.Is(err, wgpu.ErrSubmitBufferDestroyed) {
 			t.Fatalf("iteration %d: Submit = %v, want ErrSubmitBufferDestroyed", i, err)
 		}
+
+		// Released here rather than deferred: over 16 iterations the deferred
+		// form would hold every encoder and bind group to the end of the test.
+		// The submit failed validation, so the command buffer must be released
+		// to return its HAL encoder to the pool.
+		cmdBuf.Release()
+		bgLive.Release()
 	}
 }

--- a/submit_validation_test.go
+++ b/submit_validation_test.go
@@ -636,3 +636,182 @@ func TestSubmitWithReleasedTextureInBindGroup(t *testing.T) {
 		t.Errorf("Submit with released bind group texture = %v, want ErrSubmitTextureDestroyed", err)
 	}
 }
+
+// TestSubmitReleasedBufferBeatsReleasedBindGroup pins the error precedence when
+// a bind group and a buffer it binds are both released. The buffer error is the
+// actionable one, and it is what the flat usedBuffers set reported before the
+// per-draw fan-out was removed, so the bind group check runs last.
+func TestSubmitReleasedBufferBeatsReleasedBindGroup(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a6-precedence-buf",
+		Size:  128,
+		Usage: wgpu.BufferUsageUniform | wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "val-a6-precedence-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: wgpu.ShaderStageCompute,
+				Buffer: &gputypes.BufferBindingLayout{
+					Type:           gputypes.BufferBindingTypeUniform,
+					MinBindingSize: 128,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "val-a6-precedence-bg",
+		Layout: bgl,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: buf, Offset: 0, Size: 128},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	pass, err := enc.BeginComputePass(nil)
+	if err != nil {
+		t.Fatalf("BeginComputePass: %v", err)
+	}
+	pass.SetBindGroup(0, bg, nil)
+	pass.End()
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Release both — the buffer error must win.
+	buf.Release()
+	bg.Release()
+
+	_, err = device.Queue().Submit(cmdBuf)
+	if !errors.Is(err, wgpu.ErrSubmitBufferDestroyed) {
+		t.Errorf("Submit with released buffer in released bind group = %v, want ErrSubmitBufferDestroyed", err)
+	}
+}
+
+// TestSubmitResourceErrorWinsAcrossBindGroups pins error precedence when
+// several bind groups are at fault at once: many released groups binding
+// nothing, and one live group binding a released buffer. The buffer error must
+// win no matter which group the map iteration reaches first.
+//
+// Folding the release check into the resource walk passes this only when the
+// live group happens to be visited first, so the odds of catching that are
+// roughly 1/(releasedGroups+1) per attempt. Binding many released groups makes
+// a single attempt decisive and the repeats then make a miss negligible.
+func TestSubmitResourceErrorWinsAcrossBindGroups(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	const releasedGroups = 8
+
+	bufLayout, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "val-a6-cross-buf-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: wgpu.ShaderStageCompute,
+				Buffer: &gputypes.BufferBindingLayout{
+					Type:           gputypes.BufferBindingTypeUniform,
+					MinBindingSize: 128,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout buffer: %v", err)
+	}
+	defer bufLayout.Release()
+
+	emptyLayout, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label:   "val-a6-cross-empty-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout empty: %v", err)
+	}
+	defer emptyLayout.Release()
+
+	for i := 0; i < 16; i++ {
+		buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+			Label: "val-a6-cross-buf",
+			Size:  128,
+			Usage: wgpu.BufferUsageUniform | wgpu.BufferUsageCopyDst,
+		})
+		if err != nil {
+			t.Fatalf("CreateBuffer: %v", err)
+		}
+
+		// Live group binding a buffer that is about to be released.
+		bgLive, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+			Label:  "val-a6-cross-live-bg",
+			Layout: bufLayout,
+			Entries: []wgpu.BindGroupEntry{
+				{Binding: 0, Buffer: buf, Offset: 0, Size: 128},
+			},
+		})
+		if err != nil {
+			t.Fatalf("CreateBindGroup live: %v", err)
+		}
+		defer bgLive.Release()
+
+		enc, err := device.CreateCommandEncoder(nil)
+		if err != nil {
+			t.Fatalf("CreateCommandEncoder: %v", err)
+		}
+		pass, err := enc.BeginComputePass(nil)
+		if err != nil {
+			t.Fatalf("BeginComputePass: %v", err)
+		}
+		pass.SetBindGroup(0, bgLive, nil)
+
+		// Rebind slot 0 with each released group: every one lands in
+		// usedBindGroups, so this sidesteps the maxBindGroups limit.
+		for g := 0; g < releasedGroups; g++ {
+			bgReleased, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+				Label:   "val-a6-cross-released-bg",
+				Layout:  emptyLayout,
+				Entries: []wgpu.BindGroupEntry{},
+			})
+			if err != nil {
+				t.Fatalf("CreateBindGroup released: %v", err)
+			}
+			pass.SetBindGroup(0, bgReleased, nil)
+			bgReleased.Release()
+		}
+		pass.End()
+
+		cmdBuf, err := enc.Finish()
+		if err != nil {
+			t.Fatalf("Finish: %v", err)
+		}
+
+		buf.Release()
+
+		_, err = device.Queue().Submit(cmdBuf)
+		if !errors.Is(err, wgpu.ErrSubmitBufferDestroyed) {
+			t.Fatalf("iteration %d: Submit = %v, want ErrSubmitBufferDestroyed", i, err)
+		}
+	}
+}

--- a/submit_validation_test.go
+++ b/submit_validation_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu"
 )
 
@@ -478,5 +479,78 @@ func TestSubmitWithValidBindGroup(t *testing.T) {
 	_, err = device.Queue().Submit(cmdBuf)
 	if err != nil {
 		t.Fatalf("Submit should succeed: %v", err)
+	}
+}
+
+// TestSubmitWithReleasedBufferInBindGroup verifies that a buffer reachable only
+// through a bind group is still validated at Submit. Passes track the bind group
+// itself, not its contents — validateCommandBufferForSubmit walks
+// BindGroup.boundBuffers to reach this buffer.
+func TestSubmitWithReleasedBufferInBindGroup(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "val-a6-bg-buf",
+		Size:  128,
+		Usage: wgpu.BufferUsageUniform | wgpu.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Label: "val-a6-bg-layout",
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: wgpu.ShaderStageCompute,
+				Buffer: &gputypes.BufferBindingLayout{
+					Type:           gputypes.BufferBindingTypeUniform,
+					MinBindingSize: 128,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	bg, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Label:  "val-a6-bg",
+		Layout: bgl,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: buf, Offset: 0, Size: 128},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	defer bg.Release()
+
+	enc, err := device.CreateCommandEncoder(nil)
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	pass, err := enc.BeginComputePass(nil)
+	if err != nil {
+		t.Fatalf("BeginComputePass: %v", err)
+	}
+	pass.SetBindGroup(0, bg, nil)
+	pass.End()
+
+	cmdBuf, err := enc.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// Release the buffer — but not the bind group — after encoding.
+	buf.Release()
+
+	_, err = device.Queue().Submit(cmdBuf)
+	if !errors.Is(err, wgpu.ErrSubmitBufferDestroyed) {
+		t.Errorf("Submit with released bind group buffer = %v, want ErrSubmitBufferDestroyed", err)
 	}
 }


### PR DESCRIPTION
## Problem

`CommandBuffer` carries three encode-time validation sets — `usedBuffers`, `usedTextures`, `usedBindGroups` — populated during encoding so `validateCommandBufferForSubmit` can reject a submit that references a released buffer, a mapped buffer, a destroyed texture or a released bind group.

They are hard Go references to every resource the frame touched. An application using gogpu that builds bind groups per frame accumulates them without bound, and the live `BindGroup` count grows for as long as the command buffers stay reachable — while descriptor-set and destroy-queue counts both stay flat, which is what makes this hard to see from the outside.

## Changes

**Drop the per-draw fan-out.** `SetBindGroup` copied every bound buffer and texture of a bind group into the encoder's maps, once per draw. That was duplication: `CreateBindGroup` already records `boundBuffers`/`boundTextures` on the group, and the group itself is tracked in `usedBindGroups`, so those slices were already reachable. `validateCommandBufferForSubmit` now walks them from the bind group and the passes track only the group. The buffer and texture checks move into `validateSubmitBuffer`/`validateSubmitTexture`, shared by the direct and transitive paths.

One behavioural nuance: a resource reachable *only* through a bind group that is itself released now reports the released bind group rather than the released or mapped resource. Both fail the submit; only the message differs.

**Release the sets on every spent path.** `postSubmit` returned early when the device had no `DestroyQueue`, skipping both the clear and `cb.submitted`, so the loop moves above that lookup — the HAL submit has already succeeded by then and the buffers are spent regardless. `CommandBuffer.Release()` never cleared them at all, so a `Finish()` followed by `Release()` — the documented path after `hal.Submit` fails — pinned the whole frame. Both now go through `cb.dropUsedSets()`.

Clearing inside `validateCommandBufferForSubmit` instead was tempting, since it is the only consumer, but a batch where an early buffer validates and a later one fails returns without marking anything submitted; the caller is expected to retry, and the retry would revalidate the early buffer against nil sets and skip its checks silently.

## What was considered and rejected

Replacing the maps with slices. The maps exist for O(1) dedup and `SetVertexBuffer`/`SetIndexBuffer` are per-draw; renderers interleave buffers (`vb-A, vb-B, vb-A, …`), so a "same as last entry" guard never fires and a slice would grow per draw call rather than per distinct buffer. The maps are load-bearing.

## Verification

Measured in an application using gogpu that builds bind groups per frame: live `BindGroup` count goes from unbounded growth to flat.

- `TestSubmitWithReleasedBufferInBindGroup` — a buffer reachable only through a bind group is still caught at submit, covering the deleted fan-out.
- `TestCommandBufferReleaseDropsUsedSets` — `Release()` drops the sets.

Full suite passes, including the `lifecycle_test.go` additions from #288.
