### PR TITLE
fix(core): own surface configuration state

### DIFF
--- a/core/surface.go
+++ b/core/surface.go
@@ -54,7 +54,8 @@ func (s *Surface) SetPrepareFrame(fn PrepareFrameFunc) {
 // configured, it will be reconfigured with the new settings.
 //
 // After Configure, the surface enters the Configured state and is ready
-// to acquire textures.
+// to acquire textures. The configuration is copied; the surface does not
+// retain the caller's pointer.
 func (s *Surface) Configure(device *Device, config *hal.SurfaceConfiguration) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -74,13 +75,17 @@ func (s *Surface) Configure(device *Device, config *hal.SurfaceConfiguration) er
 		return ErrDeviceDestroyed
 	}
 
-	if err := s.raw.Configure(halDevice, config); err != nil {
+	// Keep the caller's configuration private to the surface. Backends may
+	// inspect the configuration after Configure returns, so pass the copy to
+	// the HAL as well as storing it only after a successful configure.
+	configCopy := *config
+	if err := s.raw.Configure(halDevice, &configCopy); err != nil {
 		return err
 	}
 
 	s.invalidateAcquisitionLocked()
 	s.device = device
-	s.config = config
+	s.config = &configCopy
 	s.state = SurfaceStateConfigured
 	return nil
 }
@@ -337,12 +342,17 @@ func (s *Surface) State() SurfaceState {
 	return s.state
 }
 
-// Config returns the current surface configuration.
-// Returns nil if the surface is unconfigured.
+// Config returns a copy of the current surface configuration.
+// Returns nil if the surface is unconfigured. Mutating the returned value does
+// not change the surface or reconfigure its HAL surface.
 func (s *Surface) Config() *hal.SurfaceConfiguration {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.config
+	if s.config == nil {
+		return nil
+	}
+	configCopy := *s.config
+	return &configCopy
 }
 
 // applyPrepareFrame calls the PrepareFrame hook and reconfigures if dimensions changed.

