### PR TITLE
ci: harden Dependencies job against go-mod-outdated proxy flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,7 +299,7 @@ jobs:
 
   # Dependency freshness check
   # Uses go-mod-outdated (https://github.com/psampaz/go-mod-outdated)
-  # Non-blocking: reports outdated deps as warnings
+  # Non-blocking: reports outdated deps as warnings; never fails the workflow.
   deps:
     name: Dependencies
     runs-on: ubuntu-latest
@@ -314,10 +314,27 @@ jobs:
         go-version: '1.25'
         cache: true
 
+    # Pin the module version so each run does not re-resolve @latest.
+    # Retry: proxy.golang.org occasionally returns INTERNAL_ERROR / stream
+    # resets (seen as red Dependencies checks on otherwise-green PRs).
+    # continue-on-error: the direct-deps step is advisory only; ecosystem
+    # checks below do not need this binary.
     - name: Install go-mod-outdated
-      run: go install github.com/psampaz/go-mod-outdated@latest
+      id: install-outdated
+      continue-on-error: true
+      run: |
+        for attempt in 1 2 3; do
+          if go install github.com/psampaz/go-mod-outdated@v0.9.0; then
+            exit 0
+          fi
+          echo "install attempt ${attempt} failed; retrying..."
+          sleep $((attempt * 5))
+        done
+        echo "::warning::Failed to install go-mod-outdated after retries; skipping direct-deps check"
+        exit 1
 
     - name: Check direct dependencies for updates
+      if: steps.install-outdated.outcome == 'success'
       run: |
         echo "## Direct Dependencies with Updates"
         OUTDATED=$(go list -u -m -json all 2>/dev/null | go-mod-outdated -update -direct || true)


### PR DESCRIPTION
## Summary
- The advisory **Dependencies** job was failing PRs when `go install github.com/psampaz/go-mod-outdated@latest` hit a transient `proxy.golang.org` `INTERNAL_ERROR` (e.g. [#353 run](https://github.com/gogpu/wgpu/actions/runs/34125006674/job/101751523783)).
- Pin `go-mod-outdated@v0.9.0`, retry install up to 3 times, and `continue-on-error` so a module-proxy blip cannot red the check; skip the direct-deps step if install still fails. Ecosystem checks still run.

## Test plan
- [x] CI on this PR: Dependencies job succeeds (or soft-continues) even if a single install attempt flakes
- [x] Confirm direct-deps step runs when install succeeds; ecosystem step always runs
- [x] Re-check that a green PR is no longer blocked solely by this advisory job