### PR TITLE
release: v0.34.5 — Vulkan depth-only render passes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Example: `examples/raytracing-headless/` — visual RT verification on software 
 
 ## Current Version
 
-v0.34.3 | Go 1.25+ | Dependencies: naga v0.19.0, gpucontext v0.31.3, gputypes v0.8.0, goffi v0.6.3, webgpu v0.5.5
+v0.34.5 | Go 1.25+ | Dependencies: naga v0.19.0, gpucontext v0.31.3, gputypes v0.8.0, goffi v0.6.3, webgpu v0.5.5
 
 ## Build & Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.5] - 2026-09-07
+
+### Fixed
+
+- **Vulkan depth-only render passes** (#353, @dvoyni) — BeginRenderPass derives render area and sample count from the depth/stencil attachment when there are no usable color attachments (shadow maps), and End calls `vkCmdEndRenderPass` only if Begin actually ran. Previously depth-only passes skipped Begin and End faulted inside the driver (`vkCmdEndRenderPass` without a matching begin).
+
+### Changed
+
+- **CI Dependencies job** (#354, @lkmavi) — pin `go-mod-outdated@v0.9.0`, retry install up to 3 times, and `continue-on-error` so transient `proxy.golang.org` flakes no longer fail the advisory check.
+
 ## [0.34.4] - 2026-09-07
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.34.4
+## Current State: v0.34.5
 
 ✅ **Triple-backend architecture (ADR-038)** — Native Go, Rust FFI, Browser WASM via build tags
 ✅ **All 5 Native HAL backends complete** (~127K LOC)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -103,6 +103,7 @@ Pure Go Vulkan implementation using goffi for dynamic function loading.
 - Surface-qualified adapter selection: `vkGetPhysicalDeviceSurfaceSupportKHR` across all queue families (ahead of Rust wgpu)
 - Platform surface: VkWin32, VkXlib/VkWayland, VkMetal, and Android `ANativeWindow` (arm64/API 29+ preview; see [ANDROID.md](ANDROID.md))
 - Multi-draw indirect: native `vkCmdDrawIndirect`/`vkCmdDrawIndexedIndirect` with `drawCount`, feature-gated fallback loop
+- Depth-only render passes: render area and sample count fall back to the depth/stencil attachment; `End` is gated on a begun pass (v0.34.5)
 
 ### `hal/metal/` — Metal Backend
 


### PR DESCRIPTION
## Summary

- **Vulkan depth-only render passes** (#353, @dvoyni) — BeginRenderPass derives render area/sample count from the depth/stencil attachment when there are no usable color attachments; End calls `vkCmdEndRenderPass` only if Begin actually ran (fixes driver fault on shadow-map style passes).
- **CI Dependencies job** (#354, @lkmavi) — pin `go-mod-outdated@v0.9.0`, retry install, `continue-on-error` against transient `proxy.golang.org` flakes.

## Docs

- `CHANGELOG.md` — `[0.34.5]` section
- `ROADMAP.md` — Current State → v0.34.5
- `AGENTS.md` — Current Version → v0.34.5 (was stale at v0.34.3)
- `docs/ARCHITECTURE.md` — Vulkan depth-only render pass note

## Test plan

- [x] `go build ./...` (darwin/arm64, linux/amd64, js/wasm)
- [x] `go test ./...`
- [x] `gofmt -l .` clean
- [x] `golangci-lint run --timeout=5m` clean
- [x] Ecosystem deps at latest released versions
- [x] CI green on this PR
- [ ] Maintainer approval → squash merge → tag `v0.34.5` (tag not pushed yet)