### PR TITLE
deps: goffi v0.6.3 + gpucontext v0.24.0 (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.33] - 2026-08-01
+
+### Changed
+
+- **deps:** goffi v0.6.2 → v0.6.3 — fixes ARM64 HFA return checkptr crash under
+  `-race` (go-webgpu/goffi#67)
+
 ## [0.30.32] - 2026-08-01
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/wgpu
 go 1.25.0
 
 require (
-	github.com/go-webgpu/goffi v0.6.2
+	github.com/go-webgpu/goffi v0.6.3
 	github.com/go-webgpu/webgpu v0.5.4
 	github.com/gogpu/gpucontext v0.24.0
 	github.com/gogpu/gputypes v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.6.2 h1:xuMaUbqsNQ/xiyy5UwAKZb5vQZUDg9QRCrJIpHJaXSE=
-github.com/go-webgpu/goffi v0.6.2/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A=
+github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V4=
 github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
 github.com/gogpu/gpucontext v0.24.0 h1:YQ0FxGqXEO8LQB+6/TOqZOV1fn0mO9UDYR0obSU3R6o=

--- a/scripts/check-android-arm64-preview.sh
+++ b/scripts/check-android-arm64-preview.sh
@@ -52,7 +52,7 @@ require_checkout() {
 }
 
 goffi_module=github.com/go-webgpu/goffi
-goffi_version=v0.6.2
+goffi_version=v0.6.3
 (
 	cd "$root"
 	GOWORK=off go mod download "$goffi_module@$goffi_version"


### PR DESCRIPTION
PATCH release v0.30.32. goffi v0.6.3 fixes ARM64 HFA return checkptr crash under -race (go-webgpu/goffi#67). gpucontext v0.24.0 adds ScaleChangedEvent (ADR-059).