### PR TITLE
release: v0.34.6 — deps goffi v0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.34.6] - 2026-09-10
+
+### Changed
+
+- **deps:** goffi v0.6.3 → v0.6.4 ([goffi v0.6.4](https://github.com/go-webgpu/goffi/releases/tag/v0.6.4) — `-tags goffi_static` linking profile)
+
 ## [0.34.5] - 2026-09-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ CGO_ENABLED=0 go build
 > **Note:** wgpu uses Pure Go FFI via [goffi](https://github.com/go-webgpu/goffi). Both `CGO_ENABLED=0` (default, zero C compiler dependency) and `CGO_ENABLED=1` (for race detector or coexistence with CGO libraries) are supported.
 
 The unreleased Android/arm64 Vulkan implementation is documented separately in
-[Android Vulkan preview](docs/ANDROID.md). It consumes canonical goffi v0.6.3
+[Android Vulkan preview](docs/ANDROID.md). It consumes canonical goffi v0.6.4
 and is not yet a released support claim; the optional Rust path temporarily
 pins the exact merged WebGPU Android source until that dependency is released.
 

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -10,8 +10,7 @@ Vulkan, arm64, Android API 29 or newer, and both `CGO_ENABLED=0` and
 API 28 or older are out of scope.
 
 The default backend consumes canonical
-[goffi v0.6.4](https://github.com/go-webgpu/goffi/releases/tag/v0.6.1), released
-from [go-webgpu/goffi#62](https://github.com/go-webgpu/goffi/pull/62). The
+[goffi v0.6.4](https://github.com/go-webgpu/goffi/releases/tag/v0.6.4) (Android preview originally landed in [goffi v0.6.1](https://github.com/go-webgpu/goffi/releases/tag/v0.6.1) / [goffi#62](https://github.com/go-webgpu/goffi/pull/62)). The
 `rust` build-tag path also depends on canonical
 [go-webgpu/webgpu#24](https://github.com/go-webgpu/webgpu/pull/24), merged at
 `a801aed7399042e5564ef76fc9f075da5cb70081`. goffi is declared directly in

--- a/docs/ANDROID.md
+++ b/docs/ANDROID.md
@@ -10,7 +10,7 @@ Vulkan, arm64, Android API 29 or newer, and both `CGO_ENABLED=0` and
 API 28 or older are out of scope.
 
 The default backend consumes canonical
-[goffi v0.6.1](https://github.com/go-webgpu/goffi/releases/tag/v0.6.1), released
+[goffi v0.6.4](https://github.com/go-webgpu/goffi/releases/tag/v0.6.1), released
 from [go-webgpu/goffi#62](https://github.com/go-webgpu/goffi/pull/62). The
 `rust` build-tag path also depends on canonical
 [go-webgpu/webgpu#24](https://github.com/go-webgpu/webgpu/pull/24), merged at
@@ -95,7 +95,7 @@ a code dependency.
 
 [wgpu#253](https://github.com/gogpu/wgpu/pull/253) is the design precedent for
 matching Rust's typed public/HAL seam; it is not a code dependency of Android.
-The default Vulkan path uses goffi v0.6.1. The `rust` build-tag path needs the
+The default Vulkan path uses goffi v0.6.4. The `rust` build-tag path needs the
 canonical `go-webgpu/webgpu` helper as well. No WGPU-local copy of that helper
 should be added.
 
@@ -113,7 +113,7 @@ GOTOOLCHAIN=go1.26.5 \
 ./scripts/check-android-arm64-preview.sh
 ```
 
-The script first asserts that the module graph selects canonical goffi v0.6.1.
+The script first asserts that the module graph selects canonical goffi v0.6.4.
 It then verifies Android-only source selection; compiles every package and test
 for both the default and `rust` implementations in cgo0 and cgo1 modes; builds
 each headless example; checks the generated Go and NDK C ABI layouts; and
@@ -121,7 +121,7 @@ audits both ELF dependency sets. It requires Bionic `libc.so`/`libdl.so`,
 confirms `libvulkan.so` for the default backend and `libwgpu_native.so` for the
 Rust backend, and rejects glibc sonames, standalone `libpthread`, desktop WSI,
 GLES, and software fallback. Current CI repeats both lanes with Go 1.25.12 and
-Go 1.26.5 against canonical goffi v0.6.1 and the exact clean webgpu#24 head.
+Go 1.26.5 against canonical goffi v0.6.4 and the exact clean webgpu#24 head.
 
 These are deterministic cross-build and binary-shape checks. They do not prove
 process startup, adapter enumeration, surface creation, rendering,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gogpu/wgpu
 go 1.25.0
 
 require (
-	github.com/go-webgpu/goffi v0.6.3
+	github.com/go-webgpu/goffi v0.6.4
 	github.com/go-webgpu/webgpu v0.5.5
 	github.com/gogpu/gpucontext v0.31.3
 	github.com/gogpu/gputypes v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-webgpu/goffi v0.6.3 h1:p4gKGikHBAQ/8iUiew9MV4C5M1ZGIsk8QGFGuJjMj+A=
-github.com/go-webgpu/goffi v0.6.3/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
+github.com/go-webgpu/goffi v0.6.4 h1:8UkFpiQk9nRWtft/avVYZXIt6YYpQSDW4ZIJ95Zl268=
+github.com/go-webgpu/goffi v0.6.4/go.mod h1:wfoxNsJkU+5RFbV1kNN1kunhc1lFHuJKK3zpgx08/uM=
 github.com/go-webgpu/webgpu v0.5.5 h1:pIrXzRg0LRlNjNmR+ZNo/ERN88YaObzbCY5oYhir5SA=
 github.com/go-webgpu/webgpu v0.5.5/go.mod h1:vgIuNTa1UlZ4njCGY6Pmp/0c5T5o2Ml2fQ0znLc7B98=
 github.com/gogpu/gpucontext v0.31.3 h1:SMnYOQgr+s5issi1R/Oezbo8lV5Lb6HWUZ4HujFgrZA=

--- a/scripts/check-android-arm64-preview.sh
+++ b/scripts/check-android-arm64-preview.sh
@@ -52,7 +52,7 @@ require_checkout() {
 }
 
 goffi_module=github.com/go-webgpu/goffi
-goffi_version=v0.6.3
+goffi_version=v0.6.4
 (
 	cd "$root"
 	GOWORK=off go mod download "$goffi_module@$goffi_version"


### PR DESCRIPTION
## Summary

Patch release **v0.34.6**: bump `github.com/go-webgpu/goffi` **v0.6.3 → v0.6.4**.

goffi v0.6.4 ships `-tags goffi_static` (fully static Linux ELFs; `ErrStaticBuild` when FFI unavailable), linking-mode docs, and struct examples. See [goffi v0.6.4](https://github.com/go-webgpu/goffi/releases/tag/v0.6.4).

## Test plan
- [x] CI green
- [ ] After approve+merge: tag `v0.34.6` + GitHub release

**Note:** awaiting review — do not merge without approval.