### PR TITLE
fix(browser): nil descriptor guards for all Device.Create* methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.3] - 2026-08-13
+
+### Fixed
+
+- **browser:** Nil descriptor guards for all `Device.Create*` methods (#315, @darkliquid)
+  - `CreateTextureView` panicked on nil descriptor — now defaults to empty view (WebGPU spec)
+  - `CreateSampler` panicked on nil descriptor — now defaults to empty sampler (WebGPU spec)
+  - `CreateBuffer`, `CreateTexture`, `CreateShaderModule`, `CreateBindGroupLayout`, `CreatePipelineLayout`, `CreateBindGroup`, `CreateRenderPipeline`, `CreateComputePipeline` — return error on nil (consistent with native/rust backends)
+  - Unblocks ironwail-go WASM HUD rendering in Chrome/Edge
+
 ## [0.31.2] - 2026-08-11
 
 ### Changed

--- a/device_browser.go
+++ b/device_browser.go
@@ -3,6 +3,7 @@
 package wgpu
 
 import (
+	"fmt"
 	"syscall/js"
 	"time"
 
@@ -39,6 +40,9 @@ func (d *Device) CreateBuffer(desc *BufferDescriptor) (*Buffer, error) {
 	if d.released {
 		return nil, ErrReleased
 	}
+	if desc == nil {
+		return nil, fmt.Errorf("wgpu: buffer descriptor is nil")
+	}
 	jsDesc := browser.BuildBufferDescriptor(
 		desc.Label,
 		desc.Size,
@@ -70,6 +74,9 @@ func (d *Device) CreateTexture(desc *TextureDescriptor) (*Texture, error) {
 	if d.released {
 		return nil, ErrReleased
 	}
+	if desc == nil {
+		return nil, fmt.Errorf("wgpu: texture descriptor is nil")
+	}
 	jsDesc := browser.BuildTextureDescriptor(
 		desc.Label,
 		desc.Size.Width, desc.Size.Height, desc.Size.DepthOrArrayLayers,
@@ -93,6 +100,9 @@ func (d *Device) CreateTextureView(texture *Texture, desc *TextureViewDescriptor
 	if texture == nil || texture.browser == nil {
 		return nil, ErrReleased
 	}
+	if desc == nil {
+		desc = &TextureViewDescriptor{}
+	}
 	jsDesc := browser.BuildTextureViewDescriptor(
 		desc.Label,
 		desc.Format, desc.Dimension, desc.Aspect,
@@ -111,6 +121,9 @@ func (d *Device) CreateTextureView(texture *Texture, desc *TextureViewDescriptor
 func (d *Device) CreateSampler(desc *SamplerDescriptor) (*Sampler, error) {
 	if d.released {
 		return nil, ErrReleased
+	}
+	if desc == nil {
+		desc = &SamplerDescriptor{}
 	}
 	jsDesc := browser.BuildSamplerDescriptor(
 		desc.Label,
@@ -133,6 +146,9 @@ func (d *Device) CreateShaderModule(desc *ShaderModuleDescriptor) (*ShaderModule
 	if d.released {
 		return nil, ErrReleased
 	}
+	if desc == nil {
+		return nil, fmt.Errorf("wgpu: shader module descriptor is nil")
+	}
 	jsDesc := browser.BuildShaderModuleDescriptor(desc.Label, desc.WGSL)
 	bm := d.browser.CreateShaderModuleFromDesc(jsDesc)
 	return &ShaderModule{
@@ -145,6 +161,9 @@ func (d *Device) CreateShaderModule(desc *ShaderModuleDescriptor) (*ShaderModule
 func (d *Device) CreateBindGroupLayout(desc *BindGroupLayoutDescriptor) (*BindGroupLayout, error) {
 	if d.released {
 		return nil, ErrReleased
+	}
+	if desc == nil {
+		return nil, fmt.Errorf("wgpu: bind group layout descriptor is nil")
 	}
 	entries := convertBindGroupLayoutEntries(desc.Entries)
 	jsDesc := browser.BuildBindGroupLayoutDescriptor(desc.Label, entries)
@@ -159,6 +178,9 @@ func (d *Device) CreateBindGroupLayout(desc *BindGroupLayoutDescriptor) (*BindGr
 func (d *Device) CreatePipelineLayout(desc *PipelineLayoutDescriptor) (*PipelineLayout, error) {
 	if d.released {
 		return nil, ErrReleased
+	}
+	if desc == nil {
+		return nil, fmt.Errorf("wgpu: pipeline layout descriptor is nil")
 	}
 	refs := make([]js.Value, len(desc.BindGroupLayouts))
 	for i, bgl := range desc.BindGroupLayouts {
@@ -181,6 +203,9 @@ func (d *Device) CreateBindGroup(desc *BindGroupDescriptor) (*BindGroup, error) 
 	if d.released {
 		return nil, ErrReleased
 	}
+	if desc == nil {
+		return nil, fmt.Errorf("wgpu: bind group descriptor is nil")
+	}
 	var layoutRef js.Value
 	if desc.Layout != nil && desc.Layout.browser != nil {
 		layoutRef = desc.Layout.browser.Ref()
@@ -201,6 +226,9 @@ func (d *Device) CreateRenderPipeline(desc *RenderPipelineDescriptor) (*RenderPi
 	if d.released {
 		return nil, ErrReleased
 	}
+	if desc == nil {
+		return nil, fmt.Errorf("wgpu: render pipeline descriptor is nil")
+	}
 	jsDesc := convertRenderPipelineDescriptor(desc)
 	bp := d.browser.CreateRenderPipelineFromDesc(jsDesc)
 	return &RenderPipeline{
@@ -213,6 +241,9 @@ func (d *Device) CreateRenderPipeline(desc *RenderPipelineDescriptor) (*RenderPi
 func (d *Device) CreateComputePipeline(desc *ComputePipelineDescriptor) (*ComputePipeline, error) {
 	if d.released {
 		return nil, ErrReleased
+	}
+	if desc == nil {
+		return nil, fmt.Errorf("wgpu: compute pipeline descriptor is nil")
 	}
 	var layoutRef js.Value
 	if desc.Layout != nil && desc.Layout.browser != nil {

--- a/hal/metal/device.go
+++ b/hal/metal/device.go
@@ -766,7 +766,7 @@ func (d *Device) CreateRenderPipeline(desc *hal.RenderPipelineDescriptor) (hal.R
 	}
 
 	// Get and set fragment function if present
-	if fragmentModule != nil && desc.Fragment != nil { //nolint:nestif // sequential Metal pipeline setup
+	if fragmentModule != nil && desc.Fragment != nil {
 		// Resolve translated entrypoint name
 		entrypointName := desc.Fragment.EntryPoint
 		if translated, ok := fragmentLib.entrypointNames[entrypointName]; ok {

--- a/hal/metal/encoder.go
+++ b/hal/metal/encoder.go
@@ -374,7 +374,7 @@ func (e *CommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.Ren
 			msgSendClearColor(attachment, Sel("setClearColor:"), clearColor)
 		}
 		storeAction := storeOpToMTL(ca.StoreOp)
-		if ca.ResolveTarget != nil { //nolint:nestif // sequential Metal descriptor setup
+		if ca.ResolveTarget != nil {
 			if rtv, ok := ca.ResolveTarget.(*TextureView); ok && rtv != nil {
 				_ = MsgSend(attachment, Sel("setResolveTexture:"), uintptr(rtv.raw))
 				// Metal requires MultisampleResolve store action when a resolve
@@ -389,7 +389,7 @@ func (e *CommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.Ren
 		}
 		_ = MsgSend(attachment, Sel("setStoreAction:"), uintptr(storeAction))
 	}
-	if desc.DepthStencilAttachment != nil { //nolint:nestif // sequential Metal descriptor setup
+	if desc.DepthStencilAttachment != nil {
 		dsa := desc.DepthStencilAttachment
 
 		// Depth attachment
@@ -685,7 +685,6 @@ func (e *RenderPassEncoder) SetBindGroup(index uint32, group hal.BindGroup, offs
 }
 
 func (e *RenderPassEncoder) applyBindGroup(index uint32, bg *BindGroup, offsets []uint32) {
-
 	// Metal uses per-type sequential indices: [[buffer(N)]], [[texture(M)]], [[sampler(K)]].
 	// naga MSL generates these indices sequentially across ALL bind groups in the
 	// pipeline layout. Group 0 starts at 0; group 1 starts where group 0 ended, etc.

--- a/hal/metal/icb_indexed.go
+++ b/hal/metal/icb_indexed.go
@@ -92,18 +92,18 @@ func indexedICBCountEligible(count uint32) bool {
 	return count >= indexedICBMinCommands && count <= indexedICBMaxCommands
 }
 
-func indexedICBArenaCapacity(count, max uint32) uint32 {
-	if count == 0 || max == 0 || count > max {
+func indexedICBArenaCapacity(count, maxCount uint32) uint32 {
+	if count == 0 || maxCount == 0 || count > maxCount {
 		return 0
 	}
 	capacity := indexedICBMinCommands
-	if capacity > max {
-		capacity = max
+	if capacity > maxCount {
+		capacity = maxCount
 	}
 	for capacity < count {
 		next := capacity * 2
-		if next < capacity || next > max {
-			capacity = max
+		if next < capacity || next > maxCount {
+			capacity = maxCount
 			break
 		}
 		capacity = next
@@ -331,7 +331,7 @@ func (e *RenderPassEncoder) prepareIndexedICB(arguments *Buffer, offset uint64, 
 	_ = MsgSend(compute, Sel("setBuffer:offset:atIndex:"), uintptr(arena.argumentBuffer), 0, 1)
 	_ = MsgSend(compute, Sel("setBuffer:offset:atIndex:"), uintptr(e.indexBuffer.raw), uintptr(e.indexOffset), 2)
 	params := indexedICBParams{count: count}
-	_ = MsgSend(compute, Sel("setBytes:length:atIndex:"), uintptr(unsafe.Pointer(&params)), uintptr(unsafe.Sizeof(params)), 3)
+	_ = MsgSend(compute, Sel("setBytes:length:atIndex:"), uintptr(unsafe.Pointer(&params)), unsafe.Sizeof(params), 3)
 	_ = MsgSend(compute, Sel("useResource:usage:"), uintptr(arguments.raw), 1)
 	_ = MsgSend(compute, Sel("useResource:usage:"), uintptr(arena.argumentBuffer), 1)
 	_ = MsgSend(compute, Sel("useResource:usage:"), uintptr(e.indexBuffer.raw), 1)

--- a/hal/metal/icb_indexed_test.go
+++ b/hal/metal/icb_indexed_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestIndexedICBArenaCapacityIsGeometricAndBounded(t *testing.T) {
-	const max = uint32(52428)
+	const maxCount = uint32(52428)
 	for _, test := range []struct {
 		count uint32
 		want  uint32
@@ -21,10 +21,10 @@ func TestIndexedICBArenaCapacityIsGeometricAndBounded(t *testing.T) {
 		{1024, 1024},
 		{1025, 2048},
 		{10000, 16384},
-		{max, max},
-		{max + 1, 0},
+		{maxCount, maxCount},
+		{maxCount + 1, 0},
 	} {
-		if got := indexedICBArenaCapacity(test.count, max); got != test.want {
+		if got := indexedICBArenaCapacity(test.count, maxCount); got != test.want {
 			t.Fatalf("capacity(%d) = %d, want %d", test.count, got, test.want)
 		}
 	}

--- a/hal/metal/queue.go
+++ b/hal/metal/queue.go
@@ -374,7 +374,7 @@ func (q *Queue) WriteTexture(dst *hal.ImageCopyTexture, data []byte, layout *hal
 // It uses the slice-aware replaceRegion form so 2D arrays and true 3D textures
 // preserve their distinct Metal layouts. The write is synchronous; no GPU command
 // buffer or staging buffer is required. Valid only when tex.isShared is true.
-func (q *Queue) writeTextureShared(tex *Texture, dst *hal.ImageCopyTexture, data []byte, layout *hal.ImageDataLayout, copyLayout metalTextureDataCopyLayout, size *hal.Extent3D, plan metalCopyPlan) error {
+func (q *Queue) writeTextureShared(tex *Texture, dst *hal.ImageCopyTexture, data []byte, layout *hal.ImageDataLayout, copyLayout metalTextureDataCopyLayout, size *hal.Extent3D, plan metalCopyPlan) error { //nolint:unparam // error return for API parity with writeTextureStaged
 	strides := metalReplaceRegionStrides(tex.dimension, uint64(copyLayout.bytesPerRow), copyLayout.bytesPerImage)
 	for operation := uint32(0); operation < plan.operationCount; operation++ {
 		offset, _ := plan.bufferOffset(layout.Offset, copyLayout.bytesPerImage, operation)

--- a/hal/metal/resource.go
+++ b/hal/metal/resource.go
@@ -57,7 +57,7 @@ type Texture struct {
 	isExternal bool
 	// isShared is true when this texture was created with MTLStorageModeShared
 	// (Apple Silicon UMA only). Shared textures support direct CPU writes via
-	// replaceRegion: and honour setPurgeableState(empty) for immediate OS reclaim.
+	// replaceRegion: and honor setPurgeableState(empty) for immediate OS reclaim.
 	isShared bool
 }
 

--- a/hal/metal/texture_copy_test.go
+++ b/hal/metal/texture_copy_test.go
@@ -555,10 +555,6 @@ func newMetalTextureCopyTestDevice(t *testing.T) (*Device, *Queue) {
 	return device, queue
 }
 
-func createMetalTextureCopyTestArray(t *testing.T, device *Device, width, height, layers uint32) *Texture {
-	return createMetalTextureCopyTestTexture(t, device, gputypes.TextureDimension2D, width, height, layers)
-}
-
 func createMetalTextureCopyTestTexture(t *testing.T, device *Device, dimension gputypes.TextureDimension, width, height, depthOrLayers uint32) *Texture {
 	t.Helper()
 	raw, err := device.CreateTexture(&hal.TextureDescriptor{


### PR DESCRIPTION
## Summary

Fixes #315 — browser WASM shim panics on nil `TextureViewDescriptor` (and other descriptors).

- **Root cause:** `device_browser.go` dereferences descriptor fields unconditionally, while native and Rust backends handle nil gracefully
- **Fix:** Add nil descriptor guards to **all 10** `Device.Create*` methods, matching native/Rust behavior:
  - `CreateTextureView` / `CreateSampler`: nil → default descriptor (WebGPU spec: "default view" / "default sampler")
  - `CreateBuffer` / `CreateTexture` / `CreateShaderModule` / `CreateBindGroupLayout` / `CreatePipelineLayout` / `CreateBindGroup` / `CreateRenderPipeline` / `CreateComputePipeline`: nil → return error (matches native/Rust)
- **Scope:** Issue reported for `CreateTextureView` only, but full audit found 7 additional methods with the same vulnerability

Unblocks ironwail-go walkthrough HUD (color/char texture uploads) in Chrome/Edge.

## Audit

| Method | nil behavior | Consistent across native/rust/browser? |
|--------|-------------|:------:|
| CreateBuffer | error | ✅ |
| CreateTexture | error | ✅ |
| CreateTextureView | default view | ✅ |
| CreateSampler | default sampler | ✅ |
| CreateShaderModule | error | ✅ |
| CreateBindGroupLayout | error | ✅ |
| CreatePipelineLayout | error | ✅ |
| CreateBindGroup | error | ✅ |
| CreateRenderPipeline | error | ✅ |
| CreateComputePipeline | error | ✅ |
| CreateCommandEncoder | default label="" | ✅ (already correct) |

Non-creator browser methods (queue, encoder, render/compute pass) were also audited — all already have proper nil guards.

## Test plan

- [x] `GOOS=js GOARCH=wasm go build github.com/gogpu/wgpu` — builds clean
- [x] `go build ./...` — Windows, Linux, macOS
- [x] `go test ./...` — all pass
- [x] `golangci-lint run --timeout=5m` — 0 issues