### PR TITLE
fix(vulkan): begin depth-only render passes instead of faulting on End

### DIFF
--- a/depth_only_pass_repro_test.go
+++ b/depth_only_pass_repro_test.go
@@ -1,0 +1,242 @@
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+//go:build integration && !rust && !(js && wasm)
+
+package wgpu_test
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu"
+
+	// Register the Vulkan HAL backend. Without a real backend registered only
+	// the noop/software backends are available, and neither encodes a Vulkan
+	// render pass.
+	//
+	// This import is why the file sits behind the integration tag: registering
+	// a real backend changes adapter selection for every test in the package.
+	_ "github.com/gogpu/wgpu/hal/vulkan"
+)
+
+const (
+	depthOnlyWidth  = 256
+	depthOnlyHeight = 256
+	// depthOnlyBytesPerTexel is the size of one Depth32Float texel.
+	depthOnlyBytesPerTexel = 4
+	// depthOnlyClearValue is deliberately neither 0 nor 1: an untouched depth
+	// texture would plausibly read back as either, and then a pass that never
+	// ran would look like a pass that did.
+	depthOnlyClearValue = 0.25
+	// depthOnlyEpsilon allows for nothing but float32 representation. The
+	// value is cleared, not computed, so it comes back exactly.
+	depthOnlyEpsilon = 1e-6
+)
+
+// TestDepthOnlyRenderPassExecutes renders a pass that has a depth attachment
+// and no color attachment, then reads the depth back to confirm the pass ran.
+//
+// A depth-only pass is legal in WebGPU and is how a shadow map is drawn. The
+// Vulkan HAL used to return a render pass encoder without calling
+// vkCmdBeginRenderPass whenever the descriptor named no color attachments,
+// because the render area and sample count were derived from the color
+// attachments alone. End then called vkCmdEndRenderPass regardless, which is
+// undefined behavior: the driver faults rather than reporting a validation
+// error, killing the process several frames of stack away from anything that
+// names a pass.
+//
+// Reaching the end of this test at all covers the fault. The depth readback
+// covers the other half -- that the pass was actually begun and executed,
+// rather than merely not crashing.
+func TestDepthOnlyRenderPassExecutes(t *testing.T) {
+	device := newVulkanDevice(t)
+
+	// bytesPerRow must be a multiple of 256 per the copy alignment rules.
+	bytesPerRow := alignUp(depthOnlyWidth*depthOnlyBytesPerTexel, 256)
+	bufferSize := uint64(bytesPerRow) * uint64(depthOnlyHeight)
+
+	depth, err := device.CreateTexture(&wgpu.TextureDescriptor{
+		Label: "depth-only-target",
+		Size: wgpu.Extent3D{
+			Width:              depthOnlyWidth,
+			Height:             depthOnlyHeight,
+			DepthOrArrayLayers: 1,
+		},
+		MipLevelCount: 1,
+		SampleCount:   1,
+		Dimension:     gputypes.TextureDimension2D,
+		Format:        gputypes.TextureFormatDepth32Float,
+		Usage:         gputypes.TextureUsageRenderAttachment | gputypes.TextureUsageCopySrc,
+	})
+	if err != nil {
+		t.Fatalf("CreateTexture: %v", err)
+	}
+	t.Cleanup(depth.Release)
+
+	depthView, err := device.CreateTextureView(depth, nil)
+	if err != nil {
+		t.Fatalf("CreateTextureView: %v", err)
+	}
+	t.Cleanup(depthView.Release)
+
+	staging, err := device.CreateBuffer(&wgpu.BufferDescriptor{
+		Label: "depth-readback",
+		Size:  bufferSize,
+		Usage: wgpu.BufferUsageCopyDst | wgpu.BufferUsageMapRead,
+	})
+	if err != nil {
+		t.Fatalf("CreateBuffer: %v", err)
+	}
+	t.Cleanup(staging.Release)
+
+	encoder, err := device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{Label: "depth-only"})
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder: %v", err)
+	}
+
+	pass, err := encoder.BeginRenderPass(&wgpu.RenderPassDescriptor{
+		Label:            "depth-only-pass",
+		ColorAttachments: nil,
+		DepthStencilAttachment: &wgpu.RenderPassDepthStencilAttachment{
+			View:            depthView,
+			DepthLoadOp:     gputypes.LoadOpClear,
+			DepthStoreOp:    gputypes.StoreOpStore,
+			DepthClearValue: depthOnlyClearValue,
+		},
+	})
+	if err != nil {
+		t.Fatalf("BeginRenderPass with no color attachment: %v", err)
+	}
+
+	// The fault was here.
+	pass.End()
+
+	cmd, err := encoder.Finish()
+	if err != nil {
+		t.Fatalf("Finish: %v", err)
+	}
+
+	// The copy needs its own encoder: the depth texture is a render attachment
+	// for the pass and a copy source afterwards, and the resource tracker will
+	// not carry both usages through one submission.
+	readback, err := device.CreateCommandEncoder(&wgpu.CommandEncoderDescriptor{Label: "depth-readback"})
+	if err != nil {
+		t.Fatalf("CreateCommandEncoder for readback: %v", err)
+	}
+	readback.CopyTextureToBuffer(depth, staging, []wgpu.BufferTextureCopy{{
+		BufferLayout: wgpu.ImageDataLayout{
+			BytesPerRow:  bytesPerRow,
+			RowsPerImage: depthOnlyHeight,
+		},
+		TextureBase: wgpu.ImageCopyTexture{
+			Texture: depth,
+			Aspect:  gputypes.TextureAspectDepthOnly,
+		},
+		Size: wgpu.Extent3D{
+			Width:              depthOnlyWidth,
+			Height:             depthOnlyHeight,
+			DepthOrArrayLayers: 1,
+		},
+	}})
+	readbackCmd, err := readback.Finish()
+	if err != nil {
+		t.Fatalf("Finish readback: %v", err)
+	}
+
+	if _, err := device.Queue().Submit(cmd, readbackCmd); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	assertDepthCleared(t, staging, bufferSize, bytesPerRow)
+}
+
+// assertDepthCleared checks every texel holds the value the pass cleared depth
+// to. A pass that was never begun leaves the texture untouched, so this is
+// what separates "did not crash" from "actually ran".
+func assertDepthCleared(t *testing.T, staging *wgpu.Buffer, bufferSize uint64, bytesPerRow uint32) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := staging.Map(ctx, wgpu.MapModeRead, 0, bufferSize); err != nil {
+		t.Fatalf("Map staging buffer: %v", err)
+	}
+	rng, err := staging.MappedRange(0, bufferSize)
+	if err != nil {
+		_ = staging.Unmap()
+		t.Fatalf("MappedRange: %v", err)
+	}
+	pixels := make([]byte, bufferSize)
+	copy(pixels, rng.Bytes())
+	if err := staging.Unmap(); err != nil {
+		t.Fatalf("Unmap: %v", err)
+	}
+
+	wrong := 0
+	var firstWrong float32
+	for y := range depthOnlyHeight {
+		for x := range depthOnlyWidth {
+			off := uint32(y)*bytesPerRow + uint32(x)*depthOnlyBytesPerTexel
+			d := math.Float32frombits(
+				uint32(pixels[off]) |
+					uint32(pixels[off+1])<<8 |
+					uint32(pixels[off+2])<<16 |
+					uint32(pixels[off+3])<<24,
+			)
+			if math.Abs(float64(d-depthOnlyClearValue)) > depthOnlyEpsilon {
+				if wrong == 0 {
+					firstWrong = d
+				}
+				wrong++
+			}
+		}
+	}
+
+	if wrong > 0 {
+		t.Fatalf("depth = %v at %d of %d texels, want %v: the depth-only pass did not execute",
+			firstWrong, wrong, depthOnlyWidth*depthOnlyHeight, float32(depthOnlyClearValue))
+	}
+}
+
+// newVulkanDevice returns a device on the Vulkan backend, skipping when this
+// machine cannot provide one. The bug under test is in the Vulkan HAL, so
+// another backend's adapter would make the test pass without proving anything.
+func newVulkanDevice(t *testing.T) *wgpu.Device {
+	t.Helper()
+
+	instance, err := wgpu.CreateInstance(&wgpu.InstanceDescriptor{Backends: wgpu.BackendsVulkan})
+	if err != nil {
+		t.Skipf("CreateInstance: %v", err)
+	}
+	t.Cleanup(instance.Release)
+
+	adapter, err := instance.RequestAdapter(&wgpu.RequestAdapterOptions{
+		PowerPreference: gputypes.PowerPreferenceHighPerformance,
+	})
+	if err != nil {
+		t.Skipf("RequestAdapter: %v", err)
+	}
+	t.Cleanup(adapter.Release)
+
+	if got := adapter.Info().Backend; got != gputypes.BackendVulkan {
+		t.Skipf("adapter backend is %v, want Vulkan", got)
+	}
+	t.Logf("adapter: %s (%v)", adapter.Info().Name, adapter.Info().Backend)
+
+	device, err := adapter.RequestDevice(&wgpu.DeviceDescriptor{Label: "depth-only-pass-test"})
+	if err != nil {
+		t.Skipf("RequestDevice: %v", err)
+	}
+	t.Cleanup(device.Release)
+
+	return device
+}
+
+func alignUp(n, a uint32) uint32 {
+	return (n + a - 1) / a * a
+}

