### PR TITLE
perf(metal): reduce buffer size binding allocations

### DIFF
--- a/arraylength_repro_test.go
+++ b/arraylength_repro_test.go
@@ -45,6 +45,28 @@ const noArrayLengthShader = `
 fn main() {}
 `
 
+const twoBufferSizesShader = `
+@group(0) @binding(0) var<storage, read_write> first: array<u32>;
+@group(0) @binding(1) var<storage, read_write> second: array<u32>;
+
+@compute @workgroup_size(1)
+fn main() {
+    first[0] = arrayLength(&first);
+    first[1] += 1u;
+    second[0] = arrayLength(&second);
+    second[1] += 1u;
+}
+`
+
+const oneBufferSizeShader = `
+@group(0) @binding(0) var<storage, read_write> first: array<u32>;
+
+@compute @workgroup_size(1)
+fn main() {
+    first[2] = arrayLength(&first);
+}
+`
+
 // arrayLengthElems is the element count bound to the storage binding.
 const arrayLengthElems = 4
 
@@ -95,6 +117,273 @@ func TestArrayLengthReportsBoundSizeWhenBindGroupPrecedesPipeline(t *testing.T) 
 // needs no sizes buffer to one that does.
 func TestArrayLengthReportsBoundSizeAfterCompatiblePipelineSwitch(t *testing.T) {
 	testArrayLengthReportsBoundSize(t, compatiblePipelineSwitch)
+}
+
+func TestBufferSizesRemainCorrectAcrossPipelineReuse(t *testing.T) {
+	fixture := newBufferSizesFixture(t)
+	firstA := newBufferSizesTestBuffer(t, fixture.device, "first-a", 4)
+	secondA := newBufferSizesTestBuffer(t, fixture.device, "second-a", 7)
+	firstB := newBufferSizesTestBuffer(t, fixture.device, "first-b", 5)
+	secondB := newBufferSizesTestBuffer(t, fixture.device, "second-b", 9)
+	groupA := fixture.newBindGroup(t, firstA, secondA)
+	groupB := fixture.newBindGroup(t, firstB, secondB)
+
+	encoder, err := fixture.device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{})
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	pass, err := encoder.BeginComputePass(&wgpu.ComputePassDescriptor{})
+	if err != nil {
+		t.Fatalf("BeginComputePass: %v", err)
+	}
+
+	pass.SetBindGroup(0, groupA, nil)
+	pass.SetPipeline(fixture.oneSizePipeline)
+	pass.Dispatch(1, 1, 1)
+
+	pass.SetPipeline(fixture.twoSizesPipeline)
+	pass.Dispatch(1, 1, 1)
+
+	pass.SetBindGroup(0, groupB, nil)
+	pass.Dispatch(1, 1, 1)
+
+	pass.SetPipeline(fixture.oneSizePipeline)
+	pass.Dispatch(1, 1, 1)
+
+	pass.SetPipeline(fixture.twoSizesPipeline)
+	pass.Dispatch(1, 1, 1)
+	if err := pass.End(); err != nil {
+		t.Fatalf("ComputePass.End: %v", err)
+	}
+
+	got := fixture.submitAndRead(t, encoder, firstA, secondA, firstB, secondB)
+	assertBufferSizesValues(t, "first-a", got[0], []uint32{4, 1, 4})
+	assertBufferSizesValues(t, "second-a", got[1], []uint32{7, 1})
+	assertBufferSizesValues(t, "first-b", got[2], []uint32{5, 2, 5})
+	assertBufferSizesValues(t, "second-b", got[3], []uint32{9, 2})
+}
+
+func TestBufferSizesRemainCorrectForIndirectDispatch(t *testing.T) {
+	fixture := newBufferSizesFixture(t)
+	first := newBufferSizesTestBuffer(t, fixture.device, "indirect-first", 6)
+	second := newBufferSizesTestBuffer(t, fixture.device, "indirect-second", 11)
+	group := fixture.newBindGroup(t, first, second)
+
+	indirect, err := fixture.device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "buffer-sizes-indirect-arguments",
+		Size:  12,
+		Usage: gputypes.BufferUsageIndirect | gputypes.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer(indirect): %v", err)
+	}
+	t.Cleanup(indirect.Release)
+	arguments := make([]byte, 12)
+	binary.LittleEndian.PutUint32(arguments[0:4], 1)
+	binary.LittleEndian.PutUint32(arguments[4:8], 1)
+	binary.LittleEndian.PutUint32(arguments[8:12], 1)
+	if err := fixture.device.Queue().WriteBuffer(indirect, 0, arguments); err != nil {
+		t.Fatalf("WriteBuffer(indirect): %v", err)
+	}
+
+	encoder, err := fixture.device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{})
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+	pass, err := encoder.BeginComputePass(&wgpu.ComputePassDescriptor{})
+	if err != nil {
+		t.Fatalf("BeginComputePass: %v", err)
+	}
+	pass.SetPipeline(fixture.twoSizesPipeline)
+	pass.SetBindGroup(0, group, nil)
+	pass.DispatchIndirect(indirect, 0)
+	if err := pass.End(); err != nil {
+		t.Fatalf("ComputePass.End: %v", err)
+	}
+
+	got := fixture.submitAndRead(t, encoder, first, second)
+	assertBufferSizesValues(t, "indirect-first", got[0], []uint32{6, 1})
+	assertBufferSizesValues(t, "indirect-second", got[1], []uint32{11, 1})
+}
+
+type bufferSizesFixture struct {
+	device           *wgpu.Device
+	layout           *wgpu.BindGroupLayout
+	twoSizesPipeline *wgpu.ComputePipeline
+	oneSizePipeline  *wgpu.ComputePipeline
+}
+
+func newBufferSizesFixture(t *testing.T) *bufferSizesFixture {
+	t.Helper()
+	instance, err := wgpu.CreateInstance(&wgpu.InstanceDescriptor{Backends: wgpu.BackendsPrimary})
+	if err != nil {
+		t.Skipf("CreateInstance: %v", err)
+	}
+	t.Cleanup(instance.Release)
+
+	adapter, err := instance.RequestAdapter(&wgpu.RequestAdapterOptions{
+		PowerPreference: gputypes.PowerPreferenceHighPerformance,
+	})
+	if err != nil {
+		t.Skipf("RequestAdapter: %v", err)
+	}
+	t.Cleanup(adapter.Release)
+
+	device, err := adapter.RequestDevice(&wgpu.DeviceDescriptor{Label: "buffer-sizes-test"})
+	if err != nil {
+		t.Skipf("RequestDevice: %v", err)
+	}
+	t.Cleanup(device.Release)
+
+	layout, err := device.CreateBindGroupLayout(&wgpu.BindGroupLayoutDescriptor{
+		Entries: []wgpu.BindGroupLayoutEntry{
+			{
+				Binding:    0,
+				Visibility: wgpu.ShaderStageCompute,
+				Buffer:     &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeStorage},
+			},
+			{
+				Binding:    1,
+				Visibility: wgpu.ShaderStageCompute,
+				Buffer:     &gputypes.BufferBindingLayout{Type: gputypes.BufferBindingTypeStorage},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroupLayout: %v", err)
+	}
+	t.Cleanup(layout.Release)
+
+	pipelineLayout, err := device.CreatePipelineLayout(&wgpu.PipelineLayoutDescriptor{
+		BindGroupLayouts: []*wgpu.BindGroupLayout{layout},
+	})
+	if err != nil {
+		t.Fatalf("CreatePipelineLayout: %v", err)
+	}
+	t.Cleanup(pipelineLayout.Release)
+
+	newPipeline := func(label, source string) *wgpu.ComputePipeline {
+		t.Helper()
+		shader, shaderErr := device.CreateShaderModule(&wgpu.ShaderModuleDescriptor{
+			Label: label,
+			WGSL:  source,
+		})
+		if shaderErr != nil {
+			t.Fatalf("CreateShaderModule(%s): %v", label, shaderErr)
+		}
+		t.Cleanup(shader.Release)
+		pipeline, pipelineErr := device.CreateComputePipeline(&wgpu.ComputePipelineDescriptor{
+			Label:      label,
+			Layout:     pipelineLayout,
+			Module:     shader,
+			EntryPoint: "main",
+		})
+		if pipelineErr != nil {
+			t.Fatalf("CreateComputePipeline(%s): %v", label, pipelineErr)
+		}
+		t.Cleanup(pipeline.Release)
+		return pipeline
+	}
+
+	return &bufferSizesFixture{
+		device:           device,
+		layout:           layout,
+		twoSizesPipeline: newPipeline("two-buffer-sizes", twoBufferSizesShader),
+		oneSizePipeline:  newPipeline("one-buffer-size", oneBufferSizeShader),
+	}
+}
+
+type bufferSizesTestBuffer struct {
+	storage  *wgpu.Buffer
+	staging  *wgpu.Buffer
+	elements uint32
+}
+
+func newBufferSizesTestBuffer(t *testing.T, device *wgpu.Device, label string, elements uint32) *bufferSizesTestBuffer {
+	t.Helper()
+	nbytes := uint64(elements) * 4
+	storage, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: label,
+		Size:  nbytes,
+		Usage: gputypes.BufferUsageStorage | gputypes.BufferUsageCopyDst | gputypes.BufferUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer(%s): %v", label, err)
+	}
+	t.Cleanup(storage.Release)
+	if err := device.Queue().WriteBuffer(storage, 0, make([]byte, nbytes)); err != nil {
+		t.Fatalf("WriteBuffer(%s): %v", label, err)
+	}
+
+	staging, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: label + "-staging",
+		Size:  nbytes,
+		Usage: gputypes.BufferUsageMapRead | gputypes.BufferUsageCopyDst,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer(%s staging): %v", label, err)
+	}
+	t.Cleanup(staging.Release)
+	return &bufferSizesTestBuffer{storage: storage, staging: staging, elements: elements}
+}
+
+func (f *bufferSizesFixture) newBindGroup(t *testing.T, first, second *bufferSizesTestBuffer) *wgpu.BindGroup {
+	t.Helper()
+	group, err := f.device.CreateBindGroup(&wgpu.BindGroupDescriptor{
+		Layout: f.layout,
+		Entries: []wgpu.BindGroupEntry{
+			{Binding: 0, Buffer: first.storage, Size: uint64(first.elements) * 4},
+			{Binding: 1, Buffer: second.storage, Size: uint64(second.elements) * 4},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateBindGroup: %v", err)
+	}
+	t.Cleanup(group.Release)
+	return group
+}
+
+func (f *bufferSizesFixture) submitAndRead(t *testing.T, encoder *wgpu.CommandEncoder, buffers ...*bufferSizesTestBuffer) [][]uint32 {
+	t.Helper()
+	for _, buffer := range buffers {
+		nbytes := uint64(buffer.elements) * 4
+		encoder.CopyBufferToBuffer(buffer.storage, 0, buffer.staging, 0, nbytes)
+	}
+	command, err := encoder.Finish()
+	if err != nil {
+		t.Fatalf("CommandEncoder.Finish: %v", err)
+	}
+	if _, err := f.device.Queue().Submit(command); err != nil {
+		t.Fatalf("Queue.Submit: %v", err)
+	}
+
+	results := make([][]uint32, len(buffers))
+	for i, buffer := range buffers {
+		nbytes := uint64(buffer.elements) * 4
+		if err := buffer.staging.Map(context.Background(), wgpu.MapModeRead, 0, nbytes); err != nil {
+			t.Fatalf("Buffer.Map(%d): %v", i, err)
+		}
+		rng, err := buffer.staging.MappedRange(0, nbytes)
+		if err != nil {
+			t.Fatalf("Buffer.MappedRange(%d): %v", i, err)
+		}
+		values := make([]uint32, buffer.elements)
+		for j := range values {
+			values[j] = binary.LittleEndian.Uint32(rng.Bytes()[j*4:])
+		}
+		buffer.staging.Unmap()
+		results[i] = values
+	}
+	return results
+}
+
+func assertBufferSizesValues(t *testing.T, name string, got, want []uint32) {
+	t.Helper()
+	for i, value := range want {
+		if got[i] != value {
+			t.Errorf("%s[%d] = %d; want %d (full result: %v)", name, i, got[i], value, got)
+		}
+	}
 }
 
 func testArrayLengthReportsBoundSize(t *testing.T, order arrayLengthBindOrder) {

--- a/hal/metal/encoder.go
+++ b/hal/metal/encoder.go
@@ -8,6 +8,7 @@ package metal
 import (
 	"fmt"
 	"math"
+	"runtime"
 	"sync"
 	"unsafe"
 
@@ -1045,8 +1046,9 @@ func (e *ComputePassEncoder) bindBufferSizes() {
 		}
 		sizes[i] = uint32(size)
 	}
-	_ = MsgSend(e.raw, Sel("setBytes:length:atIndex:"),
-		uintptr(unsafe.Pointer(&sizes[0])), uintptr(4*len(sizes)), uintptr(p.sizesSlot))
+	_ = msgSendSetBytes(e.raw, Sel("setBytes:length:atIndex:"),
+		unsafe.Pointer(&sizes[0]), NSUInteger(4*len(sizes)), NSUInteger(p.sizesSlot))
+	runtime.KeepAlive(sizes)
 }
 
 // Dispatch dispatches compute workgroups.

--- a/hal/metal/encoder_test.go
+++ b/hal/metal/encoder_test.go
@@ -7,9 +7,11 @@ package metal
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/gogpu/gputypes"
+	"github.com/gogpu/naga/ir"
 )
 
 func TestCommandEncoderRecordingErrorKeepsFirstFailure(t *testing.T) {
@@ -187,6 +189,74 @@ func TestRenderPassDeferredStateUsesBoundedStorage(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Fatalf("deferred state allocated %.2f objects per recording", allocs)
+	}
+}
+
+func BenchmarkComputePassEncoderBindBufferSizes(b *testing.B) {
+	if err := Init(); err != nil {
+		b.Fatalf("Init: %v", err)
+	}
+	rawDevice := CreateSystemDefaultDevice()
+	if rawDevice == 0 {
+		b.Skip("no Metal device available")
+	}
+	b.Cleanup(func() { Release(rawDevice) })
+
+	device, err := newDevice(&Adapter{raw: rawDevice})
+	if err != nil {
+		b.Fatalf("newDevice: %v", err)
+	}
+	b.Cleanup(device.Destroy)
+
+	command := &CommandEncoder{device: device}
+	if err := command.BeginEncoding("bind-buffer-sizes-benchmark"); err != nil {
+		b.Fatalf("BeginEncoding: %v", err)
+	}
+	pass, ok := command.BeginComputePass(nil).(*ComputePassEncoder)
+	if !ok || pass == nil {
+		command.DiscardEncoding()
+		b.Fatal("BeginComputePass returned no Metal compute encoder")
+	}
+	b.Cleanup(func() {
+		pass.End()
+		command.DiscardEncoding()
+	})
+
+	pipeline := &ComputePipeline{
+		sizesBindings: []ir.ResourceBinding{
+			{Group: 0, Binding: 0},
+			{Group: 0, Binding: 1},
+			{Group: 1, Binding: 0},
+			{Group: 1, Binding: 1},
+		},
+		sizesSlot: 4,
+	}
+	bindingSizes := map[[2]uint32]uint64{
+		{0, 0}: 16,
+		{0, 1}: 28,
+		{1, 0}: 64,
+		{1, 1}: 256,
+	}
+
+	// Warm the selector cache before the timed region.
+	_ = Sel("setBytes:length:atIndex:")
+
+	for _, dispatches := range []int{1, 8, 64} {
+		b.Run(fmt.Sprintf("dispatches_per_pass=%d", dispatches), func(b *testing.B) {
+			// This benchmark compares Go allocations only. Repeated setBytes
+			// calls intentionally reuse one native command encoder.
+			b.ReportAllocs()
+			for b.Loop() {
+				encoder := ComputePassEncoder{
+					raw:          pass.raw,
+					pipeline:     pipeline,
+					bindingSizes: bindingSizes,
+				}
+				for range dispatches {
+					encoder.bindBufferSizes()
+				}
+			}
+		})
 	}
 }
 

--- a/hal/metal/metal.go
+++ b/hal/metal/metal.go
@@ -143,6 +143,8 @@ func preRegisterSelectors() {
 		"drawPrimitives:vertexStart:vertexCount:",
 		"drawIndexedPrimitives:indexCount:indexType:indexBuffer:indexBufferOffset:",
 		"endEncoding",
+		// MTLComputeCommandEncoder
+		"setBytes:length:atIndex:",
 		// CAMetalLayer
 		"setDevice:",
 		"setPixelFormat:",

--- a/hal/metal/objc.go
+++ b/hal/metal/objc.go
@@ -29,6 +29,7 @@ var (
 
 	cifGetClass    types.CallInterface
 	cifSelRegister types.CallInterface
+	cifSetBytes    types.CallInterface
 )
 
 // selectorCache caches registered selectors for performance.
@@ -159,6 +160,19 @@ func prepareObjCCallInterfaces() error {
 		return fmt.Errorf("metal: failed to prepare sel_registerName: %w", err)
 	}
 
+	err = ffi.PrepareCallInterface(&cifSetBytes, types.DefaultCall,
+		types.VoidTypeDescriptor,
+		[]*types.TypeDescriptor{
+			types.PointerTypeDescriptor,
+			types.PointerTypeDescriptor,
+			types.PointerTypeDescriptor,
+			types.UInt64TypeDescriptor,
+			types.UInt64TypeDescriptor,
+		})
+	if err != nil {
+		return fmt.Errorf("metal: failed to prepare setBytes:length:atIndex: call: %w", err)
+	}
+
 	return nil
 }
 
@@ -270,6 +284,31 @@ func msgSend(obj ID, sel SEL, retType *types.TypeDescriptor, retPtr unsafe.Point
 
 func msgSendVoid(obj ID, sel SEL, args ...objcArg) {
 	_ = msgSend(obj, sel, types.VoidTypeDescriptor, nil, args...)
+}
+
+func msgSendSetBytes(obj ID, sel SEL, bytes unsafe.Pointer, length, index NSUInteger) error {
+	if obj == 0 || sel == 0 {
+		return nil
+	}
+
+	self := uintptr(obj)
+	cmd := uintptr(sel)
+	lengthValue := uint64(length)
+	indexValue := uint64(index)
+	args := [5]unsafe.Pointer{
+		unsafe.Pointer(&self),
+		unsafe.Pointer(&cmd),
+		unsafe.Pointer(&bytes),
+		unsafe.Pointer(&lengthValue),
+		unsafe.Pointer(&indexValue),
+	}
+
+	// Use a per-call copy because goffi requires separate CallInterface
+	// instances for concurrent calls. The prepared type data is immutable.
+	cif := cifSetBytes
+	_, err := ffi.CallFunction(&cif, symObjcMsgSend, nil, args[:])
+	runtime.KeepAlive(bytes)
+	return err
 }
 
 func msgSendID(obj ID, sel SEL, args ...objcArg) ID {


### PR DESCRIPTION
## Summary

This PR follows up on the [minor performance note from the review of #306](https://github.com/gogpu/wgpu/pull/306#pullrequestreview-4891380026). `ComputePassEncoder.bindBufferSizes()` sends runtime-array sizes before each direct or indirect dispatch.

I first tried reusing a pre-allocated Go slice. Measurements showed that the original local slice does not escape. The reusable slice added one allocation per pass. A second version used an inline array, but it did not reduce allocations and made one benchmark case slightly slower.

Profiling showed that most allocations came from preparing the generic Objective-C call. This change prepares the call interface once and uses a specialized `setBytes:length:atIndex:` path. The buffer-size values and binding behavior stay unchanged.

## Testing

The first commit adds functional Metal tests without allocation assertions. They cover repeated direct dispatches with compatible pipeline and bind group changes, plus indirect dispatch with two runtime-sized arrays.

```console
go test -tags integration -run '^(TestArrayLength|TestBufferSizes)' -count=5 -v .
go test -race -count=1 ./hal/metal/...
go test -count=1 ./...
go build ./...
```

The benchmark uses a real Metal compute encoder with the same inputs before and after the implementation:

```console
go test -run='^$' -bench='^BenchmarkComputePassEncoderBindBufferSizes$' -benchmem -count=10 ./hal/metal
```

Apple M4, Go 1.26.5, 10 samples:

| Dispatches per pass | Time | Memory | Allocations |
| --- | ---: | ---: | ---: |
| 1 | 181.1 → 133.7 ns/op (-26.15%) | 320 → 184 B/op (-42.50%) | 9 → 6 allocs/op (-33.33%) |
| 8 | 1.462 → 1.080 µs/op (-26.10%) | 2561 → 1472 B/op (-42.52%) | 72 → 48 allocs/op (-33.33%) |
| 64 | 11.780 → 8.620 µs/op (-26.83%) | 20489 → 11781 B/op (-42.50%) | 576 → 384 allocs/op (-33.33%) |

The `benchstat` comparison shows lower execution time, memory use, and allocation counts in all three cases.

## Scope

- Metal compute passes only.
- No public API changes.
- No render-path changes or unrelated lint cleanup.