### PR TITLE
docs: post-v0.32.0 — RT docs, example fix, AGENTS.md update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,5 @@ docs/dev/
 tmp/
 
 # Investigation backups
-.backup-investigation/
+.backup-investigation/*.json
+VP_VULKANINFO*.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,10 +62,23 @@ wgpu (public API — Device, Queue, Buffer, Texture, Pipeline...)
 | `wgpu/hal/dx12` | DirectX 12 backend (Windows) |
 | `wgpu/hal/gles` | OpenGL ES backend |
 | `wgpu/hal/software` | CPU software renderer |
+| `wgpu/internal/raytracing` | RT build orchestration, compaction, validation (ADR-062) |
+
+### Ray Tracing (experimental, v0.32.0)
+
+Inline ray queries matching Rust wgpu's `EXPERIMENTAL_RAY_QUERY`. Feature-gated by `FeatureRayQuery`.
+
+- **Vulkan**: VK_KHR_acceleration_structure + VK_KHR_ray_query
+- **DX12**: DXR Tier 1.1, SM 6.5
+- **Metal**: MTLAccelerationStructure (macOS 15.0+, iOS 18.0+)
+- **Software**: CPU BVH (Moller-Trumbore) for CI/testing without GPU
+- **GLES**: Not supported
+
+Example: `examples/raytracing-headless/` — visual RT verification on software backend.
 
 ## Current Version
 
-v0.31.8 | Go 1.25+ | Dependencies: naga v0.19.0, gpucontext v0.28.0, gputypes v0.5.2, goffi v0.6.3, webgpu v0.5.5
+v0.32.0 | Go 1.25+ | Dependencies: naga v0.19.0, gpucontext v0.29.0, gputypes v0.6.0, goffi v0.6.3, webgpu v0.5.5
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **RT example**: copyright header + proper error handling on `WriteBuffer`/`Submit`
+- **CHANGELOG**: Software backend description — "full RT on any platform without GPU" (was "CI/testing only")
+
+### Changed
+
+- **docs**: `docs/RAY-TRACING.md` — public RT documentation (backends, architecture, limitations)
+- **docs**: AGENTS.md updated to v0.32.0 with RT section and corrected dependency versions
+- **docs**: README.md — ray tracing added to features table and examples
+- **docs**: ROADMAP.md + ARCHITECTURE.md updated for v0.32.0
+
 ## [0.32.0] - 2026-08-27
 
 ### Added
@@ -14,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Vulkan**: VK_KHR_acceleration_structure + VK_KHR_ray_query (real FFI calls)
   - **DX12**: DXR Tier 1.1 + SM 6.5 (COM bindings for ID3D12Device5/CommandList4)
   - **Metal**: MTLAccelerationStructure (macOS 15.0+)
-  - **Software**: CPU BVH build + Möller-Trumbore intersection (for CI/testing without GPU)
+  - **Software**: CPU BVH build + Möller-Trumbore intersection — full RT on any platform without GPU (servers, CI, containers, embedded)
   - **`internal/raytracing/`**: build orchestration, compaction state machine, 9 validation checks (96.8% coverage)
   - **Example**: `examples/raytracing-headless/` — visual RT verification on software backend
 - **`NewBackend()` constructors** on all 6 backends (enterprise API consistency)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 | **Shaders** | WGSL via gogpu/naga compiler (SPIR-V, HLSL, MSL, GLSL, DXIL) |
 | **Compute** | Full compute shader support, GPU→CPU readback |
 | **Present** | Damage-aware presentation — compositor dirty rects (first WebGPU implementation) |
+| **Ray Tracing** | Inline ray queries (experimental) — Vulkan (VK_KHR), DX12 (DXR), Metal (macOS 15+), Software (CPU BVH). Feature-gated by `FeatureRayQuery` |
 | **Debug** | Leak detection, error scopes, validation layers, DRED diagnostics (DX12), structured logging (`log/slog`) |
 | **Build** | Zero CGO, simple `go build` |
 
@@ -229,8 +230,9 @@ wgpu/
 │   ├── metal/          # Metal (~7K LOC)
 │   └── dx12/           # DirectX 12 (~17K LOC)
 ├── examples/
-│   ├── compute-copy/   # GPU buffer copy with compute shader
-│   └── compute-sum/    # Parallel reduction on GPU
+│   ├── compute-copy/          # GPU buffer copy with compute shader
+│   ├── compute-sum/           # Parallel reduction on GPU
+│   └── raytracing-headless/   # Ray tracing on software backend (no GPU required)
 └── cmd/
     ├── vk-gen/         # Vulkan bindings generator
     └── ...             # Backend integration tests
@@ -410,6 +412,7 @@ recipe and the explicit non-WebGPU support contract.
 
 - **[Compute Shaders Guide](docs/COMPUTE-SHADERS.md)** — Getting started with compute
 - **[Compute Backend Differences](docs/COMPUTE-BACKENDS.md)** — Per-backend capabilities
+- **[Ray Tracing Extensions](docs/RAY-TRACING.md)** — Experimental inline ray queries (v0.32.0)
 - **[ARCHITECTURE.md](docs/ARCHITECTURE.md)** — System architecture
 - **[ROADMAP.md](ROADMAP.md)** — Development milestones
 - **[CHANGELOG.md](CHANGELOG.md)** — Release notes

--- a/docs/RAY-TRACING.md
+++ b/docs/RAY-TRACING.md
@@ -1,0 +1,77 @@
+# Ray Tracing Extensions (Experimental)
+
+> **Status:** Experimental (not in W3C WebGPU spec, Milestone 4+)
+> **Since:** v0.32.0
+> **Feature gate:** `FeatureRayQuery`
+
+## Overview
+
+wgpu supports inline ray queries matching Rust wgpu's `EXPERIMENTAL_RAY_QUERY`.
+Ray tracing enables acceleration structure-based ray-scene intersection testing
+in compute and fragment shaders.
+
+## Backend Support
+
+| Backend | Platform | API | Min Hardware |
+|---------|----------|-----|-------------|
+| Vulkan | Windows, Linux | VK_KHR_acceleration_structure + VK_KHR_ray_query | RTX 20+, RDNA 2+, Arc |
+| DX12 | Windows | DXR Tier 1.1, SM 6.5 | Same GPUs |
+| Metal | macOS 15.0+, iOS 18.0+ | MTLAccelerationStructure | A13+, Apple Silicon |
+| Software | All platforms | CPU BVH (Moller-Trumbore) | Any CPU |
+| GLES | — | Not supported | — |
+
+## Architecture
+
+Ray tracing is implemented as a three-layer architecture (ADR-062):
+
+### 1. `internal/raytracing/` — Build Orchestration & Validation
+
+Isolated in `internal/` per ADR-069 (struct ownership + callback interface pattern).
+Core holds pointers and calls directly.
+
+- **types.go** — CompactionState (Idle -> Waiting -> Ready -> Compacted), BlasAction enums
+- **blas.go, tlas.go** — BLAS/TLAS resource structs with helpers (IsBuilt, AllowsCompaction)
+- **build.go** — BuildContext: scratch buffer alignment, BLAS -> TLAS dependency tracking (built_index)
+- **compaction.go** — per-state handler functions
+- **validate.go** — 9 validation checks: feature gate, geometry/instance counts, build ordering, alignment, compact state
+- **errors.go** — typed ValidationError with operation constants
+- **context.go** — DeviceContext callback interface (core.Device implements without import cycle)
+
+~1,300 LOC, 73 tests, 96.8% coverage.
+
+### 2. `hal/raytracing.go` — HAL Interface
+
+Defines the backend-agnostic RT interface:
+
+- `AccelerationStructure` resource type
+- 12 descriptor types for BLAS/TLAS geometry, instances, and build parameters
+- `TlasInstance` for positioning geometry in the scene
+- 5 Device methods (create, build, compact acceleration structures)
+- 4 CommandEncoder methods (build BLAS/TLAS, write instances, compact)
+
+### 3. Per-Backend Implementations
+
+All 4 GPU backends implement real API calls:
+
+- **Vulkan** — VK_KHR_acceleration_structure + VK_KHR_ray_query (FFI calls via goffi)
+- **DX12** — DXR Tier 1.1, COM bindings for ID3D12Device5/CommandList4
+- **Metal** — MTLAccelerationStructure (macOS 15.0+)
+- **Software** — CPU BVH build + Moller-Trumbore ray-triangle intersection (for CI/testing without GPU)
+- **GLES/Noop** — return ErrUnsupported
+
+## Example
+
+See `examples/raytracing-headless/` for a complete working example that:
+1. Creates triangle geometry
+2. Builds a BLAS (bottom-level acceleration structure)
+3. Traces rays against the BVH
+4. Renders result to PNG
+
+No GPU required — runs on the software backend.
+
+## Limitations
+
+- Inline ray queries only (no ray tracing pipelines yet)
+- Experimental — API may change before v1.0
+- Not in W3C WebGPU spec (Milestone 4+, blocked on bindless in spec)
+- Software backend uses simple midpoint-split BVH (not SAH) — for CI correctness, not production performance

--- a/examples/raytracing-headless/main.go
+++ b/examples/raytracing-headless/main.go
@@ -1,3 +1,6 @@
+// Copyright 2026 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
 // Ray tracing headless verification — proves RT pipeline correctness on software backend.
 //
 // Creates one triangle, builds BLAS, traces one ray → verifies hit.
@@ -67,7 +70,9 @@ func buildTriangleBLAS(dev hal.Device, queue hal.Queue) (hal.AccelerationStructu
 		return nil, nil, fmt.Errorf("vertex buffer: %w", err)
 	}
 	defer dev.DestroyBuffer(vbuf)
-	_ = queue.WriteBuffer(vbuf, 0, vertexData)
+	if err := queue.WriteBuffer(vbuf, 0, vertexData); err != nil {
+		return nil, nil, fmt.Errorf("write vertices: %w", err)
+	}
 
 	blas, err := dev.CreateAccelerationStructure(&hal.AccelerationStructureDescriptor{
 		Label:  "tri-blas",
@@ -101,7 +106,9 @@ func buildTriangleBLAS(dev hal.Device, queue hal.Queue) (hal.AccelerationStructu
 	if err != nil {
 		return nil, nil, fmt.Errorf("end: %w", err)
 	}
-	_, _ = queue.Submit([]hal.CommandBuffer{cb})
+	if _, err = queue.Submit([]hal.CommandBuffer{cb}); err != nil {
+		return nil, nil, fmt.Errorf("submit: %w", err)
+	}
 
 	swBlas := blas.(*software.AccelerationStructure)
 	bvh := swBlas.BVH()


### PR DESCRIPTION
Post-release documentation for v0.32.0 ray tracing extensions.

- RT example: copyright header + WriteBuffer/Submit error handling
- docs/RAY-TRACING.md: public RT documentation (backends, architecture, limitations)
- AGENTS.md: v0.32.0, corrected deps (gpucontext v0.29.0, gputypes v0.6.0), RT section
- README.md: ray tracing in features table + examples
- ROADMAP.md + ARCHITECTURE.md: v0.32.0 updates
- CHANGELOG: Software backend — full platform description, [Unreleased] section
- .gitignore: VP_VULKANINFO*.json excluded