--- a/hal/vulkan/command.go
+++ b/hal/vulkan/command.go
@@ -819,6 +819,58 @@ func (e *CommandEncoder) ResolveQuerySet(querySet hal.QuerySet, firstQuery, quer
 	)
 }
 
+// renderAreaView returns the attachment view that defines a pass's render
+// area and sample count: the first color attachment carrying one, or the
+// depth/stencil attachment when the pass declares no usable color attachment
+// at all.
+//
+// A pass with no color attachments is legal in WebGPU -- it is how a shadow map
+// is drawn -- and Vulkan still needs an extent and a sample count to build the
+// framebuffer, which only the attachments can supply.
+//
+// Returns nil when nothing resolves to a view of this backend, which means
+// there is nothing to render into and no pass worth beginning.
+//
+// Rust wgpu-hal has no equivalent: its RenderPassDescriptor carries extent
+// and sample_count as fields the caller supplies, so begin_render_pass reads
+// them straight off the descriptor (wgpu-hal/src/vulkan/command.rs). This
+// HAL's descriptor carries neither, so a pass has to derive both from its
+// attachments -- and a depth-only pass has only the depth attachment to
+// derive them from.
+func renderAreaView(desc *hal.RenderPassDescriptor) *TextureView {
+	if desc == nil {
+		return nil
+	}
+	for _, ca := range desc.ColorAttachments {
+		if view := asTextureView(ca.View); view != nil {
+			return view
+		}
+	}
+	if desc.DepthStencilAttachment != nil {
+		return asTextureView(desc.DepthStencilAttachment.View)
+	}
+	return nil
+}
+
+// asTextureView narrows a HAL view to this backend's, treating an absent view,
+// a typed-nil pointer and a view belonging to another backend alike: each comes
+// back as nil. The comma-ok assertion is what makes that true -- a failed
+// assertion yields a nil *TextureView -- so callers get a pointer they can
+// compare against nil rather than one they must not dereference.
+func asTextureView(view hal.TextureView) *TextureView {
+	v, _ := view.(*TextureView)
+	return v
+}
+
+// attachmentSampleCount reports the sample count a pass's attachments share.
+// Swapchain views carry no texture and are always single-sampled.
+func attachmentSampleCount(view *TextureView) vk.SampleCountFlagBits {
+	if view != nil && view.texture != nil && view.texture.samples > 1 {
+		return vk.SampleCountFlagBits(view.texture.samples)
+	}
+	return vk.SampleCountFlagBits(1)
+}
+
 // BeginRenderPass begins a render pass using VkRenderPass (classic Vulkan approach).
 // This is compatible with Intel drivers that don't properly support dynamic rendering.
 // Supports up to MaxColorAttachments (8) color attachments with optional MSAA resolve,
