### PR TITLE
fix(metal): bind buffer sizes for runtime arrays

### DIFF
--- a/arraylength_repro_test.go
+++ b/arraylength_repro_test.go
@@ -1,0 +1,269 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build integration && darwin && !rust && !(js && wasm)
+
+package wgpu_test
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+
+	// Register the Metal HAL backend. Without a real backend registered only
+	// the noop/software backends are available, and neither executes compute.
+	//
+	// This import is why the file sits behind the integration tag: registering
+	// a real backend changes adapter selection for every test in the package.
+	_ "github.com/gogpu/wgpu/hal/metal"
+)
+
+// arrayLengthShader writes arrayLength(&out) into the first element of a
+// runtime-sized storage array.
+//
+// WGSL defines arrayLength() as the number of elements bound to the binding, so
+// for a 16-byte binding of u32 the only correct answer is 4. One invocation
+// writes it, so the result cannot depend on dispatch size, scheduling, thread
+// index, or buffer placement.
+const arrayLengthShader = `
+@group(0) @binding(0) var<storage, read_write> out: array<u32>;
+
+@compute @workgroup_size(1)
+fn main() {
+    out[0] = arrayLength(&out);
+}
+`
+
+// noArrayLengthShader has no runtime-sized array, but uses the same explicit
+// pipeline layout as arrayLengthShader. It lets a test switch between compatible
+// pipelines without rebinding the bind group.
+const noArrayLengthShader = `
+@compute @workgroup_size(1)
+fn main() {}
+`
+
+// arrayLengthElems is the element count bound to the storage binding.
+const arrayLengthElems = 4
+
+type arrayLengthBindOrder uint8
+
+const (
+	pipelineBeforeBindGroup arrayLengthBindOrder = iota
+	bindGroupBeforePipeline
+	compatiblePipelineSwitch
+)
+
+// TestArrayLengthReportsBoundSize asserts the WGSL contract that arrayLength()
+// equals the number of elements bound to the binding.
+//
+// This currently FAILS on Metal, returning 0x40000000 instead of 4.
+//
+// naga's MSL backend cannot express arrayLength() directly — MSL has no
+// equivalent construct — so it lowers it to
+// `1 + (_buffer_sizes.sizeN - offset - elemSize) / stride`, reading an extra
+// `constant _mslBufferSizes&` entry-point argument. That argument only carries
+// a [[buffer(N)]] attribute when msl.Options.PerEntryPointMap[ep].SizesBuffer
+// is set, and CreateShaderModule passes msl.DefaultOptions(), which leaves the
+// map nil. naga still reports the requirement via
+// TranslationInfo.RequiresSizesBuffer, but hal/metal never reads that flag and
+// never creates or binds a sizes buffer.
+//
+// The observed 0x40000000 follows from _buffer_sizes.size0 reading as zero:
+// in uint, 1 + (0 - 0 - 4) / 4 underflows to 1 + 0x3FFFFFFF. Which buffer
+// index Metal assigns to the un-attributed argument is not verified here.
+//
+// The defect is specific to Metal by construction: this extra argument exists
+// only in naga's MSL backend. SPIR-V emits OpArrayLength, HLSL emits a
+// NagaBufferLength helper over ByteAddressBuffer.GetDimensions, DXIL emits
+// dx.op.getDimensions, and GLSL emits .length() — all derived from the bound
+// resource, so there is nothing extra left to bind.
+func TestArrayLengthReportsBoundSize(t *testing.T) {
+	testArrayLengthReportsBoundSize(t, pipelineBeforeBindGroup)
+}
+
+// TestArrayLengthReportsBoundSizeWhenBindGroupPrecedesPipeline verifies that
+// buffer-size state does not depend on whether the pipeline is set first.
+func TestArrayLengthReportsBoundSizeWhenBindGroupPrecedesPipeline(t *testing.T) {
+	testArrayLengthReportsBoundSize(t, bindGroupBeforePipeline)
+}
+
+// TestArrayLengthReportsBoundSizeAfterCompatiblePipelineSwitch verifies that a
+// compatible bind group remains usable when switching from a pipeline that
+// needs no sizes buffer to one that does.
+func TestArrayLengthReportsBoundSizeAfterCompatiblePipelineSwitch(t *testing.T) {
+	testArrayLengthReportsBoundSize(t, compatiblePipelineSwitch)
+}
+
+func testArrayLengthReportsBoundSize(t *testing.T, order arrayLengthBindOrder) {
+	t.Helper()
+
+	const u32Size = 4
+	const nbytes = uint64(arrayLengthElems) * u32Size
+
+	instance, err := wgpu.CreateInstance(&wgpu.InstanceDescriptor{Backends: wgpu.BackendsPrimary})
+	if err != nil {
+		t.Skipf("CreateInstance: %v", err)
+	}
+	defer instance.Release()
+
+	adapter, err := instance.RequestAdapter(&wgpu.RequestAdapterOptions{
+		PowerPreference: gputypes.PowerPreferenceHighPerformance,
+	})
+	if err != nil {
+		t.Skipf("RequestAdapter: %v", err)
+	}
+	defer adapter.Release()
+
+	device, err := adapter.RequestDevice(&wgpu.DeviceDescriptor{Label: "arraylength-repro"})
+	if err != nil {
+		t.Skipf("RequestDevice: %v", err)
+	}
+	defer device.Release()
+
+	info := adapter.Info()
+	t.Logf("adapter: backend=%v name=%q", info.Backend, info.Name)
+
+	shader, err := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{WGSL: arrayLengthShader})
+	if err != nil {
+		t.Fatalf("CreateShaderModule: %v", err)
+	}
+	defer shader.Release()
+
+	bgl, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Entries: []wgpu.BindGroupLayoutEntry{{
+			Binding:    0,
+			Visibility: wgpu.ShaderStageCompute,
+			Buffer:     &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeStorage},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	defer bgl.Release()
+
+	pipelineLayout, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{
+		BindGroupLayouts: []*wgpu.BindGroupLayout{bgl},
+	})
+	if err != nil {
+		t.Fatalf("CreatePipelineLayout: %v", err)
+	}
+	defer pipelineLayout.Release()
+
+	pipeline, err := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+		Layout:     pipelineLayout,
+		Module:     shader,
+		EntryPoint: "main",
+	})
+	if err != nil {
+		t.Fatalf("CreateComputePipeline: %v", err)
+	}
+	defer pipeline.Release()
+
+	var noSizesPipeline *wgpu.ComputePipeline
+	if order == compatiblePipelineSwitch {
+		noSizesShader, shaderErr := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{WGSL: noArrayLengthShader})
+		if shaderErr != nil {
+			t.Fatalf("CreateShaderModule(no arrayLength): %v", shaderErr)
+		}
+		defer noSizesShader.Release()
+
+		noSizesPipeline, err = device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+			Layout:     pipelineLayout,
+			Module:     noSizesShader,
+			EntryPoint: "main",
+		})
+		if err != nil {
+			t.Fatalf("CreateComputePipeline(no arrayLength): %v", err)
+		}
+		defer noSizesPipeline.Release()
+	}
+
+	storage, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "arraylength-storage",
+		Size:  nbytes,
+		Usage: gputypes.BufferUsageStorage | gputypes.BufferUsageCopyDst | gputypes.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer(storage): %v", err)
+	}
+	defer storage.Release()
+
+	// Zero the buffer so a non-zero readback can only come from the dispatch.
+	device.Queue().WriteBuffer(storage, 0, make([]byte, nbytes))
+
+	bindGroup, err := device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Layout:  bgl,
+		Entries: []wgpu.BindGroupEntry{{Binding: 0, Buffer: storage, Offset: 0, Size: nbytes}},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	defer bindGroup.Release()
+
+	staging, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "arraylength-staging",
+		Size:  nbytes,
+		Usage: gputypes.BufferUsageMapRead | gputypes.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer(staging): %v", err)
+	}
+	defer staging.Release()
+
+	encoder, err := device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{})
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	pass, err := encoder.BeginComputePass(&wgpu.ComputePassDescriptor{})
+	if err != nil {
+		t.Fatalf("BeginComputePass: %v", err)
+	}
+	switch order {
+	case pipelineBeforeBindGroup:
+		pass.SetPipeline(pipeline)
+		pass.SetBindGroup(0, bindGroup, nil)
+	case bindGroupBeforePipeline:
+		pass.SetBindGroup(0, bindGroup, nil)
+		pass.SetPipeline(pipeline)
+	case compatiblePipelineSwitch:
+		pass.SetPipeline(noSizesPipeline)
+		pass.SetBindGroup(0, bindGroup, nil)
+		pass.SetPipeline(pipeline)
+	default:
+		t.Fatalf("unknown bind order %d", order)
+	}
+	pass.Dispatch(1, 1, 1)
+	if err := pass.End(); err != nil {
+		t.Fatalf("ComputePass.End: %v", err)
+	}
+
+	encoder.CopyBufferToBuffer(storage, 0, staging, 0, nbytes)
+
+	cmd, err := encoder.Finish()
+	if err != nil {
+		t.Fatalf("CommandEncoder.Finish: %v", err)
+	}
+	if _, err := device.Queue().Submit(cmd); err != nil {
+		t.Fatalf("Queue.Submit: %v", err)
+	}
+
+	if err := staging.Map(context.Background(), wgpu.MapModeRead, 0, nbytes); err != nil {
+		t.Fatalf("Buffer.Map: %v", err)
+	}
+	rng, err := staging.MappedRange(0, nbytes)
+	if err != nil {
+		t.Fatalf("Buffer.MappedRange: %v", err)
+	}
+	got := binary.LittleEndian.Uint32(rng.Bytes())
+	staging.Unmap()
+
+	if got != arrayLengthElems {
+		t.Errorf("arrayLength(&out) = %d (0x%08X); want %d\n"+
+			"backend %v derived a runtime array length from an unbound buffer-sizes argument",
+			got, got, arrayLengthElems, info.Backend)
+	}
+}

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gogpu/naga/ir"
 	"github.com/gogpu/naga/msl"
 	"github.com/gogpu/wgpu/hal"
