### PR TITLE
release: v0.31.7

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -155,10 +155,10 @@ linters:
           - nestif
           - maintidx
 
-      # Metal backend (//go:build darwin): nolintlint false positives on
-      # cross-GOOS lint (golangci-lint#3833). unparam doesn't trigger without
-      # full darwin type info, so //nolint:unparam appears "unused".
-      - path: hal/metal/.*\.go
+      # Metal queue (//go:build darwin): nolintlint false positive on
+      # //nolint:unparam — unparam doesn't trigger on cross-GOOS lint without
+      # full darwin type info (golangci-lint#3833).
+      - path: hal/metal/queue\.go
         linters:
           - nolintlint
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -161,6 +161,7 @@ linters:
       - path: hal/metal/queue\.go
         linters:
           - nolintlint
+        text: "unparam"
 
       # GL context - requires unsafe for C interop
       - path: hal/gles/gl/context\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -155,6 +155,13 @@ linters:
           - nestif
           - maintidx
 
+      # Metal backend (//go:build darwin): nolintlint false positives on
+      # cross-GOOS lint (golangci-lint#3833). unparam doesn't trigger without
+      # full darwin type info, so //nolint:unparam appears "unused".
+      - path: hal/metal/.*\.go
+        linters:
+          - nolintlint
+
       # GL context - requires unsafe for C interop
       - path: hal/gles/gl/context\.go
         linters:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 
 ## Current Version
 
-v0.31.6 | Go 1.25+ | Dependencies: naga v0.18.0, gpucontext v0.28.0, gputypes v0.5.2, goffi v0.6.3, webgpu v0.5.5
+v0.31.7 | Go 1.25+ | Dependencies: naga v0.19.0, gpucontext v0.28.0, gputypes v0.5.2, goffi v0.6.3, webgpu v0.5.5
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.31.7] - 2026-08-27
+
+### Fixed
+
+- **vulkan:** Fix array texture uploads — `Origin.Z` now maps to `BaseArrayLayer` for 2D textures (#323, @dvoyni)
+  - Non-3D textures: `Origin.Z` / `DepthOrArrayLayers` → array layers (was incorrectly mapped to depth offset)
+  - Pending-write barriers now target correct array subresources (was hardcoded `BaseArrayLayer: 0`)
+  - Barrier `Aspect` uses caller-supplied value instead of hardcoded `TextureAspectAll`
+
+### Changed
+
+- **deps:** naga v0.18.0 → v0.19.0
+
 ## [0.31.6] - 2026-08-23
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.30.23
+## Current State: v0.31.7
 
 ✅ **Triple-backend architecture (ADR-038)** — Native Go, Rust FFI, Browser WASM via build tags
 ✅ **All 5 Native HAL backends complete** (~127K LOC)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -334,7 +334,7 @@ gogpu (app framework) / gg (2D graphics)
 ```
 
 External dependencies:
-- `github.com/gogpu/naga` v0.18.0 — shader compiler (WGSL → SPIR-V / MSL / GLSL / HLSL / DXIL), Pure Go
+- `github.com/gogpu/naga` v0.19.0 — shader compiler (WGSL → SPIR-V / MSL / GLSL / HLSL / DXIL), Pure Go
 - `github.com/gogpu/gputypes` v0.5.2 — shared WebGPU type definitions
 - `github.com/gogpu/gpucontext` v0.28.0 — shared interfaces (DeviceProvider, PlatformProvider)
 - `github.com/go-webgpu/goffi` v0.6.3 — Pure Go FFI for Vulkan/Metal/DX12 symbol loading (Android Bionic support)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,6 @@ require (
 	github.com/go-webgpu/webgpu v0.5.5
 	github.com/gogpu/gpucontext v0.28.0
 	github.com/gogpu/gputypes v0.5.2
-	github.com/gogpu/naga v0.18.0
+	github.com/gogpu/naga v0.19.0
 	golang.org/x/sys v0.47.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,7 +6,7 @@ github.com/gogpu/gpucontext v0.28.0 h1:W27+0PRnHLVRscDJ2L6r4B1JlaKjlV/EmL0Wxx8vG
 github.com/gogpu/gpucontext v0.28.0/go.mod h1:5rpKj+DpixgAFm8ArBXFXOZQRbeJSFncVMsqyyA9Rhc=
 github.com/gogpu/gputypes v0.5.2 h1:3sbKI0+XW36Ekd3d4QhkbpdY7gbgMVgp8Q4+ZNdGhtE=
 github.com/gogpu/gputypes v0.5.2/go.mod h1:cnXrDMwTpWTvJLW1Vreop3PcT6a2YP/i3s91rPaOavw=
-github.com/gogpu/naga v0.18.0 h1:2y83HUcAnlwEZMuHOiYTMdNYM9J8rev40gkI4zJ96Uk=
-github.com/gogpu/naga v0.18.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
+github.com/gogpu/naga v0.19.0 h1:+Pu7kahdMhvRWtpEbTW5YFQZPoklccMO4vryEk6w9zU=
+github.com/gogpu/naga v0.19.0/go.mod h1:15sQaHKkbqXcwTN+hHYGLsA0WBBnkmYzne/eF5p5WEg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## Summary

- **vulkan:** Fix array texture uploads — `Origin.Z` now maps to `BaseArrayLayer` for 2D textures (#323, @dvoyni)
- **deps:** naga v0.18.0 → v0.19.0
- **lint:** Narrow Metal nolintlint exclusion to `queue.go` only (golangci-lint#3833)
- **docs:** ROADMAP v0.31.7, AGENTS.md/ARCHITECTURE.md dep versions