### PR TITLE
release: v0.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.1] - 2026-08-11
+
+### Fixed
+
+- **core:** Own surface configuration state — defensive copy prevents aliasing (#311, @besmpl)
+  - `Surface.Configure` copies input config, `Config()` returns independent copy
+  - Failed configure/reconfigure preserves previous state
+  - Race-safe under concurrent access
+
+### Changed
+
+- **deps:** gputypes v0.5.1 → v0.5.2 (`Features.Contains` all-bits fix)
+
 ## [0.31.0] - 2026-08-10
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/go-webgpu/goffi v0.6.3
 	github.com/go-webgpu/webgpu v0.5.5
 	github.com/gogpu/gpucontext v0.26.0
-	github.com/gogpu/gputypes v0.5.1
+	github.com/gogpu/gputypes v0.5.2
 	github.com/gogpu/naga v0.18.0
 	golang.org/x/sys v0.47.0
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5S
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
 github.com/gogpu/gpucontext v0.26.0 h1:5s1mAa9RULjzBDw0Ej09EVqTh3q3+44BKJ/zCljVWAI=
 github.com/gogpu/gpucontext v0.26.0/go.mod h1:OrT137boh5yPhqBEhF4UQKIOu1Jq74SLQzYa/m6JbNo=
-github.com/gogpu/gputypes v0.5.1 h1:X38OPcP6umQqqubzzJYL6Nm1tXHSNQj6TRSAoxdAJmg=
-github.com/gogpu/gputypes v0.5.1/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
+github.com/gogpu/gputypes v0.5.2 h1:3sbKI0+XW36Ekd3d4QhkbpdY7gbgMVgp8Q4+ZNdGhtE=
+github.com/gogpu/gputypes v0.5.2/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
 github.com/gogpu/naga v0.18.0 h1:2y83HUcAnlwEZMuHOiYTMdNYM9J8rev40gkI4zJ96Uk=
 github.com/gogpu/naga v0.18.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=


### PR DESCRIPTION
## Summary

- Surface config defensive copy (#311, @besmpl)
- deps: gputypes v0.5.1 → v0.5.2 (Features.Contains all-bits fix)

## Test plan

- [x] `go build ./...` — all platforms
- [x] `go test -count=1 ./...` — 19 packages, 0 fail