### PR TITLE
Fix Vulkan array texture uploads

### DIFF
--- a/hal/vulkan/command.go
+++ b/hal/vulkan/command.go
@@ -614,7 +614,7 @@ func (e *CommandEncoder) CopyBufferToBuffer(src, dst hal.Buffer, regions []hal.B
 // convertBufferImageCopyRegions converts HAL BufferTextureCopy regions to Vulkan BufferImageCopy.
 // The format parameter is the texture format, used to determine block copy size
 // for correct bytes-to-texels conversion of bufferRowLength.
-func convertBufferImageCopyRegions(regions []hal.BufferTextureCopy, format gputypes.TextureFormat) []vk.BufferImageCopy {
+func convertBufferImageCopyRegions(regions []hal.BufferTextureCopy, format gputypes.TextureFormat, dimension gputypes.TextureDimension) []vk.BufferImageCopy {
 	vkRegions := make([]vk.BufferImageCopy, len(regions))
 	blockSize := format.BlockCopySize()
 	if blockSize == 0 {
@@ -629,6 +629,19 @@ func convertBufferImageCopyRegions(regions []hal.BufferTextureCopy, format gputy
 		if r.BufferLayout.BytesPerRow > 0 {
 			bufferRowLength = r.BufferLayout.BytesPerRow / blockSize
 		}
+		baseArrayLayer := uint32(0)
+		layerCount := uint32(1)
+		imageOffsetZ := int32(r.TextureBase.Origin.Z)
+		imageExtentDepth := r.Size.DepthOrArrayLayers
+		if dimension != gputypes.TextureDimension3D {
+			baseArrayLayer = r.TextureBase.Origin.Z
+			layerCount = r.Size.DepthOrArrayLayers
+			if layerCount == 0 {
+				layerCount = 1
+			}
+			imageOffsetZ = 0
+			imageExtentDepth = 1
+		}
 
 		vkRegions[i] = vk.BufferImageCopy{
 			BufferOffset:      vk.DeviceSize(r.BufferLayout.Offset),
@@ -637,18 +650,18 @@ func convertBufferImageCopyRegions(regions []hal.BufferTextureCopy, format gputy
 			ImageSubresource: vk.ImageSubresourceLayers{
 				AspectMask:     textureAspectToVkSimple(r.TextureBase.Aspect),
 				MipLevel:       r.TextureBase.MipLevel,
-				BaseArrayLayer: 0,
-				LayerCount:     1,
+				BaseArrayLayer: baseArrayLayer,
+				LayerCount:     layerCount,
 			},
 			ImageOffset: vk.Offset3D{
 				X: int32(r.TextureBase.Origin.X),
 				Y: int32(r.TextureBase.Origin.Y),
-				Z: int32(r.TextureBase.Origin.Z),
+				Z: imageOffsetZ,
 			},
 			ImageExtent: vk.Extent3D{
 				Width:  r.Size.Width,
 				Height: r.Size.Height,
-				Depth:  r.Size.DepthOrArrayLayers,
+				Depth:  imageExtentDepth,
 			},
 		}
 	}
@@ -667,7 +680,7 @@ func (e *CommandEncoder) CopyBufferToTexture(src hal.Buffer, dst hal.Texture, re
 		return
 	}
 
-	vkRegions := convertBufferImageCopyRegions(regions, dstTex.format)
+	vkRegions := convertBufferImageCopyRegions(regions, dstTex.format, dstTex.dimension)
 	vkCmdCopyBufferToImage(
 		e.device.cmds,
 		e.active,
@@ -691,7 +704,7 @@ func (e *CommandEncoder) CopyTextureToBuffer(src hal.Texture, dst hal.Buffer, re
 		return
 	}
 
-	vkRegions := convertBufferImageCopyRegions(regions, srcTex.format)
+	vkRegions := convertBufferImageCopyRegions(regions, srcTex.format, srcTex.dimension)
 	vkCmdCopyImageToBuffer(
 		e.device.cmds,
 		e.active,

--- a/hal/vulkan/copy_test.go
+++ b/hal/vulkan/copy_test.go
@@ -1,0 +1,49 @@
+//go:build !(js && wasm)
+
+package vulkan
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/hal"
+)
+
+func TestConvertBufferImageCopyRegionsUsesArrayLayersFor2DTextures(t *testing.T) {
+	regions := []hal.BufferTextureCopy{{
+		BufferLayout: hal.ImageDataLayout{BytesPerRow: 256, RowsPerImage: 4},
+		TextureBase: hal.ImageCopyTexture{
+			Origin: hal.Origin3D{X: 2, Y: 3, Z: 1},
+			Aspect: gputypes.TextureAspectAll,
+		},
+		Size: hal.Extent3D{Width: 8, Height: 4, DepthOrArrayLayers: 2},
+	}}
+
+	converted := convertBufferImageCopyRegions(regions, gputypes.TextureFormatRGBA8Unorm, gputypes.TextureDimension2D)
+	got := converted[0]
+	if got.ImageSubresource.BaseArrayLayer != 1 || got.ImageSubresource.LayerCount != 2 {
+		t.Fatalf("array range = %d+%d, want 1+2", got.ImageSubresource.BaseArrayLayer, got.ImageSubresource.LayerCount)
+	}
+	if got.ImageOffset.Z != 0 || got.ImageExtent.Depth != 1 {
+		t.Fatalf("depth offset+extent = %d+%d, want 0+1", got.ImageOffset.Z, got.ImageExtent.Depth)
+	}
+}
+
+func TestConvertBufferImageCopyRegionsUsesDepthFor3DTextures(t *testing.T) {
+	regions := []hal.BufferTextureCopy{{
+		TextureBase: hal.ImageCopyTexture{
+			Origin: hal.Origin3D{X: 2, Y: 3, Z: 1},
+			Aspect: gputypes.TextureAspectAll,
+		},
+		Size: hal.Extent3D{Width: 8, Height: 4, DepthOrArrayLayers: 2},
+	}}
+
+	converted := convertBufferImageCopyRegions(regions, gputypes.TextureFormatRGBA8Unorm, gputypes.TextureDimension3D)
+	got := converted[0]
+	if got.ImageSubresource.BaseArrayLayer != 0 || got.ImageSubresource.LayerCount != 1 {
+		t.Fatalf("array range = %d+%d, want 0+1", got.ImageSubresource.BaseArrayLayer, got.ImageSubresource.LayerCount)
+	}
+	if got.ImageOffset.Z != 1 || got.ImageExtent.Depth != 2 {
+		t.Fatalf("depth offset+extent = %d+%d, want 1+2", got.ImageOffset.Z, got.ImageExtent.Depth)
+	}
+}

--- a/pending_writes.go
+++ b/pending_writes.go
@@ -298,16 +298,11 @@ func (pw *pendingWrites) writeTextureFor(
 
 	// Transition texture to COPY_DST using its actual tracked state.
 	currentUsage := dst.Texture.CurrentUsage()
+	copyRange := textureCopyRange(owner, dst, size)
 	if currentUsage != gputypes.TextureUsageCopyDst {
 		barrier := [1]hal.TextureBarrier{{
 			Texture: dst.Texture,
-			Range: hal.TextureRange{
-				Aspect:          gputypes.TextureAspectAll,
-				BaseMipLevel:    dst.MipLevel,
-				MipLevelCount:   1,
-				BaseArrayLayer:  0,
-				ArrayLayerCount: 1,
-			},
+			Range:   copyRange,
 			Usage: hal.TextureUsageTransition{
 				OldUsage: currentUsage,
 				NewUsage: gputypes.TextureUsageCopyDst,
@@ -334,13 +329,7 @@ func (pw *pendingWrites) writeTextureFor(
 	// also covers queue write operations (pending_writes integration, future work).
 	postBarrier := [1]hal.TextureBarrier{{
 		Texture: dst.Texture,
-		Range: hal.TextureRange{
-			Aspect:          gputypes.TextureAspectAll,
-			BaseMipLevel:    dst.MipLevel,
-			MipLevelCount:   1,
-			BaseArrayLayer:  0,
-			ArrayLayerCount: 1,
-		},
+		Range:   copyRange,
 		Usage: hal.TextureUsageTransition{
 			OldUsage: gputypes.TextureUsageCopyDst,
 			NewUsage: gputypes.TextureUsageTextureBinding,
@@ -360,6 +349,25 @@ func (pw *pendingWrites) writeTextureFor(
 	pw.dstTextures[dst.Texture] = owners
 
 	return nil
+}
+
+func textureCopyRange(owner *Texture, dst *hal.ImageCopyTexture, size *hal.Extent3D) hal.TextureRange {
+	baseLayer := uint32(0)
+	layerCount := uint32(1)
+	if owner != nil && owner.coreTexture != nil && owner.coreTexture.Dimension() != gputypes.TextureDimension3D {
+		baseLayer = dst.Origin.Z
+		layerCount = size.DepthOrArrayLayers
+		if layerCount == 0 {
+			layerCount = 1
+		}
+	}
+	return hal.TextureRange{
+		Aspect:          dst.Aspect,
+		BaseMipLevel:    dst.MipLevel,
+		MipLevelCount:   1,
+		BaseArrayLayer:  baseLayer,
+		ArrayLayerCount: layerCount,
+	}
 }
 
 func containsTextureOwner(owners []*Texture, target *Texture) bool {

--- a/pending_writes_test.go
+++ b/pending_writes_test.go
@@ -7,6 +7,7 @@ import (
 	"unsafe"
 
 	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/core"
 	"github.com/gogpu/wgpu/hal"
 	"github.com/gogpu/wgpu/hal/noop"
 )
@@ -23,6 +24,25 @@ type mockBatchingQueue struct {
 	lastWriteBuf      hal.Buffer
 	lastWriteOffset   uint64
 	lastWriteData     []byte
+}
+
+type barrierCaptureEncoder struct {
+	noop.CommandEncoder
+	textureBarriers []hal.TextureBarrier
+}
+
+func (e *barrierCaptureEncoder) TransitionTextures(barriers []hal.TextureBarrier) {
+	e.textureBarriers = append(e.textureBarriers, barriers...)
+}
+
+type barrierCaptureDevice struct {
+	noop.Device
+	encoder *barrierCaptureEncoder
+}
+
+func (d *barrierCaptureDevice) CreateCommandEncoder(*hal.CommandEncoderDescriptor) (hal.CommandEncoder, error) {
+	d.encoder = &barrierCaptureEncoder{}
+	return d.encoder, nil
 }
 
 func (q *mockBatchingQueue) SupportsCommandBufferCopies() bool { return true }
@@ -326,6 +346,67 @@ func TestPendingWrites_WriteTextureBatching(t *testing.T) {
 	pw.mu.Unlock()
 	if !tracked {
 		t.Error("expected texture to be tracked in dstTextures")
+	}
+}
+
+func captureTextureWriteBarriers(t *testing.T, dimension gputypes.TextureDimension, origin hal.Origin3D, size hal.Extent3D) []hal.TextureBarrier {
+	t.Helper()
+	dev := &barrierCaptureDevice{}
+	q := &mockBatchingQueue{}
+	pool := newEncoderPool(dev)
+	pw := newPendingWrites(dev, q, pool)
+	t.Cleanup(func() {
+		pw.destroy()
+		pool.destroy()
+	})
+
+	halTexture := &noop.Texture{}
+	coreTexture := core.NewTexture(
+		halTexture, nil, gputypes.TextureFormatRGBA8Unorm,
+		dimension, gputypes.TextureUsageCopyDst,
+		gputypes.Extent3D{Width: 16, Height: 16, DepthOrArrayLayers: 2},
+		1, 1, "texture",
+	)
+	texture := &Texture{hal: halTexture, coreTexture: coreTexture}
+	dst := &hal.ImageCopyTexture{
+		Texture: halTexture,
+		Origin:  origin,
+		Aspect:  gputypes.TextureAspectAll,
+	}
+	layout := &hal.ImageDataLayout{BytesPerRow: 4, RowsPerImage: size.Height}
+	data := make([]byte, size.Width*size.Height*size.DepthOrArrayLayers*4)
+
+	if err := pw.writeTextureFor(texture, dst, data, layout, &size); err != nil {
+		t.Fatalf("writeTextureFor: %v", err)
+	}
+	return dev.encoder.textureBarriers
+}
+
+func TestPendingWrites_WriteTextureTransitionsArrayLayers(t *testing.T) {
+	barriers := captureTextureWriteBarriers(t, gputypes.TextureDimension2D, hal.Origin3D{Z: 1}, hal.Extent3D{
+		Width: 1, Height: 1, DepthOrArrayLayers: 1,
+	})
+	if len(barriers) != 2 {
+		t.Fatalf("texture barriers = %d, want 2", len(barriers))
+	}
+	for i, barrier := range barriers {
+		if barrier.Range.BaseArrayLayer != 1 || barrier.Range.ArrayLayerCount != 1 {
+			t.Errorf("barrier %d array range = %d+%d, want 1+1", i, barrier.Range.BaseArrayLayer, barrier.Range.ArrayLayerCount)
+		}
+	}
+}
+
+func TestPendingWrites_WriteTextureTransitions3DDepth(t *testing.T) {
+	barriers := captureTextureWriteBarriers(t, gputypes.TextureDimension3D, hal.Origin3D{Z: 1}, hal.Extent3D{
+		Width: 1, Height: 1, DepthOrArrayLayers: 1,
+	})
+	if len(barriers) != 2 {
+		t.Fatalf("texture barriers = %d, want 2", len(barriers))
+	}
+	for i, barrier := range barriers {
+		if barrier.Range.BaseArrayLayer != 0 || barrier.Range.ArrayLayerCount != 1 {
+			t.Errorf("barrier %d array range = %d+%d, want 0+1", i, barrier.Range.BaseArrayLayer, barrier.Range.ArrayLayerCount)
+		}
 	}
 }
 


### PR DESCRIPTION
`Queue.WriteTexture` currently targets array layer 0 on native Vulkan even when `ImageCopyTexture.Origin.Z` selects a nonzero layer.

Two conversions contributed to the issue:

- pending-write barriers hardcoded `BaseArrayLayer: 0` and `ArrayLayerCount: 1`
- Vulkan buffer/image copies hardcoded `BaseArrayLayer: 0` and mapped `Origin.Z` to `ImageOffset.Z`, which is correct for 3D textures but not 2D texture arrays

This change makes pending-write barriers target the requested array subresources and makes Vulkan copy conversion dimension-aware. Non-3D textures map `Origin.Z`/`DepthOrArrayLayers` to array layers with a zero depth offset; 3D textures retain the existing depth behavior.

Regression tests cover nonzero 2D array layers and 3D depth for both pending barriers and Vulkan copy conversion.

Validation: `go test ./...`