### PR TITLE
release: v0.34.3 — Validation Phase C + dynamic UBO fix (#333, #343)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Example: `examples/raytracing-headless/` — visual RT verification on software 
 
 ## Current Version
 
-v0.34.2 | Go 1.25+ | Dependencies: naga v0.19.0, gpucontext v0.31.3, gputypes v0.8.0, goffi v0.6.3, webgpu v0.5.5
+v0.34.3 | Go 1.25+ | Dependencies: naga v0.19.0, gpucontext v0.31.3, gputypes v0.8.0, goffi v0.6.3, webgpu v0.5.5
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.34.3] - 2026-09-02
 
 ### Added
 

--- a/hal/vulkan/api.go
+++ b/hal/vulkan/api.go
@@ -452,7 +452,7 @@ func (s *Surface) releaseConfiguredDevice(device *Device, drained bool) {
 
 // vkMakeVersion packs Vulkan version components (major.minor.patch).
 //
-//nolint:unparam // patch is exercised in api_test.go; production call sites use patch 0.
+//nolint:unparam,nolintlint // patch exercised in tests; unparam fires on Linux only (cross-GOOS).
 func vkMakeVersion(major, minor, patch uint32) uint32 {
 	return (major << 22) | (minor << 12) | patch
 }


### PR DESCRIPTION
Validation Phase C (@lkmavi): 15+ feature gates, texture usage, indirect count, ~80 tests. Dynamic UBO fix: Vulkan + Software. Closes #333, fixes #343.