@@ -833,41 +885,22 @@ func (e *CommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.Ren
 	rpe.indexFormat = 0
 	rpe.renderPass = 0
 	rpe.framebuffer = 0
+	rpe.begun = false
 
-	if e.active == 0 || len(desc.ColorAttachments) == 0 {
+	if e.active == 0 {
 		return rpe
 	}
 
-	// Determine render area from the first valid color attachment.
-	var renderWidth, renderHeight uint32
-	for _, ca := range desc.ColorAttachments {
-		if ca.View == nil {
-			continue
-		}
-		view, ok := ca.View.(*TextureView)
-		if !ok {
-			continue
-		}
-		renderWidth = view.size.Width
-		renderHeight = view.size.Height
-		break
+	// Render area and sample count both come from the attachment that defines
+	// the pass -- the first color attachment, or the depth attachment when the
+	// pass has no color attachments at all. Every early return below leaves
+	// rpe.begun false, so End knows not to end a pass that was never begun.
+	areaView := renderAreaView(desc)
+	if areaView == nil {
+		return rpe
 	}
-
-	// Determine sample count from the first valid color attachment (all must match).
-	sampleCount := vk.SampleCountFlagBits(1)
-	for _, ca := range desc.ColorAttachments {
-		if ca.View == nil {
-			continue
-		}
-		view, ok := ca.View.(*TextureView)
-		if !ok {
-			continue
-		}
-		if view.texture != nil && view.texture.samples > 1 {
-			sampleCount = vk.SampleCountFlagBits(view.texture.samples)
-		}
-		break
-	}
+	renderWidth, renderHeight := areaView.size.Width, areaView.size.Height
+	sampleCount := attachmentSampleCount(areaView)
 
 	// Build render pass key and framebuffer key from ALL color attachments.
 	rpKey := RenderPassKey{
@@ -1020,6 +1053,7 @@ func (e *CommandEncoder) BeginRenderPass(desc *hal.RenderPassDescriptor) hal.Ren
 
 	vkCmdBeginRenderPass(e.device.cmds, e.active, &renderPassBegin, vk.SubpassContentsInline)
 	runtime.KeepAlive(clearValues)
+	rpe.begun = true
 
 	// Set default viewport and scissor for the render area.
 	// Always set viewport/scissor — the pipeline declares them as dynamic state,
@@ -1093,6 +1127,9 @@ type RenderPassEncoder struct {
 	// For VkRenderPass-based rendering (not dynamic rendering)
 	renderPass  vk.RenderPass
 	framebuffer vk.Framebuffer
+	// begun records whether vkCmdBeginRenderPass actually ran, which End needs
+	// because BeginRenderPass returns an encoder either way.
+	begun bool
 }
 
 const (
@@ -1104,13 +1141,17 @@ const (
 // End finishes the render pass.
 // Returns the encoder to the pool for reuse (VK-PERF-006).
 func (e *RenderPassEncoder) End() {
-	if e.encoder.active == 0 {
-		return
-	}
-
+	// BeginRenderPass returns an encoder even when it declined to begin a pass:
+	// an inactive command buffer, attachments that do not resolve, or a render
+	// pass or framebuffer that could not be created. Ending a pass that was
+	// never begun is undefined behavior -- the driver faults inside
+	// vkCmdEndRenderPass rather than reporting a validation error.
+	//
 	// Use vkCmdEndRenderPass (VkRenderPass handles layout transitions automatically
 	// via FinalLayout in AttachmentDescription)
-	vkCmdEndRenderPass(e.encoder.device.cmds, e.encoder.active)
+	if e.begun && e.encoder.active != 0 {
+		vkCmdEndRenderPass(e.encoder.device.cmds, e.encoder.active)
+	}
 
 	// Return to pool for reuse.
 	e.encoder = nil
@@ -1118,6 +1159,7 @@ func (e *RenderPassEncoder) End() {
 	e.pipeline = nil
 	e.renderPass = 0
 	e.framebuffer = 0
+	e.begun = false
 	renderPassPool.Put(e)
 }
 

--- a/hal/vulkan/renderpass_depthonly_test.go
+++ b/hal/vulkan/renderpass_depthonly_test.go
@@ -1,0 +1,243 @@
+//go:build !(js && wasm)
+
+// Copyright 2025 The GoGPU Authors
+// SPDX-License-Identifier: MIT
+
+package vulkan
+
+import (
+	"testing"
+
+	"github.com/gogpu/gputypes"
+	"github.com/gogpu/wgpu/hal"
+	"github.com/gogpu/wgpu/hal/vulkan/vk"
+)
+
+// foreignView is a hal.TextureView belonging to no backend in this package,
+// standing in for a view handed over from another HAL.
+type foreignView struct{}
+
+func (foreignView) Destroy()              {}
+func (foreignView) NativeHandle() uintptr { return 0 }
+
+// attachmentView builds a TextureView standing in for a render target. Only
+// the fields the render-area helpers read are populated.
+func attachmentView(width, height, samples uint32, format gputypes.TextureFormat) *TextureView {
+	return &TextureView{
+		size: Extent3D{Width: width, Height: height, Depth: 1},
+		texture: &Texture{
+			size:    Extent3D{Width: width, Height: height, Depth: 1},
+			format:  format,
+			samples: samples,
+		},
+	}
+}
+
+// TestRenderAreaView covers which attachment defines a pass's render area.
+// A nil want means the pass names nothing usable, so the caller should decline
+// to begin it rather than encode one with a zero extent.
+func TestRenderAreaView(t *testing.T) {
+	color := attachmentView(800, 600, 1, gputypes.TextureFormatRGBA8Unorm)
+	second := attachmentView(640, 480, 1, gputypes.TextureFormatRGBA8Unorm)
+	depth := attachmentView(2048, 2048, 1, gputypes.TextureFormatDepth32Float)
+	var typedNil *TextureView
+
+	cases := []struct {
+		name string
+		desc *hal.RenderPassDescriptor
+		want *TextureView
+	}{
+		{
+			name: "color attachment wins over depth",
+			desc: &hal.RenderPassDescriptor{
+				ColorAttachments:       []hal.RenderPassColorAttachment{{View: color}},
+				DepthStencilAttachment: &hal.RenderPassDepthStencilAttachment{View: depth},
+			},
+			want: color,
+		},
+		{
+			// A sparse color array is legal in WebGPU and is how MRT declares
+			// an unused slot, so a gap is skipped rather than stopped at.
+			name: "sparse color array skips the absent slot",
+			desc: &hal.RenderPassDescriptor{
+				ColorAttachments: []hal.RenderPassColorAttachment{{View: nil}, {View: second}},
+			},
+			want: second,
+		},
+		{
+			// The depth-only pass -- how a shadow map is drawn, and the reason
+			// this fallback exists at all.
+			name: "no color attachments falls back to depth",
+			desc: &hal.RenderPassDescriptor{
+				DepthStencilAttachment: &hal.RenderPassDepthStencilAttachment{View: depth},
+			},
+			want: depth,
+		},
+		{
+			name: "no usable color slot falls back to depth",
+			desc: &hal.RenderPassDescriptor{
+				ColorAttachments:       []hal.RenderPassColorAttachment{{View: nil}},
+				DepthStencilAttachment: &hal.RenderPassDepthStencilAttachment{View: depth},
+			},
+			want: depth,
+		},
+		{
+			name: "nil descriptor",
+			desc: nil,
+			want: nil,
+		},
+		{
+			name: "empty descriptor",
+			desc: &hal.RenderPassDescriptor{},
+			want: nil,
+		},
+		{
+			name: "color slot with no view and no depth",
+			desc: &hal.RenderPassDescriptor{
+				ColorAttachments: []hal.RenderPassColorAttachment{{View: nil}},
+			},
+			want: nil,
+		},
+		{
+			name: "depth attachment with no view",
+			desc: &hal.RenderPassDescriptor{
+				DepthStencilAttachment: &hal.RenderPassDepthStencilAttachment{View: nil},
+			},
+			want: nil,
+		},
+		{
+			// A typed-nil pointer satisfies the type assertion; a foreign view
+			// fails it. Neither may be dereferenced, and neither may be
+			// mistaken for a render area.
+			name: "typed-nil view",
+			desc: &hal.RenderPassDescriptor{
+				DepthStencilAttachment: &hal.RenderPassDepthStencilAttachment{View: typedNil},
+			},
+			want: nil,
+		},
+		{
+			name: "view from another backend",
+			desc: &hal.RenderPassDescriptor{
+				ColorAttachments: []hal.RenderPassColorAttachment{{View: foreignView{}}},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := renderAreaView(tc.desc); got != tc.want {
+				t.Fatalf("render area view = %p, want %p", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAttachmentSampleCountFollowsTheView verifies that the pass sample count
+// comes from the view that defines the render area -- including a depth-only
+// pass, whose only attachment is the depth target.
+func TestAttachmentSampleCountFollowsTheView(t *testing.T) {
+	cases := []struct {
+		name string
+		view *TextureView
+		want vk.SampleCountFlagBits
+	}{
+		{
+			name: "single sampled",
+			view: attachmentView(64, 64, 1, gputypes.TextureFormatRGBA8Unorm),
+			want: vk.SampleCountFlagBits(1),
+		},
+		{
+			name: "msaa depth target",
+			view: attachmentView(64, 64, 4, gputypes.TextureFormatDepth32Float),
+			want: vk.SampleCountFlagBits(4),
+		},
+		{
+			name: "swapchain view with no texture",
+			view: &TextureView{size: Extent3D{Width: 64, Height: 64, Depth: 1}, isSwapchain: true},
+			want: vk.SampleCountFlagBits(1),
+		},
+		{
+			name: "no view",
+			view: nil,
+			want: vk.SampleCountFlagBits(1),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := attachmentSampleCount(tc.view); got != tc.want {
+				t.Fatalf("sample count = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEndDoesNotEndAPassThatWasNeverBegun is the fault this whole change
+// exists for. BeginRenderPass declines to begin a pass whose attachments do
+// not resolve, or whose render pass or framebuffer could not be created, and
+// returns an encoder anyway. Ending that encoder used to call
+// vkCmdEndRenderPass regardless, which is undefined behavior -- an access
+// violation inside the driver rather than a validation error.
+//
+// The command buffer is non-zero and the device carries no dispatch table, so
+// any call that reaches the driver panics and any call that does not is
+// silent. TestEndEndsAPassThatWasBegun is the other half: without it this test
+// would still pass if End stopped ending passes altogether.
+func TestEndDoesNotEndAPassThatWasNeverBegun(t *testing.T) {
+	enc := &CommandEncoder{
+		device: &Device{}, // cmds is nil: reaching the driver panics
+		active: 0x1234,    // recording, so the active guard does not hide the bug
+	}
+	rpe := &RenderPassEncoder{encoder: enc} // begun is false
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("End reached the driver for a pass that was never begun: %v", r)
+		}
+	}()
+
+	rpe.End()
+}
+
+// TestEndEndsAPassThatWasBegun pins the other direction: a pass that
+// vkCmdBeginRenderPass did run on must still be ended. Reaching the nil
+// dispatch table is the proof that End tried.
+func TestEndEndsAPassThatWasBegun(t *testing.T) {
+	enc := &CommandEncoder{
+		device: &Device{}, // cmds is nil: reaching the driver panics
+		active: 0x1234,
+	}
+	rpe := &RenderPassEncoder{
+		encoder:     enc,
+		renderPass:  0x5678,
+		framebuffer: 0x9abc,
+		begun:       true,
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("End did not end a pass that was begun")
+		}
+	}()
+
+	rpe.End()
+}
+
+// TestEndReleasesAnUnbegunEncoderToThePool verifies that declining to end the
+// pass still clears the encoder, so a pooled encoder cannot carry a stale
+// descriptor, or a set begun flag, into the next BeginRenderPass.
+func TestEndReleasesAnUnbegunEncoderToThePool(t *testing.T) {
+	enc := &CommandEncoder{device: &Device{}, active: 0x1234}
+	rpe := &RenderPassEncoder{
+		encoder: enc,
+		desc:    &hal.RenderPassDescriptor{Label: "stale"},
+	}
+
+	rpe.End()
+
+	if rpe.encoder != nil || rpe.desc != nil || rpe.framebuffer != 0 || rpe.renderPass != 0 || rpe.begun {
+		t.Fatalf("End left the encoder populated: encoder=%v desc=%v framebuffer=%d renderPass=%d begun=%v",
+			rpe.encoder, rpe.desc, rpe.framebuffer, rpe.renderPass, rpe.begun)
+	}
+}


### PR DESCRIPTION
## What happens

A render pass with a depth attachment and **no color attachment** kills the
process. Not a validation error — a fault: an access violation inside the
driver, several frames of stack away from anything that names a pass.

```
github.com/gogpu/wgpu/hal/vulkan/vk.(*Commands).CmdEndRenderPass
github.com/gogpu/wgpu/hal/vulkan.vkCmdEndRenderPass       hal/vulkan/command.go
github.com/gogpu/wgpu/hal/vulkan.(*RenderPassEncoder).End hal/vulkan/command.go
github.com/gogpu/wgpu/core.(*CoreRenderPassEncoder).End   core/command.go
```

A depth-only pass is legal in WebGPU and is how a shadow map is drawn. A
browser's WebGPU encodes the same descriptor correctly, so this is specific to
the Vulkan HAL.

Reproduced on an **NVIDIA GeForce RTX 4070 SUPER**, so despite the Intel-driver
workarounds nearby this is not driver-specific — `vkCmdEndRenderPass` without a
matching begin is undefined behavior on any implementation.

## Why

Two defects, and the second is the more serious because nothing asked for it.

**1. The pass is never begun.** `BeginRenderPass` derived the render area and
the sample count from the color attachments alone, so it bailed out before
`vkCmdBeginRenderPass`:

```go
if e.active == 0 || len(desc.ColorAttachments) == 0 {
    return rpe
}
```

`RenderPassCache.createRenderPass` and `createFramebuffer` already handle
`ColorCount == 0` correctly — a depth-only subpass with `PColorAttachments` nil
is exactly what they build. Only the encoder refused.

**2. `End` ends a pass that was never begun.** It called `vkCmdEndRenderPass`
whenever the command buffer was active, regardless of whether a pass had been
begun. That also fires on the two *other* early returns in `BeginRenderPass` —
a descriptor whose attachments do not resolve, and a render pass or framebuffer
that could not be created — so those were already unsafe, independently of
depth-only passes.

## What this changes

- `renderAreaView` picks the attachment that defines the pass: the first color
  attachment carrying a view, falling back to the depth/stencil attachment when
  the pass declares no usable color attachment. Returns nil when nothing
  resolves, and `BeginRenderPass` then declines rather than encoding a pass with
  a zero extent.
- `attachmentSampleCount` reads the sample count off that same view. This also
  consolidates two near-identical loops that walked the color attachments
  separately for extent and for samples.
- `RenderPassEncoder.begun` records whether `vkCmdBeginRenderPass` actually ran,
  and `End` is gated on it.

Rust wgpu-hal has no equivalent of the first two: its `RenderPassDescriptor`
carries `extent` and `sample_count` as caller-supplied fields, so
`begin_render_pass` reads them straight off the descriptor. This HAL's
descriptor carries neither, so a pass has to derive both from its attachments —
and a depth-only pass has only the depth attachment to derive them from.

## Tests

`hal/vulkan/renderpass_depthonly_test.go` — no GPU, runs in the default suite:
attachment selection (color precedence, sparse color arrays, the depth
fallback, typed-nil and foreign views), sample-count derivation, and **both
directions** of the `End` guard — that it does not end an unbegun pass, and
that it still ends a begun one.

`depth_only_pass_repro_test.go` — behind the `integration` tag, following
`arraylength_repro_test.go`: clears depth in a color-less pass and reads the
value back, so it distinguishes "did not crash" from "actually ran". It skips
when no Vulkan adapter is available, and skips if the selected adapter is not
Vulkan, since another backend would make it pass without proving anything.

Every test was mutation-checked in both directions. Two findings came out of
that and are folded in: an earlier `begun`-flag test could only be falsified in
one direction until the positive case was added, and a redundant `|| v == nil`
guard in the view-narrowing helper turned out to be unfalsifiable dead code —
a failed type assertion already yields a nil `*TextureView` — so it is gone and
the remaining comma-ok is covered by the foreign-view case.

Verification:

```
go build ./...                                  ok
go test ./...                                   22 packages ok
go vet ./hal/vulkan/...                          clean on linux, darwin, windows
go test -tags integration -run TestDepthOnlyRenderPassExecutes .   ok (RTX 4070 SUPER)
```

`CHANGELOG.md` is deliberately untouched — happy to add an entry if you would
rather it land with the PR.

## What is still not fixed

Nothing here changes the GLES or software backends. Their `len(ColorAttachments)
== 0` checks are unrelated — they resolve a target texture and correctly report
"none" — not a begin/end mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
