### PR TITLE
docs: CHANGELOG v0.31.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.5] - 2026-08-18
+
+### Added
+
+- **mapped-range:** `MappedRange.BytesMut()` and `MappedRange.Flush()` on native backend (#318, @tarmo888)
+  - API parity with browser and Rust backends — cross-backend code compiles without build tags
+  - Native `BytesMut()` aliases `Bytes()` (direct mapping already writable); `Flush()` is a no-op (direct pointer, no staging)
+  - Prerequisite for `gogpu/g3d` geometry upload API
+
 ## [0.31.4] - 2026-08-13
 
 ### Changed


### PR DESCRIPTION
## Summary

- Add CHANGELOG entry for v0.31.5: `MappedRange.BytesMut()` / `Flush()` native backend API parity (#318, @tarmo888)