--- a/core/surface_test.go
+++ b/core/surface_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"image"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/gogpu/gputypes"
@@ -94,6 +95,135 @@ func TestSurfaceConfigure(t *testing.T) {
 	if surface.Config().Width != 800 || surface.Config().Height != 600 {
 		t.Errorf("config dimensions = %dx%d, want 800x600",
 			surface.Config().Width, surface.Config().Height)
+	}
+}
+
+func TestSurfaceConfigureCopiesInputConfig(t *testing.T) {
+	surface, device, _ := newTestSurface(t)
+	config := testSurfaceConfig()
+
+	if err := surface.Configure(device, config); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	config.Width = 1024
+	config.Height = 768
+	config.EnableDamagePresent = true
+
+	got := surface.Config()
+	if got == nil {
+		t.Fatal("Config() returned nil after Configure")
+	}
+	if got == config {
+		t.Fatal("Configure retained the caller's configuration pointer")
+	}
+	if got.Width != 800 || got.Height != 600 || got.EnableDamagePresent {
+		t.Fatalf("stored config changed with caller mutation: %+v", *got)
+	}
+}
+
+func TestSurfaceConfigReturnsCopy(t *testing.T) {
+	surface, device, _ := newTestSurface(t)
+	if err := surface.Configure(device, testSurfaceConfig()); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	got := surface.Config()
+	if got == nil {
+		t.Fatal("Config() returned nil after Configure")
+	}
+	got.Width = 1024
+	got.Height = 768
+	got.EnableDamagePresent = true
+
+	stored := surface.Config()
+	if stored == nil {
+		t.Fatal("Config() returned nil after returned-copy mutation")
+	}
+	if stored == got {
+		t.Fatal("Config() returned the internal configuration pointer")
+	}
+	if stored.Width != 800 || stored.Height != 600 || stored.EnableDamagePresent {
+		t.Fatalf("returned config mutation changed surface state: %+v", *stored)
+	}
+}
+
+func TestSurfaceConfigOwnershipDoesNotRace(t *testing.T) {
+	surface, device, _ := newTestSurface(t)
+	config := testSurfaceConfig()
+	if err := surface.Configure(device, config); err != nil {
+		t.Fatalf("Configure: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 1000; i++ {
+			config.Width = uint32(800 + i%2)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 1000; i++ {
+			_ = surface.Config().Width
+		}
+	}()
+	close(start)
+	wg.Wait()
+}
+
+var errTestSurfaceConfigure = errors.New("test surface configure failed")
+
+type failingConfigureSurface struct {
+	noop.Surface
+	fail bool
+}
+
+func (s *failingConfigureSurface) Configure(_ hal.Device, config *hal.SurfaceConfiguration) error {
+	if s.fail {
+		return errTestSurfaceConfigure
+	}
+	return s.Surface.Configure(nil, config)
+}
+
+func TestSurfaceFailedConfigureDoesNotCommit(t *testing.T) {
+	_, device, _ := newTestSurface(t)
+	raw := &failingConfigureSurface{}
+	surface := NewSurface(raw, "failed-configure-test")
+	initial := testSurfaceConfig()
+	if err := surface.Configure(device, initial); err != nil {
+		t.Fatalf("initial Configure: %v", err)
+	}
+
+	raw.fail = true
+	replacement := *initial
+	replacement.Width = 1024
+	replacement.Height = 768
+	if err := surface.Configure(device, &replacement); !errors.Is(err, errTestSurfaceConfigure) {
+		t.Fatalf("failed Configure = %v, want %v", err, errTestSurfaceConfigure)
+	}
+
+	got := surface.Config()
+	if got == nil {
+		t.Fatal("Config() returned nil after failed reconfigure")
+	}
+	if got.Width != initial.Width || got.Height != initial.Height {
+		t.Fatalf("failed reconfigure committed config %+v, want %dx%d", *got, initial.Width, initial.Height)
+	}
+	if surface.State() != SurfaceStateConfigured {
+		t.Fatalf("state after failed reconfigure = %v, want configured", surface.State())
+	}
+
+	initialSurface := NewSurface(&failingConfigureSurface{fail: true}, "failed-initial-configure-test")
+	if err := initialSurface.Configure(device, initial); !errors.Is(err, errTestSurfaceConfigure) {
+		t.Fatalf("failed initial Configure = %v, want %v", err, errTestSurfaceConfigure)
+	}
+	if initialSurface.State() != SurfaceStateUnconfigured || initialSurface.Config() != nil {
+		t.Fatalf("failed initial Configure committed state=%v config=%v", initialSurface.State(), initialSurface.Config())
 	}
 }
 


### PR DESCRIPTION
## Summary

- copy surface configuration before passing it to HAL or storing it in core state
- return a defensive copy from `Surface.Config`
- preserve the previous configuration when an initial or subsequent HAL configure attempt fails
- add ownership, failure, and concurrency regressions

## Why

`Surface.Configure` stored the caller's `*hal.SurfaceConfiguration` directly, and `Config()` returned the same internal pointer. Mutating either pointer silently changed core dimensions/format without reconfiguring HAL and raced with concurrent core reads.

`hal.SurfaceConfiguration` contains only scalar fields, so value copying completely establishes ownership without a deep-copy dependency.

## Verification

- baseline input mutation changes the stored config
- baseline mutation of `Config()` changes subsequent reads
- baseline concurrent mutation reproduces a race
- failed configure/reconfigure calls leave committed state unchanged
- unconfigured `Config()` remains nil
- focused ownership tests repeated 100 times
- `go test ./core`
- `go test -race ./core`
- `go test ./...`
- `go build ./...`
- Linux, Windows, Darwin, and WASM builds
- `gofmt` and `git diff --check`

The full repository race suite still reports the pre-existing `hal/noop.Queue.Submit` counter race; the changed core surface tests are race-clean.
