### PR TITLE
fix: add writable mapped-range API across backends

### DIFF
--- a/mapped_range.go
+++ b/mapped_range.go
@@ -77,6 +77,19 @@ func (m *MappedRange) Bytes() []byte {
 	return unsafe.Slice((*byte)(m.data), m.size) //nolint:gosec // range validated at MappedRange creation
 }
 
+// BytesMut returns a mutable byte slice for writing into the mapped region.
+// On native backend, this returns the same underlying data as Bytes() since
+// the mapped range is already writable through the direct mapping.
+func (m *MappedRange) BytesMut() []byte {
+	return m.Bytes()
+}
+
+// Flush writes the cached data back. On native backend, data is written through
+// the direct pointer, so this is a no-op.
+func (m *MappedRange) Flush() error {
+	return nil
+}
+
 // Len returns the size of the mapped range in bytes.
 func (m *MappedRange) Len() int {
 	if m == nil {

--- a/mapped_range_test.go
+++ b/mapped_range_test.go
@@ -1,0 +1,42 @@
+//go:build !rust && !(js && wasm)
+
+package wgpu_test
+
+import (
+	"testing"
+
+	"github.com/gogpu/wgpu"
+)
+
+func TestMappedRangeBytesMutAndFlush(t *testing.T) {
+	_, _, device := newDevice(t)
+	defer device.Release()
+	requireHAL(t, device)
+
+	buf, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label:            "mapped-write",
+		Size:             16,
+		Usage:            wgpu.BufferUsageVertex | wgpu.BufferUsageCopyDst,
+		MappedAtCreation: true,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	defer buf.Release()
+
+	rangeValue, err := buf.MappedRange(0, 16)
+	if err != nil {
+		t.Fatalf("MappedRange: %v", err)
+	}
+	data := rangeValue.BytesMut()
+	if len(data) != 16 {
+		t.Fatalf("BytesMut length = %d, want 16", len(data))
+	}
+	data[0] = 0x42
+	if err := rangeValue.Flush(); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if err := buf.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Add a common writable mapped-range API to the native `wgpu` backend:

```go
BytesMut() []byte
Flush() error
```

The browser and Rust backends already expose equivalent behavior. This change brings the native backend into API parity so higher-level libraries such as `g3d` can write mapped buffer data without build-tag-specific code.

## Motivation

`MappedRange.Bytes()` is currently suitable for reading, but higher-level code that writes mapped buffer contents needs an explicit writable-range API.

The browser backend uses a Go-side staging slice for mapped writes and requires `Flush()` to copy modified data back to the JavaScript `ArrayBuffer`. The Rust backend exposes a direct writable mapping. Native mappings also expose direct writable memory.

Without a common API, consumers need platform-specific implementations for the same geometry or buffer upload code.

## Changes

- Added `MappedRange.BytesMut()` to the native backend.
- Added `MappedRange.Flush()` to the native backend.
- Implemented native `BytesMut()` as an alias of `Bytes()`.
- Implemented native `Flush()` as a no-op because native mappings are directly device-visible.
- Added a regression test

## Related

This change is a prerequisite for the corresponding `gogpu/g3d` update that switches geometry uploads to the common `BytesMut()` and `Flush()` API.