+	"github.com/gogpu/wgpu/hal/metal/mslmap"
 )
 
 // Vertex buffer indices are assigned from the end of the range and count down.
@@ -497,7 +498,12 @@ func (d *Device) CreatePipelineLayout(desc *hal.PipelineLayoutDescriptor) (hal.P
 			samAccum += bgl.samplerCount
 		}
 	}
-	return &PipelineLayout{layouts: desc.BindGroupLayouts, device: d, groupOffsets: offsets}, nil
+	return &PipelineLayout{
+		layouts:      desc.BindGroupLayouts,
+		device:       d,
+		groupOffsets: offsets,
+		totalBuffers: bufAccum,
+	}, nil
 }
 
 // DestroyPipelineLayout destroys a pipeline layout.
@@ -510,73 +516,140 @@ func (d *Device) DestroyPipelineLayout(layout hal.PipelineLayout) {
 }
 
 // CreateShaderModule creates a shader module.
+//
+// This function parses WGSL and lowers it to naga IR. It does not write MSL,
+// because the buffer slot for naga's `_buffer_sizes` argument comes from the
+// pipeline layout, which is not known yet. The pipeline writes the MSL later.
+// WGSL syntax and validation errors are still reported here.
+//
+// Reference: Rust wgpu-hal metal/device.rs:138-145 (load_shader takes the
+// pipeline layout and is called from create_*_pipeline).
 func (d *Device) CreateShaderModule(desc *hal.ShaderModuleDescriptor) (hal.ShaderModule, error) {
-	// If WGSL source is provided, compile to MSL
-	if desc.Source.WGSL != "" { //nolint:nestif // WGSL→MSL pipeline is sequential; splitting would scatter coupled logic
-		start := time.Now()
-
-		// Parse WGSL to AST
-		ast, err := naga.Parse(desc.Source.WGSL)
-		if err != nil {
-			return nil, fmt.Errorf("metal: failed to parse WGSL: %w", err)
-		}
-
-		// Lower AST to IR
-		irModule, err := naga.LowerWithSource(ast, desc.Source.WGSL)
-		if err != nil {
-			return nil, fmt.Errorf("metal: failed to lower WGSL to IR: %w", err)
-		}
-
-		// Extract workgroup sizes from entry points for compute shaders
-		workgroupSizes := extractWorkgroupSizes(irModule)
-
-		// Compile IR to MSL
-		mslSource, info, err := msl.Compile(irModule, msl.DefaultOptions())
-		if err != nil {
-			return nil, fmt.Errorf("metal: failed to compile to MSL: %w", err)
-		}
-
-		hal.Logger().Debug("metal: WGSL→MSL compilation",
-			"elapsed", time.Since(start),
-			"mslBytes", len(mslSource),
-		)
-
-		// Create NSString from MSL source
-		mslString := NSString(mslSource)
-		defer Release(mslString)
-
-		// Create MTLLibrary from source
-		// MTLLibrary* newLibraryWithSource:options:error:
-		var errorPtr ID
-		library := MsgSend(d.raw, Sel("newLibraryWithSource:options:error:"),
-			uintptr(mslString), 0, uintptr(unsafe.Pointer(&errorPtr)))
-
-		if library == 0 {
-			errMsg := unknownError
-			if errorPtr != 0 {
-				if details := formatNSError(errorPtr); details != "" {
-					errMsg = details
-				}
-				// Object is autoreleased
-			}
-			return nil, fmt.Errorf("metal: failed to compile MSL: %s\nMSL:\n%s", errMsg, mslSource)
-		}
-
-		hal.Logger().Info("metal: shader module compiled",
-			"entryPoints", len(workgroupSizes),
-		)
-
-		return &ShaderModule{
-			source:          desc.Source,
-			library:         library,
-			device:          d,
-			workgroupSizes:  workgroupSizes,
-			entrypointNames: info.EntryPointNames,
-		}, nil
+	if desc.Source.WGSL == "" {
+		// No WGSL source - just store the descriptor for later
+		return &ShaderModule{source: desc.Source, device: d}, nil
 	}
 
-	// No WGSL source - just store the descriptor for later
-	return &ShaderModule{source: desc.Source, device: d}, nil
+	start := time.Now()
+
+	// Parse WGSL to AST
+	ast, err := naga.Parse(desc.Source.WGSL)
+	if err != nil {
+		return nil, fmt.Errorf("metal: failed to parse WGSL: %w", err)
+	}
+
+	// Lower AST to IR
+	irModule, err := naga.LowerWithSource(ast, desc.Source.WGSL)
+	if err != nil {
+		return nil, fmt.Errorf("metal: failed to lower WGSL to IR: %w", err)
+	}
+
+	// Extract workgroup sizes from entry points for compute shaders
+	workgroupSizes := extractWorkgroupSizes(irModule)
+
+	hal.Logger().Debug("metal: WGSL→IR lowering",
+		"elapsed", time.Since(start),
+		"entryPoints", len(irModule.EntryPoints),
+	)
+
+	return &ShaderModule{
+		source:         desc.Source,
+		irModule:       irModule,
+		device:         d,
+		workgroupSizes: workgroupSizes,
+	}, nil
+}
+
+// compiledLibrary holds one MSL translation of a shader module and the data
+// that the caller needs in order to bind it.
+type compiledLibrary struct {
+	library         ID // id<MTLLibrary>; the caller must release it
+	entrypointNames map[string]string
+	// sizesBindings lists the bindings whose byte size the kernel needs, in
+	// the field order that naga uses. It is empty if the shader has no
+	// runtime-sized array.
+	sizesBindings []ir.ResourceBinding
+	// sizesSlot is the buffer slot that the `_buffer_sizes` argument was
+	// compiled with. It has a meaning only if sizesBindings is not empty.
+	sizesSlot int
+}
+
+// compileLibrary writes MSL for the shader module and builds an MTLLibrary
+// from it.
+//
+// If bindSizes is true, the MSL binds naga's `_buffer_sizes` argument to the
+// first free buffer slot from the pipeline layout. If it is false, naga assigns
+// the bindings on its own, and the MSL is the same as in earlier releases.
+//
+// Reference: Rust wgpu-hal metal/device.rs:138-145.
+func (d *Device) compileLibrary(module *ShaderModule, layout *PipelineLayout, bindSizes bool) (*compiledLibrary, error) {
+	if module == nil || module.irModule == nil {
+		return nil, fmt.Errorf("metal: shader module has no WGSL source")
+	}
+
+	start := time.Now()
+
+	out := &compiledLibrary{}
+	options := msl.DefaultOptions()
+	if bindSizes {
+		bindings, err := mslmap.RuntimeArrayBindings(module.irModule)
+		if err != nil {
+			return nil, fmt.Errorf("metal: %w", err)
+		}
+		if len(bindings) > 0 {
+			if layout == nil {
+				// Without a slot, the `_buffer_sizes` argument
+				// stays unbound and arrayLength() reads
+				// whatever the slot happens to hold.
+				return nil, fmt.Errorf("metal: shader uses runtime-sized arrays but has no pipeline layout")
+			}
+			options, err = mslmap.Options(module.irModule, layout.totalBuffers)
+			if err != nil {
+				return nil, fmt.Errorf("metal: %w", err)
+			}
+			out.sizesBindings = bindings
+			out.sizesSlot = layout.totalBuffers
+		}
+	}
+
+	mslSource, info, err := msl.Compile(module.irModule, options)
+	if err != nil {
+		return nil, fmt.Errorf("metal: failed to compile to MSL: %w", err)
+	}
+	if info.RequiresSizesBuffer && len(out.sizesBindings) == 0 && bindSizes {
+		return nil, fmt.Errorf("metal: shader requires a buffer sizes argument but no runtime-sized array binding was found")
+	}
+	out.entrypointNames = info.EntryPointNames
+
+	hal.Logger().Debug("metal: IR→MSL compilation",
+		"elapsed", time.Since(start),
+		"mslBytes", len(mslSource),
+		"sizesBuffer", len(out.sizesBindings) > 0,
+	)
+
+	// Create NSString from MSL source
+	mslString := NSString(mslSource)
+	defer Release(mslString)
+
+	// Create MTLLibrary from source
+	// MTLLibrary* newLibraryWithSource:options:error:
+	var errorPtr ID
+	library := MsgSend(d.raw, Sel("newLibraryWithSource:options:error:"),
+		uintptr(mslString), 0, uintptr(unsafe.Pointer(&errorPtr)))
+
+	if library == 0 {
+		errMsg := unknownError
+		if errorPtr != 0 {
+			if details := formatNSError(errorPtr); details != "" {
+				errMsg = details
+			}
+			// Object is autoreleased
+		}
+		return nil, fmt.Errorf("metal: failed to compile MSL: %s\nMSL:\n%s", errMsg, mslSource)
+	}
+	out.library = library
+
+	return out, nil
 }
 
 func formatNSError(errObj ID) string {
@@ -607,10 +680,7 @@ func (d *Device) DestroyShaderModule(module hal.ShaderModule) {
 	if !ok || mtlModule == nil {
 		return
 	}
-	if mtlModule.library != 0 {
-		Release(mtlModule.library)
-		mtlModule.library = 0
-	}
+	mtlModule.irModule = nil
 	mtlModule.device = nil
 }
 
@@ -619,17 +689,38 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 	pool := NewAutoreleasePool()
 	defer pool.Drain()
 
-	// Get shader modules
-	vertexModule, ok := desc.Vertex.Module.(*ShaderModule)
-	if !ok || vertexModule == nil || vertexModule.library == 0 {
-		return nil, fmt.Errorf("metal: invalid vertex shader module")
+	var pipeLayout *PipelineLayout
+	if pl, ok := desc.Layout.(*PipelineLayout); ok {
+		pipeLayout = pl
 	}
 
+	// Get shader modules
+	//
+	// The render path does not bind naga's `_buffer_sizes` argument, so this
+	// MSL does not change.
+	vertexModule, ok := desc.Vertex.Module.(*ShaderModule)
+	if !ok || vertexModule == nil {
+		return nil, fmt.Errorf("metal: invalid vertex shader module")
+	}
+	vertexLib, err := d.compileLibrary(vertexModule, pipeLayout, false)
+	if err != nil {
+		return nil, err
+	}
+	defer Release(vertexLib.library)
+
 	var fragmentModule *ShaderModule
+	fragmentLib := vertexLib
 	if desc.Fragment != nil {
 		fragmentModule, ok = desc.Fragment.Module.(*ShaderModule)
-		if !ok || fragmentModule == nil || fragmentModule.library == 0 {
+		if !ok || fragmentModule == nil {
 			return nil, fmt.Errorf("metal: invalid fragment shader module")
+		}
+		if fragmentModule != vertexModule {
+			fragmentLib, err = d.compileLibrary(fragmentModule, pipeLayout, false)
+			if err != nil {
+				return nil, err
+			}
+			defer Release(fragmentLib.library)
 		}
 	}
 
@@ -649,13 +740,13 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 
 	// Resolve translated entrypoint name
 	entrypointName := desc.Vertex.EntryPoint
-	if translated, ok := vertexModule.entrypointNames[entrypointName]; ok {
+	if translated, ok := vertexLib.entrypointNames[entrypointName]; ok {
 		entrypointName = translated
 	}
 
 	// Get vertex function from library
 	vertexFuncName := NSString(entrypointName)
-	vertexFunc := MsgSend(vertexModule.library, Sel("newFunctionWithName:"), uintptr(vertexFuncName))
+	vertexFunc := MsgSend(vertexLib.library, Sel("newFunctionWithName:"), uintptr(vertexFuncName))
 	Release(vertexFuncName)
 	if vertexFunc == 0 {
 		return nil, fmt.Errorf("metal: vertex function '%s' not found", entrypointName)
@@ -678,12 +769,12 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 	if fragmentModule != nil && desc.Fragment != nil { //nolint:nestif // sequential Metal pipeline setup
 		// Resolve translated entrypoint name
 		entrypointName := desc.Fragment.EntryPoint
-		if translated, ok := fragmentModule.entrypointNames[entrypointName]; ok {
+		if translated, ok := fragmentLib.entrypointNames[entrypointName]; ok {
 			entrypointName = translated
 		}
 
 		fragmentFuncName := NSString(entrypointName)
-		fragmentFunc := MsgSend(fragmentModule.library, Sel("newFunctionWithName:"), uintptr(fragmentFuncName))
+		fragmentFunc := MsgSend(fragmentLib.library, Sel("newFunctionWithName:"), uintptr(fragmentFuncName))
 		Release(fragmentFuncName)
 		if fragmentFunc == 0 {
 			return nil, fmt.Errorf("metal: fragment function '%s' not found", entrypointName)
@@ -802,10 +893,6 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 		"sampleCount", sampleCount,
 	)
 
-	var pipeLayout *PipelineLayout
-	if pl, ok := desc.Layout.(*PipelineLayout); ok {
-		pipeLayout = pl
-	}
 	return &RenderPipeline{
 		raw:           pipelineState,
 		device:        d,
@@ -897,21 +984,33 @@ func (d *Device) CreateComputePipeline(desc *hal.ComputePipelineDescriptor) (hal
 	pool := NewAutoreleasePool()
 	defer pool.Drain()
 
+	var pipeLayout *PipelineLayout
+	if pl, ok := desc.Layout.(*PipelineLayout); ok {
+		pipeLayout = pl
+	}
+
 	// Get shader module
 	computeModule, ok := desc.Compute.Module.(*ShaderModule)
-	if !ok || computeModule == nil || computeModule.library == 0 {
+	if !ok || computeModule == nil {
 		return nil, fmt.Errorf("metal: invalid compute shader module")
 	}
 
+	// Write the MSL now, because the pipeline layout gives the sizes slot.
+	lib, err := d.compileLibrary(computeModule, pipeLayout, true)
+	if err != nil {
+		return nil, err
+	}
+	defer Release(lib.library)
+
 	// Resolve translated entrypoint name
 	entrypointName := desc.Compute.EntryPoint
-	if translated, ok := computeModule.entrypointNames[entrypointName]; ok {
+	if translated, ok := lib.entrypointNames[entrypointName]; ok {
 		entrypointName = translated
 	}
 
 	// Get compute function from library
 	funcName := NSString(entrypointName)
-	computeFunc := MsgSend(computeModule.library, Sel("newFunctionWithName:"), uintptr(funcName))
+	computeFunc := MsgSend(lib.library, Sel("newFunctionWithName:"), uintptr(funcName))
 	Release(funcName)
 	if computeFunc == 0 {
 		return nil, fmt.Errorf("metal: compute function '%s' not found", entrypointName)
@@ -943,15 +1042,13 @@ func (d *Device) CreateComputePipeline(desc *hal.ComputePipelineDescriptor) (hal
 		"workgroupSize", fmt.Sprintf("%dx%dx%d", workgroupSize.Width, workgroupSize.Height, workgroupSize.Depth),
 	)
 
-	var pipeLayout *PipelineLayout
-	if pl, ok := desc.Layout.(*PipelineLayout); ok {
-		pipeLayout = pl
-	}
 	return &ComputePipeline{
 		raw:           pipelineState,
 		device:        d,
 		layout:        pipeLayout,
 		workgroupSize: workgroupSize,
+		sizesBindings: lib.sizesBindings,
+		sizesSlot:     lib.sizesSlot,
 	}, nil
 }
 

--- a/hal/metal/encoder.go
+++ b/hal/metal/encoder.go
@@ -7,7 +7,9 @@ package metal
 
 import (
 	"fmt"
+	"math"
 	"sync"
+	"unsafe"
 
 	"github.com/gogpu/gputypes"
 	"github.com/gogpu/wgpu/hal"
@@ -928,6 +930,11 @@ type ComputePassEncoder struct {
 	device        *Device
 	pipeline      *ComputePipeline
 	currentLayout *PipelineLayout // set by SetPipeline for SetBindGroup slot offsets
+
+	// bindingSizes holds the usable byte size of each bound buffer, by group
+	// and binding. A dispatch copies these sizes into naga's `_buffer_sizes`
+	// argument.
+	bindingSizes map[[2]uint32]uint64
 }
 
 // End finishes the compute pass.
@@ -986,6 +993,19 @@ func (e *ComputePassEncoder) SetBindGroup(index uint32, group hal.BindGroup, off
 			_ = MsgSend(e.raw, Sel("setBuffer:offset:atIndex:"), res.Buffer, offset, bufferSlot)
 			bufferSlot++
 
+			// Save the usable byte size for `_buffer_sizes`. A zero
+			// entry size means the rest of the buffer.
+			size := res.Size
+			if size == 0 {
+				if l := uint64(MsgSend(ID(res.Buffer), Sel("length"))); l > res.Offset {
+					size = l - res.Offset
+				}
+			}
+			if e.bindingSizes == nil {
+				e.bindingSizes = make(map[[2]uint32]uint64)
+			}
+			e.bindingSizes[[2]uint32{index, entry.Binding}] = size
+
 		case gputypes.TextureViewBinding:
 			_ = MsgSend(e.raw, Sel("setTexture:atIndex:"), res.TextureView, textureSlot)
 			textureSlot++
@@ -997,11 +1017,44 @@ func (e *ComputePassEncoder) SetBindGroup(index uint32, group hal.BindGroup, off
 	}
 }
 
+// bindBufferSizes binds naga's `_buffer_sizes` argument. Kernels need it when
+// they use a runtime-sized array, either through WGSL arrayLength() or through
+// naga's bounds checks on storage buffers.
+//
+// The MSL kernel takes one extra parameter. It holds one uint32 byte size for
+// each runtime-sized array. The pipeline compiled that parameter to the buffer
+// slot that follows the buffers of the pipeline layout.
+//
+// This binding is required. If it is missing, the kernel reads a size of zero,
+// and naga's arrayLength() formula, 1 + (size - offset - stride) / stride,
+// wraps around to a very large number.
+//
+// Reference: Rust wgpu-hal metal/command.rs:1736-1747.
+func (e *ComputePassEncoder) bindBufferSizes() {
+	p := e.pipeline
+	if p == nil || len(p.sizesBindings) == 0 {
+		return
+	}
+	sizes := make([]uint32, len(p.sizesBindings))
+	for i, rb := range p.sizesBindings {
+		// The fields are 32-bit, so a binding above 4 GiB reports the
+		// largest value that fits.
+		size := e.bindingSizes[[2]uint32{rb.Group, rb.Binding}]
+		if size > math.MaxUint32 {
+			size = math.MaxUint32
+		}
+		sizes[i] = uint32(size)
+	}
+	_ = MsgSend(e.raw, Sel("setBytes:length:atIndex:"),
+		uintptr(unsafe.Pointer(&sizes[0])), uintptr(4*len(sizes)), uintptr(p.sizesSlot))
+}
+
 // Dispatch dispatches compute workgroups.
 func (e *ComputePassEncoder) Dispatch(x, y, z uint32) {
 	if e.pipeline == nil {
 		return // No pipeline set
 	}
+	e.bindBufferSizes()
 
 	threadgroupsPerGrid := MTLSize{Width: NSUInteger(x), Height: NSUInteger(y), Depth: NSUInteger(z)}
 	// Use pipeline's workgroup size instead of hardcoded value
@@ -1023,6 +1076,7 @@ func (e *ComputePassEncoder) DispatchIndirect(buffer hal.Buffer, offset uint64) 
 	if !ok || buf == nil {
 		return
 	}
+	e.bindBufferSizes()
 	// Use pipeline's workgroup size instead of hardcoded value
 	threadsPerThreadgroup := e.pipeline.workgroupSize
 	msgSendVoid(e.raw, Sel("dispatchThreadgroupsWithIndirectBuffer:indirectBufferOffset:threadsPerThreadgroup:"),

--- a/hal/metal/mslmap/mslmap.go
+++ b/hal/metal/mslmap/mslmap.go
@@ -1,0 +1,202 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+// Package mslmap builds the naga MSL binding map for the Metal backend.
+//
+// naga translates WGSL arrayLength() into arithmetic on an extra entry point
+// argument named `_buffer_sizes`. naga gives that argument a [[buffer(N)]]
+// attribute only if msl.Options.PerEntryPointMap[ep].SizesBuffer is set. If it
+// is not set, Metal binds nothing to the argument and arrayLength() returns a
+// wrong value. The backend must therefore supply the map.
+//
+// The map must list every resource, not only the sizes buffer. When an entry
+// point is present in PerEntryPointMap, naga uses its Resources field as is and
+// does not number the other resources itself. A map with only SizesBuffer would
+// therefore lose every normal binding. This package copies naga's own numbering
+// rule, so the MSL for normal resources stays the same.
+//
+// The package has no build tags and does not call Objective-C, so its tests run
+// on any CI runner.
+//
+// Reference: Rust wgpu-hal metal/device.rs:851-856 (sizes_buffer =
+// counters.buffers) and metal/device.rs:138-145 (load_shader takes the layout).
+package mslmap
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/gogpu/naga/ir"
+	"github.com/gogpu/naga/msl"
+)
+
+// maxBufferSlot is the largest buffer slot naga can encode, because
+// msl.BindTarget stores the slot in a uint8. Real Metal devices allow only 31
+// buffers, so a value above this limit means the caller made a mistake.
+const maxBufferSlot = 255
+
+// Options returns MSL options that put naga's `_buffer_sizes` argument at
+// buffer slot sizesSlot. It does this for every entry point in module, and it
+// numbers all other resources the same way naga does.
+//
+// sizesSlot is the number of buffer bindings that the pipeline layout declares.
+// That is the first free slot, directly after the last declared buffer. Rust
+// wgpu-hal picks the slot the same way, after it walks the pipeline layout.
+func Options(module *ir.Module, sizesSlot int) (msl.Options, error) {
+	opts := msl.DefaultOptions()
+	if module == nil {
+		return opts, fmt.Errorf("mslmap: nil IR module")
+	}
+	if sizesSlot < 0 || sizesSlot > maxBufferSlot {
+		return opts, fmt.Errorf("mslmap: buffer sizes slot %d out of range 0..%d", sizesSlot, maxBufferSlot)
+	}
+
+	resources, err := autoResourceMap(module)
+	if err != nil {
+		return opts, err
+	}
+
+	slot := uint8(sizesSlot)
+	perEP := make(map[string]msl.EntryPointResources, len(module.EntryPoints))
+	for i := range module.EntryPoints {
+		// The key is the WGSL entry point name, which is the IR name.
+		// It is not the MSL function name, which naga can rename.
+		perEP[module.EntryPoints[i].Name] = msl.EntryPointResources{
+			Resources:   resources,
+			SizesBuffer: &slot,
+		}
+	}
+	opts.PerEntryPointMap = perEP
+
+	return opts, nil
+}
+
+// autoResourceMap copies the numbering rule of naga's computeResourceMap. It
+// takes every global variable that has a binding, sorts them by group and then
+// by binding, and gives each one an index. Samplers, textures and buffers are
+// counted apart, and each kind starts at zero.
+//
+// The encoder already binds bind group entries in this same order, so the
+// current code depends on this rule. Because the map comes from the IR, the MSL
+// for these resources does not change.
+//
+// Reference: naga v0.18.0 msl/internal/codegen/functions.go:1538-1600.
+func autoResourceMap(module *ir.Module) (map[ir.ResourceBinding]msl.BindTarget, error) {
+	type entry struct {
+		binding ir.ResourceBinding
+		kind    int // 0=buffer, 1=texture, 2=sampler
+	}
+
+	entries := make([]entry, 0, len(module.GlobalVariables))
+	for _, global := range module.GlobalVariables {
+		if global.Binding == nil {
+			continue
+		}
+		if int(global.Type) >= len(module.Types) {
+			continue
+		}
+
+		kind := 0
+		switch module.Types[global.Type].Inner.(type) {
+		case ir.SamplerType:
+			kind = 2
+		case ir.ImageType:
+			kind = 1
+		}
+
+		entries = append(entries, entry{binding: *global.Binding, kind: kind})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].binding.Group != entries[j].binding.Group {
+			return entries[i].binding.Group < entries[j].binding.Group
+		}
+		return entries[i].binding.Binding < entries[j].binding.Binding
+	})
+
+	resources := make(map[ir.ResourceBinding]msl.BindTarget, len(entries))
+	var nextBuffer, nextTexture, nextSampler uint8
+	for _, e := range entries {
+		var next *uint8
+		switch e.kind {
+		case 1:
+			next = &nextTexture
+		case 2:
+			next = &nextSampler
+		default:
+			next = &nextBuffer
+		}
+		idx := *next
+		if idx == maxBufferSlot {
+			// The index is a uint8, so the next resource of this
+			// kind would have no valid slot.
+			return nil, fmt.Errorf("mslmap: more than %d resources of one kind", maxBufferSlot)
+		}
+		*next = idx + 1
+
+		var target msl.BindTarget
+		switch e.kind {
+		case 1:
+			target.Texture = &idx
+		case 2:
+			target.Sampler = &msl.BindSamplerTarget{Slot: idx}
+		default:
+			target.Buffer = &idx
+		}
+		resources[e.binding] = target
+	}
+
+	return resources, nil
+}
+
+// RuntimeArrayBindings returns the bindings of the global variables whose type
+// holds a runtime-sized array. The order is the IR declaration order.
+//
+// naga builds one uint32 field per such global, in this same order. Each field
+// must hold the byte size of the buffer that is bound to it.
+//
+// Reference: naga v0.18.0 msl/internal/codegen/writer.go:786-797
+// (scanBufferSizeGlobals).
+func RuntimeArrayBindings(module *ir.Module) ([]ir.ResourceBinding, error) {
+	if module == nil {
+		return nil, nil
+	}
+	var out []ir.ResourceBinding
+	for i, global := range module.GlobalVariables {
+		if !typeNeedsArrayLength(module, global.Type) {
+			continue
+		}
+		if global.Binding == nil {
+			// Such a global has a field in the sizes struct, but no
+			// size that the encoder can find. Skipping it would
+			// shift all later fields. WGSL cannot declare this
+			// today, so report an error instead of writing the
+			// sizes to the wrong fields.
+			return nil, fmt.Errorf("mslmap: global %d has a runtime-sized array but no binding", i)
+		}
+		out = append(out, *global.Binding)
+	}
+	return out, nil
+}
+
+// typeNeedsArrayLength reports whether the type is a runtime-sized array, or a
+// struct whose last member ends in one.
+//
+// Reference: naga v0.18.0 msl/internal/codegen/writer.go:770-784
+// (needsArrayLength).
+func typeNeedsArrayLength(module *ir.Module, handle ir.TypeHandle) bool {
+	if int(handle) >= len(module.Types) {
+		return false
+	}
+	switch inner := module.Types[handle].Inner.(type) {
+	case ir.ArrayType:
+		return inner.Size.Constant == nil
+	case ir.StructType:
+		if len(inner.Members) == 0 {
+			return false
+		}
+		return typeNeedsArrayLength(module, inner.Members[len(inner.Members)-1].Type)
+	default:
+		return false
+	}
+}

--- a/hal/metal/mslmap/mslmap_test.go
+++ b/hal/metal/mslmap/mslmap_test.go
@@ -1,0 +1,200 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+package mslmap_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gogpu/naga"
+	"github.com/gogpu/naga/msl"
+	"github.com/gogpu/wgpu/hal/metal/mslmap"
+)
+
+// wgslRuntimeArray calls arrayLength() on a runtime-sized storage array and
+// also reads a uniform buffer. The generated MSL therefore has both the sizes
+// argument and a normal buffer binding.
+const wgslRuntimeArray = `
+struct Params {
+	scale: u32,
+}
+
+@group(0) @binding(0) var<storage, read_write> out: array<u32>;
+@group(0) @binding(1) var<uniform> params: Params;
+
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+	if (gid.x < arrayLength(&out)) {
+		out[gid.x] = arrayLength(&out) * params.scale;
+	}
+}
+`
+
+// bufferParamRe finds each MSL parameter name and its buffer slot, for example
+// "out [[buffer(0)]]".
+var bufferParamRe = regexp.MustCompile(`(\w+)\s*\[\[buffer\((\d+)\)\]\]`)
+
+func compile(t *testing.T, source string, opts msl.Options) (string, msl.TranslationInfo) {
+	t.Helper()
+
+	ast, err := naga.Parse(source)
+	if err != nil {
+		t.Fatalf("naga.Parse: %v", err)
+	}
+	module, err := naga.LowerWithSource(ast, source)
+	if err != nil {
+		t.Fatalf("naga.LowerWithSource: %v", err)
+	}
+	out, info, err := msl.Compile(module, opts)
+	if err != nil {
+		t.Fatalf("msl.Compile: %v", err)
+	}
+	return out, info
+}
+
+func bufferSlots(mslSource string) map[string]string {
+	slots := make(map[string]string)
+	for _, m := range bufferParamRe.FindAllStringSubmatch(mslSource, -1) {
+		slots[m[1]] = m[2]
+	}
+	return slots
+}
+
+// TestDefaultOptionsLeaveSizesBufferUnbound records the bug that this package
+// fixes. With msl.DefaultOptions, naga reports that the sizes buffer is
+// required, but it writes the argument without a [[buffer(N)]] attribute.
+func TestDefaultOptionsLeaveSizesBufferUnbound(t *testing.T) {
+	t.Parallel()
+
+	source, info := compile(t, wgslRuntimeArray, msl.DefaultOptions())
+
+	if !info.RequiresSizesBuffer {
+		t.Fatal("RequiresSizesBuffer = false; want true for a runtime-sized array")
+	}
+	if !strings.Contains(source, "_buffer_sizes") {
+		t.Fatal("generated MSL has no _buffer_sizes argument")
+	}
+	if slot, ok := bufferSlots(source)["_buffer_sizes"]; ok {
+		t.Fatalf("_buffer_sizes has [[buffer(%s)]] under DefaultOptions; want no attribute", slot)
+	}
+}
+
+// TestOptionsBindSizesBuffer checks that the map from this package puts the
+// sizes argument at the slot that the caller asked for.
+func TestOptionsBindSizesBuffer(t *testing.T) {
+	t.Parallel()
+
+	ast, err := naga.Parse(wgslRuntimeArray)
+	if err != nil {
+		t.Fatalf("naga.Parse: %v", err)
+	}
+	module, err := naga.LowerWithSource(ast, wgslRuntimeArray)
+	if err != nil {
+		t.Fatalf("naga.LowerWithSource: %v", err)
+	}
+
+	const sizesSlot = 2
+
+	opts, err := mslmap.Options(module, sizesSlot)
+	if err != nil {
+		t.Fatalf("mslmap.Options: %v", err)
+	}
+	source, _, err := msl.Compile(module, opts)
+	if err != nil {
+		t.Fatalf("msl.Compile: %v", err)
+	}
+
+	got, ok := bufferSlots(source)["_buffer_sizes"]
+	if !ok {
+		t.Fatalf("_buffer_sizes has no [[buffer(N)]] attribute\nMSL:\n%s", source)
+	}
+	if got != "2" {
+		t.Errorf("_buffer_sizes bound to buffer(%s); want buffer(%d)", got, sizesSlot)
+	}
+
+	bindings, err := mslmap.RuntimeArrayBindings(module)
+	if err != nil {
+		t.Fatalf("mslmap.RuntimeArrayBindings: %v", err)
+	}
+	if len(bindings) != 1 {
+		t.Fatalf("RuntimeArrayBindings = %v; want exactly the storage array binding", bindings)
+	}
+	if bindings[0].Group != 0 || bindings[0].Binding != 0 {
+		t.Errorf("RuntimeArrayBindings[0] = (%d,%d); want (0,0)", bindings[0].Group, bindings[0].Binding)
+	}
+}
+
+// TestOptionsPreserveOrdinaryBindings is the most important check. naga uses
+// PerEntryPointMap[ep].Resources as is and does not number the resources
+// itself. An incomplete map would move every normal resource to a wrong slot,
+// with no error. The normal bindings must stay the same as with
+// msl.DefaultOptions.
+func TestOptionsPreserveOrdinaryBindings(t *testing.T) {
+	t.Parallel()
+
+	ast, err := naga.Parse(wgslRuntimeArray)
+	if err != nil {
+		t.Fatalf("naga.Parse: %v", err)
+	}
+	module, err := naga.LowerWithSource(ast, wgslRuntimeArray)
+	if err != nil {
+		t.Fatalf("naga.LowerWithSource: %v", err)
+	}
+
+	auto, _, err := msl.Compile(module, msl.DefaultOptions())
+	if err != nil {
+		t.Fatalf("msl.Compile (auto): %v", err)
+	}
+	opts, err := mslmap.Options(module, 2)
+	if err != nil {
+		t.Fatalf("mslmap.Options: %v", err)
+	}
+	mapped, _, err := msl.Compile(module, opts)
+	if err != nil {
+		t.Fatalf("msl.Compile (mapped): %v", err)
+	}
+
+	autoSlots := bufferSlots(auto)
+	mappedSlots := bufferSlots(mapped)
+	delete(mappedSlots, "_buffer_sizes")
+
+	if len(autoSlots) == 0 {
+		t.Fatalf("no [[buffer(N)]] parameters found in auto-numbered MSL:\n%s", auto)
+	}
+	for name, want := range autoSlots {
+		got, ok := mappedSlots[name]
+		if !ok {
+			t.Errorf("parameter %q lost its [[buffer(N)]] attribute under the explicit map", name)
+			continue
+		}
+		if got != want {
+			t.Errorf("parameter %q bound to buffer(%s); want buffer(%s) as with auto-numbering", name, got, want)
+		}
+	}
+	for name := range mappedSlots {
+		if _, ok := autoSlots[name]; !ok {
+			t.Errorf("parameter %q gained a [[buffer(N)]] attribute under the explicit map", name)
+		}
+	}
+}
+
+// TestOptionsRejectsOutOfRangeSlot checks the guard for a slot that does not
+// fit in a uint8.
+func TestOptionsRejectsOutOfRangeSlot(t *testing.T) {
+	t.Parallel()
+
+	ast, err := naga.Parse(wgslRuntimeArray)
+	if err != nil {
+		t.Fatalf("naga.Parse: %v", err)
+	}
+	module, err := naga.LowerWithSource(ast, wgslRuntimeArray)
+	if err != nil {
+		t.Fatalf("naga.LowerWithSource: %v", err)
+	}
+
+	if _, err := mslmap.Options(module, 256); err == nil {
+		t.Error("mslmap.Options(module, 256) = nil error; want an out-of-range error")
+	}
+}

--- a/hal/metal/resource.go
+++ b/hal/metal/resource.go
@@ -9,6 +9,7 @@ import (
 	"unsafe"
 
 	"github.com/gogpu/gputypes"
+	"github.com/gogpu/naga/ir"
 	"github.com/gogpu/wgpu/hal"
 )
 
@@ -114,12 +115,18 @@ func (s *Sampler) Destroy() {
 func (s *Sampler) NativeHandle() uintptr { return uintptr(s.raw) }
 
 // ShaderModule implements hal.ShaderModule for Metal.
+//
+// WGSL is parsed and lowered to naga IR here. MSL is written later, when the
+// pipeline is created, because the buffer slot for naga's `_buffer_sizes`
+// argument comes from the pipeline layout.
+//
+// Reference: Rust wgpu-hal metal/device.rs:138-145 (load_shader takes
+// `layout: &super::PipelineLayout`).
 type ShaderModule struct {
-	source          hal.ShaderSource
-	library         ID // id<MTLLibrary>
-	device          *Device
-	workgroupSizes  map[string][3]uint32 // entry point name -> workgroup size
-	entrypointNames map[string]string
+	source         hal.ShaderSource
+	irModule       *ir.Module // nil unless the module was created from WGSL
+	device         *Device
+	workgroupSizes map[string][3]uint32 // entry point name -> workgroup size
 }
 
 // Destroy releases the shader module.
@@ -187,6 +194,14 @@ type PipelineLayout struct {
 	//
 	// Reference: Rust wgpu-hal metal/mod.rs PipelineLayout.bind_group_infos.
 	groupOffsets []GroupSlotOffsets
+
+	// totalBuffers is how many buffer bindings all bind group layouts declare
+	// together. It is also the first free Metal buffer slot, which is where
+	// naga's `_buffer_sizes` argument goes.
+	//
+	// Reference: Rust wgpu-hal metal/device.rs:851-856
+	// (info.sizes_buffer = Some(info.counters.buffers)).
+	totalBuffers int
 }
 
 // Destroy releases the pipeline layout.
@@ -224,6 +239,13 @@ type ComputePipeline struct {
 	device        *Device
 	layout        *PipelineLayout // for SetBindGroup slot offset lookup
 	workgroupSize MTLSize         // workgroup size from shader
+
+	// sizesBindings lists the bindings whose byte size the kernel needs, in the
+	// field order that naga uses. It is empty if the kernel has no
+	// runtime-sized array. sizesSlot is the buffer slot that the MSL was
+	// compiled with, and it comes from PipelineLayout.totalBuffers.
+	sizesBindings []ir.ResourceBinding
+	sizesSlot     int
 }
 
 // Destroy releases the compute pipeline.


### PR DESCRIPTION

Fixes #305

## Summary

On Metal, `arrayLength()` returns an incorrect value for a runtime-sized storage array. With 16 bytes (4 x `u32`) bound, the shader reads `1073741824` (`0x40000000`) instead of `4`.

naga's MSL backend reads the length from an extra entry point argument, `constant _mslBufferSizes& _buffer_sizes`. Before this PR, `hal/metal` did not bind that argument. This PR assigns it a buffer slot and uploads the buffer sizes before each compute dispatch, following the Rust Metal HAL.

## Root cause

MSL has no `arrayLength()`, so naga computes it as `1 + (size0 - offset - stride) / stride`, where `size0` comes from the `_buffer_sizes` argument. naga writes a `[[buffer(N)]]` attribute on that argument only when `msl.Options.PerEntryPointMap[ep].SizesBuffer` is set (`resolveBufferSizesBinding`, naga v0.18.0 `msl/internal/codegen/writer.go:1301`).

`CreateShaderModule` calls `msl.Compile(irModule, msl.DefaultOptions())` (`hal/metal/device.go:534`). `msl.DefaultOptions()` leaves `PerEntryPointMap` nil, so the argument is emitted with no attribute:

```metal
kernel void main_(
  device type_1& out [[buffer(0)]]
, constant _mslBufferSizes& _buffer_sizes
) {
    if (uint(0) < 1 + (_buffer_sizes.size0 - 0 - 4) / 4) {
        out[0] = 1 + (_buffer_sizes.size0 - 0 - 4) / 4;
    }
```

`msl.Compile` does report the requirement — `TranslationInfo.RequiresSizesBuffer` is `true` — but before this PR, `RequiresSizesBuffer`, `SizesBuffer` and `PerEntryPointMap` did not appear anywhere in the repository, so the required size data was never bound. The observed value is consistent with `size0` reading as zero: `1 + (0 - 0 - 4) / 4` wraps around in `uint` to `0x40000000`.

The same argument feeds naga's implicit bounds checks, whose default policy is `BoundsCheckReadZeroSkipWrite`. The same wrap-around makes those guards pass, so the problem can also affect a shader that never calls `arrayLength()`, as long as it declares a runtime-sized array.

## Changes

- **`hal/metal/device.go`** — `CreatePipelineLayout` stores the accumulated buffer count as `PipelineLayout.totalBuffers`. That is the first free Metal buffer slot and therefore the slot for `_buffer_sizes`; the `bufAccum` loop already computed the value.

  `CreateShaderModule` now stops after `naga.Parse`, `naga.LowerWithSource` and workgroup size extraction, and keeps the IR module. `msl.Compile` and `newLibraryWithSource:` move to a new `Device.compileLibrary`, called from `CreateComputePipeline` and `CreateRenderPipeline`. The slot is only known there. WGSL syntax and validation errors are still reported from `CreateShaderModule`.

  `CreateComputePipeline` passes `bindSizes = true` and records the bindings and the slot on the pipeline. `CreateRenderPipeline` passes `false` and keeps `msl.DefaultOptions()`, so **the MSL it produces does not change** — see Scope.

  Pipeline creation now fails instead of running a kernel with an unbound argument: when a shader uses a runtime-sized array but has no `*PipelineLayout`, and when naga reports `RequiresSizesBuffer` but no binding was found.

- **`hal/metal/mslmap`** (new package) — builds the `msl.Options`. The map has to list **every** resource, not only the sizes buffer: when an entry point is present in `PerEntryPointMap`, naga's `computeResourceMap` uses its `Resources` field as is and does no numbering of its own, so a map carrying only `SizesBuffer` would silently move every normal binding to a wrong slot. `mslmap.Options` therefore reproduces naga's numbering rule — globals that have a binding, sorted by group then binding, with samplers, textures and buffers counted apart from zero. That is the order `SetBindGroup` already binds in.

  The package has no build tags and does not call Objective-C, so its tests run on the Linux CI runner. `hal/metal` itself cannot host them, because `hal/metal/main_test.go` calls `os.Exit(0)` for the whole package when `CI` or `GITHUB_ACTIONS` is set.

- **`hal/metal/encoder.go`** — `SetBindGroup` records each bound buffer's usable byte size (the entry `Size`, or `MTLBuffer.length - offset` when `Size` is zero). `Dispatch` and `DispatchIndirect` upload those sizes with `setBytes:length:atIndex:` at the slot the pipeline was compiled with.

- **`hal/metal/resource.go`** — the new fields, and `ShaderModule` now holds the IR module instead of an `MTLLibrary`. The library is created and released per pipeline.

## Rust wgpu reference

`gfx-rs/wgpu` at `wgpu-v29.0.1`.

| Decision | Rust wgpu | Here |
| --- | --- | --- |
| Which slot | [`device.rs:851-856`](https://github.com/gfx-rs/wgpu/blob/wgpu-v29.0.1/wgpu-hal/src/metal/device.rs#L851-L856) — `info.sizes_buffer = Some(info.counters.buffers)`, fixed while the pipeline layout is built | `PipelineLayout.totalBuffers` |
| Where to compile | [`device.rs:138-145`](https://github.com/gfx-rs/wgpu/blob/wgpu-v29.0.1/wgpu-hal/src/metal/device.rs#L138-L145) — `load_shader` takes `layout: &super::PipelineLayout` | `Device.compileLibrary(module, layout, bindSizes)` |
| How to upload | [`command.rs:1736-1747`](https://github.com/gfx-rs/wgpu/blob/wgpu-v29.0.1/wgpu-hal/src/metal/command.rs#L1736-L1747) — `set_bytes` of the size array at that slot | `ComputePassEncoder.bindBufferSizes` |

The `GroupSlotOffsets` doc comment already cites `PipelineLayout.bind_group_infos` from the same Rust file, so the slot comes from the structure that was built for it.

## Testing

Apple M4, macOS 26.6.1, Go 1.25.

The GPU tests are in the **first commit**, so their failures are visible in the history. Before the fix, all three command sequences return the same incorrect value:

```text
--- FAIL: TestArrayLengthReportsBoundSize (0.03s)
--- FAIL: TestArrayLengthReportsBoundSizeWhenBindGroupPrecedesPipeline (0.00s)
--- FAIL: TestArrayLengthReportsBoundSizeAfterCompatiblePipelineSwitch (0.00s)

Each test reports:
arrayLength(&out) = 1073741824 (0x40000000); want 4
    backend Metal derived a runtime array length from an unbound buffer-sizes argument
```

After:

```text
$ go test -tags integration -run TestArrayLength -count=5 .
ok  	github.com/gogpu/wgpu	0.112s
```

It is behind `integration && darwin && !rust && !(js && wasm)`, so the default suite is unaffected.

The MSL tests need no GPU and run in CI:

```text
$ go test -v ./hal/metal/mslmap/
--- PASS: TestDefaultOptionsLeaveSizesBufferUnbound
--- PASS: TestOptionsBindSizesBuffer
--- PASS: TestOptionsPreserveOrdinaryBindings
--- PASS: TestOptionsRejectsOutOfRangeSlot
ok  	github.com/gogpu/wgpu/hal/metal/mslmap	0.005s
```

`TestOptionsPreserveOrdinaryBindings` is the one that guards the "complete map" requirement: it compiles the same shader with `msl.DefaultOptions` and with the explicit map, and requires every normal parameter to keep the same `[[buffer(N)]]`.

Examples on Metal:

```text
$ GOGPU_GRAPHICS_API=metal go run ./examples/compute-sum/
1. Creating instance... OK
2. Requesting adapter... OK (Apple M4)
3. Creating device... OK
4. Input: 256 elements, CPU sum = 32896
5. Creating buffers... OK
6. Creating compute pipeline... OK
7. Dispatching compute... OK
8. Reading results... OK

CPU reference sum: 32896
GPU partial sum:   32896
PASS: GPU sum matches CPU reference
```

`compute-copy`, `compute-particles` and `triangle-headless` also pass on Metal.

Pre-submit checklist: `go fmt ./...`, `go build ./...`, `go test ./...` and `go test -cover ./...` are clean.

```text
$ GOOS=linux GOARCH=amd64 golangci-lint run --timeout=5m
0 issues.
```

Four broader macOS checks still report pre-existing issues. I checked each result against `main` at `46c6b77`; this PR does not introduce them.

- `go vet ./...` reports four `possible misuse of unsafe.Pointer` findings, in `hal/software/blit_darwin.go` and `hal/metal/{objc,resource}.go`. Identical on `main`; only a line number moves, because this PR adds an import to `resource.go`.
- `go test -race ./...` fails in `hal/noop` (`TestNoopConcurrentAccess`). Identical on `main`. `go test -race ./hal/metal/... .` passes.
- `GOOS=darwin GOARCH=arm64 golangci-lint run` reports 11 issues on unchanged lines; `main` reports 13. The two removed findings were attached to code that this PR restructures. I left the remaining cleanup out of scope.
- `go test -tags integration ./...` has four failures and one crash in `TestTypedSurfaceCreationPathsUseBackendMap`. The set is identical on `main`.

Downstream, two projects of mine that dispatch compute kernels over runtime-sized arrays were hitting this bug and now pass their suites against this branch.

## Scope

- **Compute only.** The render path emits the same argument and I expect the same gap, but I have not reproduced it, so I did not change its behaviour: it still compiles with `msl.DefaultOptions()` and its MSL is byte for byte what it was. I would rather file that separately, with its own test.
- No changes to other backends, and no lint cleanup outside the bug.
- The `TODO(compute-constants)` and `TODO(zero-init-workgroup)` notes on `CreateComputePipeline` are untouched.

## Considered and rejected

**Tracking the slot at encode time.** My first version watched the highest buffer slot actually bound during `SetBindGroup` and put the sizes buffer after it. It works on the shaders I tested, but it is wrong in principle: a layout entry that no bind group fills, or a gap between groups, gives a different slot than the one the MSL was compiled against. Taking the slot from the pipeline layout is deterministic and is what Rust does.

**Keeping `msl.Compile` in `CreateShaderModule`.** This would need the slot to be passed in some other way, and `PerEntryPointMap` is keyed by entry point name, which is also unknown there. If you would rather have it that way and thread the values differently, say so and I will redo it — moving the code is cheap.
