### PR TITLE
release: v0.34.2 — pipeline disk cache (#331)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -214,6 +214,13 @@ linters:
           - gocritic
           - nestif
 
+      # DX12 PSO cache - createGraphicsPSO/createComputePSO are structurally
+      # similar but handle different COM types (ID3D12GraphicsPipelineState vs
+      # ID3D12ComputePipelineState). Duplication is inherent to the D3D12 API.
+      - path: hal/dx12/pso_cache\.go
+        linters:
+          - dupl
+
       # DX12 COM bindings - Windows API naming conventions preserved
       # D3D12_* types match the Windows SDK headers exactly for documentation cross-reference
       - path: hal/dx12/d3d12/.*\.go

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Example: `examples/raytracing-headless/` — visual RT verification on software 
 
 ## Current Version
 
-v0.34.0 | Go 1.25+ | Dependencies: naga v0.19.0, gpucontext v0.31.3, gputypes v0.8.0, goffi v0.6.3, webgpu v0.5.5
+v0.34.2 | Go 1.25+ | Dependencies: naga v0.19.0, gpucontext v0.31.3, gputypes v0.8.0, goffi v0.6.3, webgpu v0.5.5
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.34.2] - 2026-08-31
 
 ### Added
 
-- **Pipeline disk cache** (#331) — driver-compiled GPU ISA persistence for faster cold starts on repeat launches
-  - **Vulkan**: `VkPipelineCache` created at device init, passed to all `vkCreateGraphicsPipelines` / `vkCreateComputePipelines`, saved via `vkGetPipelineCacheData` on device destroy. Disk path: `UserCacheDir()/gogpu/vulkan/<adapterKey>/pipeline.cache`
-  - **DX12**: `GetCachedBlob` after PSO creation, `D3D12_CACHED_PIPELINE_STATE` on restore. Per-PSO blobs keyed by root signature + shader bytecode + fixed-function state hash. Disk path: `UserCacheDir()/gogpu/dx12/<adapterKey>/`
-  - **`internal/pipelinecache`**: shared atomic blob I/O and adapter key helpers (DRY across backends)
+- **Pipeline disk cache** (#331, @lkmavi) — driver-compiled GPU ISA persistence for faster cold starts on repeat launches. Extends existing in-memory shader cache to disk.
+  - **Vulkan**: `VkPipelineCache` created at device init, passed to all `vkCreateGraphicsPipelines` / `vkCreateComputePipelines`, saved via `vkGetPipelineCacheData` on device destroy. Graceful fallback on stale/corrupt cache. Adapter key includes vendorID + deviceID + driverVersion + PipelineCacheUUID. Disk path: `UserCacheDir()/gogpu/vulkan/<adapterKey>/pipeline.cache`
+  - **DX12**: `GetCachedBlob` after PSO creation, `D3D12_CACHED_PIPELINE_STATE` on restore. Per-PSO blobs keyed by root signature + shader bytecode + fixed-function state SHA-256 (including full depth/stencil hash with all stencil ops). Stale blob → E_INVALIDARG → automatic retry without cache. DX12 PSO caching is **ahead of Rust wgpu** (which has an empty stub). Disk path: `UserCacheDir()/gogpu/dx12/<adapterKey>/`
+  - **`internal/pipelinecache`**: shared atomic blob I/O (`write-tmp + rename` for crash safety) and adapter-scoped cache path helpers. Follows ADR-069 internal package pattern. 179 LOC tests.
+  - Pipeline cache init is **non-fatal** — failure logs warning and continues with `pipelineCache = 0` (VK_NULL_HANDLE) or nil PSO cache.
+
+### Fixed
+
+- **Race conditions** (@lkmavi) — `RegisterHALBackends()` wrapped in `sync.Once` (prevents double registration on concurrent `CreateInstance`), `instanceEnumerateMu` mutex serializes adapter probing (Windows driver init not thread-safe).
+- **codecov.yml** — `hal/**` glob pattern for nested packages (was `hal/` which missed sub-packages), patch coverage target 85%.
 
 ## [0.34.1] - 2026-08-31
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.34.1
+## Current State: v0.34.2
 
 ✅ **Triple-backend architecture (ADR-038)** — Native Go, Rust FFI, Browser WASM via build tags
 ✅ **All 5 Native HAL backends complete** (~127K LOC)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -276,6 +276,20 @@ HAL backend (per-adapter)
 
 **Consumer gate:** gg checks `CheckGPUComputeSupport(provider)` BEFORE creating compute pipelines in both init paths (SetDeviceProvider + standalone). Matches Skia Graphite `computeSupport()` gate (`AtlasProvider.cpp:42`).
 
+## Pipeline Disk Cache (#331)
+
+Persists driver-compiled GPU ISA across process launches for faster cold starts. Extends the existing in-memory shader cache (`hal/dx12/shader_cache.go`) to disk.
+
+**Vulkan:** One device-wide `VkPipelineCache` created at device init, passed to all `vkCreateGraphicsPipelines`/`vkCreateComputePipelines`, saved via `vkGetPipelineCacheData` on device destroy. Matches Rust wgpu and Dawn monolithic cache pattern.
+
+**DX12:** `GetCachedBlob` after each PSO creation → per-PSO `.pso` blobs on disk. On next launch: `D3D12_CACHED_PIPELINE_STATE` with saved blob. Stale blob → `E_INVALIDARG` → automatic retry without cache. **Ahead of Rust wgpu** (which has an empty DX12 pipeline cache stub).
+
+**Shared infrastructure:** `internal/pipelinecache/` — atomic blob I/O (`write-tmp + rename`), adapter-scoped cache paths (`os.UserCacheDir()/gogpu/{backend}/{adapterKey}/`). Follows ADR-069 internal package pattern.
+
+**Non-fatal:** Pipeline cache init failure logs warning and continues with uncached pipelines. Cache is a performance optimization, not a correctness requirement.
+
+**Race hardening:** `RegisterHALBackends()` wrapped in `sync.Once`, `instanceEnumerateMu` serializes concurrent adapter probing.
+
 ## Typed Surface Targets (Rust v29 Parity)
 
 Surface creation uses typed targets instead of raw `uintptr` handles:

--- a/hal/dx12/adapter.go
+++ b/hal/dx12/adapter.go
@@ -329,7 +329,7 @@ func (a *Adapter) Open(features gputypes.Features, limits gputypes.Limits) (hal.
 	}
 
 	// Create device using the adapter
-	device, err := newDevice(a.instance, unsafe.Pointer(a.raw), a.desc, a.capabilities.FeatureLevel)
+	device, err := newDevice(a.instance, unsafe.Pointer(a.raw), &a.desc, a.capabilities.FeatureLevel)
 	if err != nil {
 		return hal.OpenDevice{}, err
 	}
@@ -642,7 +642,7 @@ func (a *AdapterLegacy) Open(features gputypes.Features, limits gputypes.Limits)
 	}
 
 	// Create device using the legacy adapter
-	device, err := newDevice(a.instance, unsafe.Pointer(a.raw), a.desc, a.capabilities.FeatureLevel)
+	device, err := newDevice(a.instance, unsafe.Pointer(a.raw), &a.desc, a.capabilities.FeatureLevel)
 	if err != nil {
 		return hal.OpenDevice{}, err
 	}

--- a/hal/dx12/device.go
+++ b/hal/dx12/device.go
@@ -237,7 +237,7 @@ func (h *DescriptorHeap) HandleToIndex(handle d3d12.D3D12_CPU_DESCRIPTOR_HANDLE)
 
 // newDevice creates a new DX12 device from a DXGI adapter.
 // adapterPtr is the IUnknown pointer to the DXGI adapter.
-func newDevice(instance *Instance, adapterPtr unsafe.Pointer, adapterDesc dxgi.DXGI_ADAPTER_DESC1, featureLevel d3d12.D3D_FEATURE_LEVEL) (*Device, error) {
+func newDevice(instance *Instance, adapterPtr unsafe.Pointer, adapterDesc *dxgi.DXGI_ADAPTER_DESC1, featureLevel d3d12.D3D_FEATURE_LEVEL) (*Device, error) {
 	// Create D3D12 device
 	rawDevice, err := instance.d3d12Lib.CreateDevice(adapterPtr, featureLevel)
 	if err != nil {

--- a/hal/dx12/pso_cache.go
+++ b/hal/dx12/pso_cache.go
@@ -6,6 +6,7 @@
 package dx12
 
 import (
+	"errors"
 	"path/filepath"
 	"runtime"
 	"unsafe"
@@ -93,7 +94,8 @@ func isInvalidCachedPSOError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if hr, ok := err.(d3d12.HRESULTError); ok {
+	var hr d3d12.HRESULTError
+	if errors.As(err, &hr) {
 		return hr == d3d12.E_INVALIDARG
 	}
 	return false

--- a/hal/dx12/pso_cache_key.go
+++ b/hal/dx12/pso_cache_key.go
@@ -132,7 +132,7 @@ func writeGraphicsFixedState(
 	binary.LittleEndian.PutUint32(buf[0:4], uint32(psoDesc.PrimitiveTopologyType))
 	binary.LittleEndian.PutUint32(buf[4:8], psoDesc.NumRenderTargets)
 	binary.LittleEndian.PutUint32(buf[8:12], uint32(psoDesc.DSVFormat))
-	binary.LittleEndian.PutUint32(buf[12:16], uint32(psoDesc.SampleDesc.Count))
+	binary.LittleEndian.PutUint32(buf[12:16], psoDesc.SampleDesc.Count)
 	binary.LittleEndian.PutUint32(buf[16:20], psoDesc.SampleDesc.Quality)
 	binary.LittleEndian.PutUint32(buf[20:24], uint32(psoDesc.IBStripCutValue))
 	_, _ = h.Write(buf[:24])


### PR DESCRIPTION
Pipeline disk cache for Vulkan + DX12 (@lkmavi). Extends in-memory shader cache to disk persistence. Non-fatal init. Race hardening. Lint fixes.