### PR TITLE
release: v0.32.1 — Software FeatureRayQuery + RT docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.32.1] - 2026-08-28
 
 ### Fixed
 
+- **Software backend**: `FeatureRayQuery` now advertised in adapter features — consumers can discover RT capability via `device.Features().Contains(FeatureRayQuery)`. RT limits set (MaxBlasPrimitiveCount=1M, MaxBlasGeometryCount=64, MaxTlasInstanceCount=65K).
 - **RT example**: copyright header + proper error handling on `WriteBuffer`/`Submit`
 - **CHANGELOG**: Software backend description — "full RT on any platform without GPU" (was "CI/testing only")
 

--- a/hal/software/api.go
+++ b/hal/software/api.go
@@ -87,9 +87,9 @@ func (i *Instance) EnumerateAdapters(_ hal.Surface) []hal.ExposedAdapter {
 				DriverInfo: "CPU-based software rendering backend",
 				Backend:    gputypes.BackendEmpty,
 			},
-			Features: 0, // No optional features supported
+			Features: gputypes.Features(gputypes.FeatureRayQuery),
 			Capabilities: hal.Capabilities{
-				Limits: gputypes.DefaultLimits(),
+				Limits: softwareLimits(),
 				AlignmentsMask: hal.Alignments{
 					BufferCopyOffset: 4,
 					BufferCopyPitch:  256,
@@ -101,6 +101,16 @@ func (i *Instance) EnumerateAdapters(_ hal.Surface) []hal.ExposedAdapter {
 			},
 		},
 	}
+}
+
+func softwareLimits() gputypes.Limits {
+	l := gputypes.DefaultLimits()
+	l.MaxBlasPrimitiveCount = 1 << 20
+	l.MaxBlasGeometryCount = 64
+	l.MaxTlasInstanceCount = 1 << 16
+	l.MaxAccelerationStructuresPerShaderStage = 16
+	l.MaxBuffersAndAccelerationStructuresPerShaderStage = 28
+	return l
 }
 
 // Destroy is a no-op for the software instance.


### PR DESCRIPTION
### Fixed

- **Software backend**: `FeatureRayQuery` now advertised in adapter features — consumers can discover RT capability via `device.Features().Contains(FeatureRayQuery)`. RT limits set (MaxBlasPrimitiveCount=1M, MaxBlasGeometryCount=64, MaxTlasInstanceCount=65K).
- **RT example**: copyright header + proper error handling on `WriteBuffer`/`Submit`

### Changed

- Public RT documentation: `docs/RAY-TRACING.md` (backends, architecture, limitations)
- AGENTS.md, README.md, ROADMAP.md, ARCHITECTURE.md updated for v0.32.0
