### PR TITLE
deps: naga v0.18.0, webgpu v0.5.5 v0.30.34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.30.34] - 2026-08-02
+
+### Changed
+
+- **deps:** naga v0.17.16 → v0.18.0 — unified validator (ADR-002), Rust naga parity
+- **deps:** webgpu v0.5.4 → v0.5.5 — goffi v0.6.3 cascade
+
 ## [0.30.33] - 2026-08-01
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.25.0
 
 require (
 	github.com/go-webgpu/goffi v0.6.3
-	github.com/go-webgpu/webgpu v0.5.4
+	github.com/go-webgpu/webgpu v0.5.5
 	github.com/gogpu/gpucontext v0.24.0
 	github.com/gogpu/gputypes v0.5.1
-	github.com/gogpu/naga v0.17.16
+	github.com/gogpu/naga v0.18.0
 	golang.org/x/sys v0.47.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,12 @@
 github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A=
 github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
-github.com/go-webgpu/webgpu v0.5.4 h1:4Tjcq3T2Zz81iOrxDfs7qcdWG45WZUFTvjhvtVc4/V4=
-github.com/go-webgpu/webgpu v0.5.4/go.mod h1:iUdgoB4ISDyXvozQ7E4oiudvNZTB8ol1NngUWmdZGqQ=
+github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
+github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
 github.com/gogpu/gpucontext v0.24.0 h1:YQ0FxGqXEO8LQB+6/TOqZOV1fn0mO9UDYR0obSU3R6o=
 github.com/gogpu/gpucontext v0.24.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
 github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=
 github.com/gogpu/gputypes v0.5.1/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.17.16 h1:SaDkx2laBNg1+nM25X91F7vopLalbI+MGn8diM9YB9Y=
-github.com/gogpu/naga v0.17.16/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.18.0 h1:2y83HUcAnlwEZMuHOiYTMdNYM9J8rev40gkI4zJ96Uk=
+github.com/gogpu/naga v0.18.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
PATCH release. naga v0.18.0 (unified validator ADR-002, Rust parity). webgpu v0.5.5 (goffi v0.6.3 cascade).