### PR TITLE
release: v0.30.32 — deps gpucontext v0.24.0 (ScaleChangedEvent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.32] - 2026-08-01
+
+### Changed
+
+- **deps:** gpucontext v0.23.0 → v0.24.0 — `ScaleChangedEvent` for runtime DPI change (ADR-059, gogpu#409)
+
 ## [0.30.31] - 2026-08-01
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/go-webgpu/goffi v0.6.2
 	github.com/go-webgpu/webgpu v0.5.4
-	github.com/gogpu/gpucontext v0.23.0
+	github.com/gogpu/gpucontext v0.24.0
 	github.com/gogpu/gputypes v0.5.1
 	github.com/gogpu/naga v0.17.16
 	golang.org/x/sys v0.47.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/go-webgpu/goffi v0.6.2 h1:xuMaUbqsNQ/xiyy5UwAKZb5vQZUDg9QRCrJIpHJaXSE
 github.com/go-webgpu/goffi v0.6.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V4=
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
-github.com/gogpu/gpucontext v0.23.0 h1:DiqZfXk2x5mql76zLUToB6a352J6NoAuE25VZbT/D5g=
-github.com/gogpu/gpucontext v0.23.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
+github.com/gogpu/gpucontext v0.24.0 h1:YQ0FxGqXEO8LQB+6/TOqZOV1fn0mO9UDYR0obSU3R6o=
+github.com/gogpu/gpucontext v0.24.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=
 github.com/gogpu/gputypes v0.5.1/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.17.16 h1:SaDkx2laBNg1+nM25X91F7vopLalbI+MGn8diM9YB9Y=


### PR DESCRIPTION
## [0.30.32] - 2026-08-01

### Changed

- **deps:** gpucontext v0.23.0 → v0.24.0 — `ScaleChangedEvent` for runtime DPI change (ADR-059, gogpu#409)